### PR TITLE
fix(transfers): carry externalId/counterpartyAddress through manual merge & split

### DIFF
--- a/MoolahTests/Shared/TransferMergeBuilderFixture.swift
+++ b/MoolahTests/Shared/TransferMergeBuilderFixture.swift
@@ -31,6 +31,8 @@ struct TransferMergeBuilderFixture {
     type: TransactionType,
     payee: String? = nil,
     notes: String? = nil,
+    externalId: String? = nil,
+    counterpartyAddress: String? = nil,
     importOrigin: TransactionImportOrigin? = nil,
     feeLegs: [TransactionLeg] = []
   ) -> Transaction {
@@ -44,6 +46,8 @@ struct TransferMergeBuilderFixture {
           accountId: accountId,
           instrument: instrument,
           quantity: quantity,
+          externalId: externalId,
+          counterpartyAddress: counterpartyAddress,
           type: type)
       ] + feeLegs,
       importOrigin: importOrigin)

--- a/MoolahTests/Shared/TransferMergeBuilderSplitTests.swift
+++ b/MoolahTests/Shared/TransferMergeBuilderSplitTests.swift
@@ -78,6 +78,30 @@ struct TransferMergeBuilderSplitTests {
     #expect(inSplit.importOrigin?.singleOrigin == inOrigin)
   }
 
+  @Test("round-trip restores each value leg's externalId and counterpartyAddress")
+  func roundTripRestoresExternalIdAndCounterpartyAddress() throws {
+    let accountA = UUID()
+    let accountB = UUID()
+    let txA = fixture.cashTx(
+      date: baseDate, accountId: accountA, quantity: -500, type: .expense,
+      externalId: "coinstash:withdraw-1", counterpartyAddress: "0xsource",
+      importOrigin: .single(origin("withdrawal")))
+    let txB = fixture.cashTx(
+      date: baseDate, accountId: accountB, quantity: 500, type: .income,
+      externalId: "alchemy:deposit-1", counterpartyAddress: "0xdest",
+      importOrigin: .single(origin("deposit")))
+
+    let merged = try builder.merged(from: txA, txB)
+    let splits = try builder.split(merged)
+
+    let outLeg = try #require(splits.first { ($0.legs.first?.quantity ?? 0) < 0 }?.legs.first)
+    let inLeg = try #require(splits.first { ($0.legs.first?.quantity ?? 0) > 0 }?.legs.first)
+    #expect(outLeg.externalId == "coinstash:withdraw-1")
+    #expect(outLeg.counterpartyAddress == "0xsource")
+    #expect(inLeg.externalId == "alchemy:deposit-1")
+    #expect(inLeg.counterpartyAddress == "0xdest")
+  }
+
   @Test("round-trip returns each cross-instrument fee leg to its originating account split")
   func roundTripReattachesFeeLegsByAccount() throws {
     let accountA = UUID()

--- a/MoolahTests/Shared/TransferMergeBuilderTests.swift
+++ b/MoolahTests/Shared/TransferMergeBuilderTests.swift
@@ -172,6 +172,27 @@ struct TransferMergeBuilderTests {
     #expect(feeLegs.contains { $0.id == feeB.id && $0.accountId == accountB && $0.quantity == -7 })
   }
 
+  @Test("merged transfer legs preserve each side's externalId and counterpartyAddress")
+  func mergedPreservesExternalIdAndCounterpartyAddress() throws {
+    let accountA = UUID()
+    let accountB = UUID()
+    let txA = fixture.cashTx(
+      date: baseDate, accountId: accountA, quantity: -500, type: .expense,
+      externalId: "coinstash:withdraw-1", counterpartyAddress: "0xsource")
+    let txB = fixture.cashTx(
+      date: baseDate, accountId: accountB, quantity: 500, type: .income,
+      externalId: "alchemy:deposit-1", counterpartyAddress: "0xdest")
+
+    let merged = try builder.merged(from: txA, txB)
+
+    let outgoing = try #require(merged.legs.first { $0.type == .transfer && $0.quantity < 0 })
+    let incoming = try #require(merged.legs.first { $0.type == .transfer && $0.quantity > 0 })
+    #expect(outgoing.externalId == "coinstash:withdraw-1")
+    #expect(outgoing.counterpartyAddress == "0xsource")
+    #expect(incoming.externalId == "alchemy:deposit-1")
+    #expect(incoming.counterpartyAddress == "0xdest")
+  }
+
   @Test("merge assigns a new id distinct from both input ids")
   func mergedAssignsNewId() throws {
     let accountA = UUID()

--- a/Shared/TransferDetection/TransferMergeBuilder.swift
+++ b/Shared/TransferDetection/TransferMergeBuilder.swift
@@ -101,11 +101,19 @@ struct TransferMergeBuilder: Sendable {
 }
 
 extension TransferMergeBuilder {
+  // `externalId` / `counterpartyAddress` are carried through both merge and
+  // split unchanged. For sync-owned legs (wallet / exchange imports),
+  // `externalId` is the dedup key the apply pass matches on
+  // `(accountId, externalId)`; omitting it causes the next sync to re-import
+  // the absorbed leg as a duplicate. Hand-entered legs carry `nil` for both
+  // fields — this is a no-op for them.
   private func transferLeg(from valueLeg: TransactionLeg) -> TransactionLeg {
     TransactionLeg(
       accountId: valueLeg.accountId,
       instrument: valueLeg.instrument,
       quantity: valueLeg.quantity,
+      externalId: valueLeg.externalId,
+      counterpartyAddress: valueLeg.counterpartyAddress,
       type: .transfer,
       categoryId: valueLeg.categoryId,
       earmarkId: valueLeg.earmarkId)
@@ -122,6 +130,8 @@ extension TransferMergeBuilder {
       accountId: valueLeg.accountId,
       instrument: valueLeg.instrument,
       quantity: valueLeg.quantity,
+      externalId: valueLeg.externalId,
+      counterpartyAddress: valueLeg.counterpartyAddress,
       type: type,
       categoryId: valueLeg.categoryId,
       earmarkId: valueLeg.earmarkId)


### PR DESCRIPTION
## Problem

`TransferMergeBuilder.merged(from:)` and `split(_:)` construct fresh `TransactionLeg`s that silently drop `externalId` and `counterpartyAddress`.

For sync-owned legs (wallet / exchange imports), `externalId` is the dedup key `WalletApplyEngine` matches on `(accountId, externalId)`. When a user manually merges a synced leg into a transfer, the absorbed leg loses its `externalId`, so the **next sync re-imports it as a duplicate**. This blocks any workflow that links a synced exchange/wallet leg to a counterparty via manual merge (e.g. migrating a legacy manual crypto account onto synced wallet + exchange accounts).

## Fix

Carry `externalId` and `counterpartyAddress` through both leg-construction sites in `TransferMergeBuilder` — `transferLeg(from:)` (merge) and the split `cashLeg`. Hand-entered legs hold `nil` for both fields, so this is a no-op for them; only sync-owned legs are affected.

## Tests

- `mergedPreservesExternalIdAndCounterpartyAddress` — merge keeps both fields on each transfer leg.
- `roundTripRestoresExternalIdAndCounterpartyAddress` — split restores both onto the value legs; a merge→split round-trip is lossless.
- Fixture `cashTx(…)` gains `externalId` / `counterpartyAddress` params (nil-defaulted; no churn to existing call sites).

Full `TransferMergeBuilder*` + `TransferDetectionCoordinator/Merge` suites pass; `format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)