### PR TITLE
feat(automation): script crypto-wallet & exchange account creation

### DIFF
--- a/Automation/AppleScript/Commands/CreateAccountCommand.swift
+++ b/Automation/AppleScript/Commands/CreateAccountCommand.swift
@@ -5,44 +5,102 @@
 
   private let logger = Logger(subsystem: "com.moolah.app", category: "CreateAccountCommand")
 
-  /// Handles: `create account profile "X" name "Checking" type "bank"`
+  /// Handles `create account`. Simple cash/investment accounts need only
+  /// `name` + `type`; a `crypto` account also needs `wallet address` + `chain`;
+  /// an `exchange` account also needs `provider` + `token`.
   class CreateAccountCommand: AppLevelScriptCommand {
     override func performDefaultImplementation() -> Any? {
       guard let profileName = resolveProfileName() else {
-        scriptErrorNumber = -10000
-        scriptErrorString = "Missing profile specifier"
-        return nil
+        return fail("Missing profile specifier")
       }
       guard let args = evaluatedArguments,
         let name = args["name"] as? String,
         let typeString = args["type"] as? String
       else {
-        scriptErrorNumber = -10000
-        scriptErrorString = "Missing required parameters: name and type"
-        return nil
+        return fail("Missing required parameters: name and type")
       }
-
       guard let accountType = AccountType(rawValue: typeString) else {
-        scriptErrorNumber = -10000
-        scriptErrorString =
-          "Invalid account type '\(typeString)'. Use: bank, cc, asset, or investment"
-        return nil
+        return fail(
+          "Invalid account type '\(typeString)'. "
+            + "Use: bank, cc, asset, investment, crypto, or exchange")
       }
 
-      let profName = profileName
+      switch accountType {
+      case .crypto:
+        return createCrypto(args: args, name: name, profileName: profileName)
+      case .exchange:
+        return createExchange(args: args, name: name, profileName: profileName)
+      case .bank, .creditCard, .asset, .investment:
+        return createSimple(type: accountType, name: name, profileName: profileName)
+      }
+    }
+
+    private func createSimple(type: AccountType, name: String, profileName: String) -> Any? {
       let result: ScriptableAccount? = runBlockingWithError {
         @MainActor () async throws -> ScriptableAccount in
-        guard let service = ScriptingContext.automationService else {
-          throw AutomationError.operationFailed("Scripting not configured")
-        }
+        let service = try Self.requireService()
         let account = try await service.createAccount(
-          profileIdentifier: profName,
-          name: name,
-          type: accountType
-        )
-        return ScriptableAccount(account: account, profileName: profName)
+          profileIdentifier: profileName, name: name, type: type)
+        return ScriptableAccount(account: account, profileName: profileName)
       }
       return result
+    }
+
+    private func createCrypto(args: [String: Any], name: String, profileName: String) -> Any? {
+      guard let walletAddress = args["walletAddress"] as? String, !walletAddress.isEmpty else {
+        return fail("A crypto account requires a 'wallet address'")
+      }
+      guard let chain = args["chain"] as? Int else {
+        return fail("A crypto account requires a 'chain' (integer chain id, e.g. 1, 10, 8453)")
+      }
+      let result: ScriptableAccount? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableAccount in
+        let service = try Self.requireService()
+        let account = try await service.createCryptoAccount(
+          profileIdentifier: profileName,
+          name: name,
+          walletAddress: walletAddress,
+          chainId: chain)
+        return ScriptableAccount(account: account, profileName: profileName)
+      }
+      return result
+    }
+
+    private func createExchange(args: [String: Any], name: String, profileName: String) -> Any? {
+      guard let providerString = args["provider"] as? String,
+        let provider = ExchangeProvider(rawValue: providerString)
+      else {
+        return fail("An exchange account requires a valid 'provider' (coinstash)")
+      }
+      guard let token = args["token"] as? String, !token.isEmpty else {
+        return fail("An exchange account requires a 'token'")
+      }
+      let result: ScriptableAccount? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableAccount in
+        let service = try Self.requireService()
+        let account = try await service.createExchangeAccount(
+          profileIdentifier: profileName,
+          name: name,
+          provider: provider,
+          token: token,
+          tokenStore: ExchangeTokenStore(synchronizable: true))
+        return ScriptableAccount(account: account, profileName: profileName)
+      }
+      return result
+    }
+
+    @MainActor
+    private static func requireService() throws -> AutomationService {
+      guard let service = ScriptingContext.automationService else {
+        throw AutomationError.operationFailed("Scripting not configured")
+      }
+      return service
+    }
+
+    private func fail(_ message: String) -> Any? {
+      scriptErrorNumber = -10000
+      scriptErrorString = message
+      return nil
     }
   }
 #endif

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -160,14 +160,26 @@
 
     <!-- MARK: - Commands -->
 
-    <command name="create account" code="Moolcrac" description="Create a new account in a profile.">
+    <command name="create account" code="Moolcrac" description="Create a new account in a profile. For type 'crypto' supply 'wallet address' and 'chain'; for type 'exchange' supply 'provider' and 'token'.">
       <cocoa class="Moolah.CreateAccountCommand"/>
       <direct-parameter type="specifier" description="The profile to create the account in."/>
       <parameter name="name" code="Cnam" type="text" description="The name of the account.">
         <cocoa key="name"/>
       </parameter>
-      <parameter name="type" code="Ctyp" type="text" description="The account type (bank, cc, asset, investment).">
+      <parameter name="type" code="Ctyp" type="text" description="The account type (bank, cc, asset, investment, crypto, exchange).">
         <cocoa key="type"/>
+      </parameter>
+      <parameter name="wallet address" code="Cwal" type="text" optional="yes" description="The wallet address for a 'crypto' account.">
+        <cocoa key="walletAddress"/>
+      </parameter>
+      <parameter name="chain" code="Cchn" type="integer" optional="yes" description="The chain id for a 'crypto' account (EVM chain id, e.g. 1, 10, 8453).">
+        <cocoa key="chain"/>
+      </parameter>
+      <parameter name="provider" code="Cprv" type="text" optional="yes" description="The exchange provider for an 'exchange' account (coinstash).">
+        <cocoa key="provider"/>
+      </parameter>
+      <parameter name="token" code="Ctok" type="text" optional="yes" description="The read-only API token for an 'exchange' account.">
+        <cocoa key="token"/>
       </parameter>
       <result type="account" description="The created account."/>
     </command>

--- a/Automation/AutomationService+SyncedAccounts.swift
+++ b/Automation/AutomationService+SyncedAccounts.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// Synced-account creation for `AutomationService`: crypto wallet accounts
+// (address + chain) and exchange accounts (provider + API token). Both reuse
+// the production creation logic the create-account sheet drives, so a script
+// behaves exactly like the UI — including the exchange token-save rollback.
+//
+// Neither method kicks off the initial sync: a script syncs explicitly with
+// the `synchronize` command once the accounts exist, which is deterministic
+// (the script can await completion) and keeps creation network-free. Both
+// members are `@MainActor` via the containing class.
+extension AutomationService {
+
+  /// Creates a crypto wallet account synced from on-chain history.
+  ///
+  /// `chainId` must be one of the supported chains (`ChainConfig.all`:
+  /// 1 Ethereum, 10 OP Mainnet, 8453 Base). `walletAddress` is validated
+  /// and normalised by `CryptoAccountCreationLogic`.
+  func createCryptoAccount(
+    profileIdentifier: String,
+    name: String,
+    walletAddress: String,
+    chainId: Int
+  ) async throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    guard let chain = ChainConfig.config(for: chainId) else {
+      let supported = ChainConfig.all.map { String($0.chainId) }.joined(separator: ", ")
+      throw AutomationError.operationFailed(
+        "Unsupported chain id \(chainId). Supported chain ids: \(supported).")
+    }
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else {
+      throw AutomationError.operationFailed("Account name must not be empty")
+    }
+    let logic = CryptoAccountCreationLogic(
+      accountStore: session.accountStore,
+      cryptoSyncStore: nil,
+      accountInstrument: session.profile.instrument)
+    switch await logic.submit(name: name, chain: chain, walletAddressInput: walletAddress) {
+    case .created(let account):
+      return account
+    case .invalidAddress:
+      throw AutomationError.operationFailed(
+        "Invalid wallet address '\(walletAddress)'")
+    case .failure(let error):
+      throw AutomationError.operationFailed(
+        "Failed to create crypto account: \(error.localizedDescription)")
+    }
+  }
+
+  /// Creates an exchange account synced from a provider's API, storing its
+  /// read-only API token in the keychain. On a token-save failure the
+  /// just-created account is rolled back (no orphan), surfaced here as a
+  /// thrown error.
+  ///
+  /// The caller supplies the `tokenStore`: production passes the iCloud-
+  /// synchronisable keychain store; tests inject a device-local or failing
+  /// double.
+  func createExchangeAccount(
+    profileIdentifier: String,
+    name: String,
+    provider: ExchangeProvider,
+    token: String,
+    tokenStore: any ExchangeTokenStoring
+  ) async throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    let logic = ExchangeAccountCreationLogic(
+      accountStore: session.accountStore,
+      tokenStore: tokenStore,
+      syncStore: nil,
+      profileInstrument: session.profile.instrument)
+    switch await logic.submit(name: name, provider: provider, token: token) {
+    case .created(let account):
+      return account
+    case .invalidInput:
+      throw AutomationError.operationFailed("Invalid account name or empty API token")
+    case .failure(let error):
+      throw AutomationError.operationFailed(
+        "Failed to create exchange account: \(error.localizedDescription)")
+    }
+  }
+}

--- a/MoolahTests/Automation/AutomationServiceAccountTests.swift
+++ b/MoolahTests/Automation/AutomationServiceAccountTests.swift
@@ -6,33 +6,10 @@ import Testing
 @Suite("AutomationService Account Operations")
 @MainActor
 struct AutomationServiceAccountTests {
-  private struct OpenSessionFailed: Error {}
-
-  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
-    let containerManager = try ProfileContainerManager.forTesting()
-    let sessionManager = SessionManager(
-      containerManager: containerManager,
-      profileIndexRepository: containerManager.profileIndexRepositoryForTesting)
-    let profile = Profile(
-      label: "Test",
-      currencyCode: "AUD",
-      financialYearStartMonth: 7
-    )
-    guard case .ready(let session) = await sessionManager.session(for: profile) else {
-      Issue.record("expected .ready")
-      throw OpenSessionFailed()
-    }
-    // AccountStore is reactive — wait for the first emission so any
-    // pre-seeded accounts are visible. For a fresh test session there
-    // are none, but the wait keeps the public API consistent.
-    try await session.accountStore.waitForFirstEmission()
-    let service = AutomationService(sessionManager: sessionManager)
-    return (service, session)
-  }
 
   @Test("createAccount creates and lists accounts")
   func createAndListAccounts() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, session) = try await AutomationTestSession.make()
 
     let account = try await service.createAccount(
       profileIdentifier: "Test",
@@ -58,7 +35,7 @@ struct AutomationServiceAccountTests {
 
   @Test("resolveAccount finds account by name case-insensitively")
   func resolveAccountByNameCaseInsensitive() async throws {
-    let (service, _) = try await makeServiceWithSession()
+    let (service, _) = try await AutomationTestSession.make()
     _ = try await service.createAccount(
       profileIdentifier: "Test",
       name: "My Savings",
@@ -74,7 +51,7 @@ struct AutomationServiceAccountTests {
 
   @Test("resolveAccount throws when not found")
   func resolveAccountNotFoundThrows() async throws {
-    let (service, _) = try await makeServiceWithSession()
+    let (service, _) = try await AutomationTestSession.make()
 
     await #expect(throws: AutomationError.self) {
       try await service.resolveAccount(named: "NonExistent", profileIdentifier: "Test")
@@ -83,7 +60,7 @@ struct AutomationServiceAccountTests {
 
   @Test("resolveAccount finds account by UUID")
   func resolveAccountByUUID() async throws {
-    let (service, _) = try await makeServiceWithSession()
+    let (service, _) = try await AutomationTestSession.make()
     let created = try await service.createAccount(
       profileIdentifier: "Test",
       name: "Checking",
@@ -97,7 +74,7 @@ struct AutomationServiceAccountTests {
 
   @Test("getNetWorth returns sum of current and investment accounts")
   func getNetWorth() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, session) = try await AutomationTestSession.make()
     let instrument = session.profile.instrument
 
     // Create a bank account with a balance
@@ -123,7 +100,7 @@ struct AutomationServiceAccountTests {
 
   @Test("updateAccount changes account name")
   func updateAccountName() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, session) = try await AutomationTestSession.make()
     let created = try await service.createAccount(
       profileIdentifier: "Test",
       name: "Old Name",
@@ -146,7 +123,7 @@ struct AutomationServiceAccountTests {
 
   @Test("deleteAccount soft-deletes (hides) the account")
   func deleteAccount() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, session) = try await AutomationTestSession.make()
     let created = try await service.createAccount(
       profileIdentifier: "Test",
       name: "ToDelete",

--- a/MoolahTests/Automation/AutomationServiceSyncedAccountTests.swift
+++ b/MoolahTests/Automation/AutomationServiceSyncedAccountTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Covers `AutomationService.createCryptoAccount(...)` and
+/// `createExchangeAccount(...)` — the scripted equivalents of the crypto /
+/// exchange branches of the create-account sheet. The methods reuse the
+/// production `CryptoAccountCreationLogic` / `ExchangeAccountCreationLogic`
+/// but pass a `nil` sync store: a script kicks off sync explicitly with the
+/// `synchronize` command, so creation stays network-free and deterministic.
+@Suite("AutomationService Synced Account Creation")
+@MainActor
+struct AutomationServiceSyncedAccountTests {
+  /// A valid lowercase EVM wallet address for crypto-account assertions.
+  private let walletAddress = "0xa1eaee65e5fb8f05cca1cc2b9126550e23513511"
+
+  @Test("createCryptoAccount creates a .crypto account with wallet + chain")
+  func createCryptoAccount() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    let account = try await service.createCryptoAccount(
+      profileIdentifier: "Test",
+      name: "Trust - Ethereum",
+      walletAddress: walletAddress,
+      chainId: 1)
+
+    #expect(account.name == "Trust - Ethereum")
+    #expect(account.type == .crypto)
+    #expect(account.walletAddress == walletAddress)
+    #expect(account.chainId == 1)
+    #expect(account.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("createCryptoAccount rejects an unsupported chain id")
+  func createCryptoAccountUnsupportedChain() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    await #expect(throws: AutomationError.self) {
+      _ = try await service.createCryptoAccount(
+        profileIdentifier: "Test",
+        name: "Bad Chain",
+        walletAddress: walletAddress,
+        chainId: 999_999)
+    }
+  }
+
+  @Test("createCryptoAccount rejects an invalid wallet address")
+  func createCryptoAccountInvalidAddress() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    await #expect(throws: AutomationError.self) {
+      _ = try await service.createCryptoAccount(
+        profileIdentifier: "Test",
+        name: "Bad Address",
+        walletAddress: "not-an-address",
+        chainId: 1)
+    }
+  }
+
+  @Test("createExchangeAccount creates a .exchange account and stores its token")
+  func createExchangeAccount() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+    // Device-local keychain (no entitlement) so the token round-trip runs
+    // in the test host; cleaned up after the assertions.
+    let tokenStore = ExchangeTokenStore(synchronizable: false)
+
+    let account = try await service.createExchangeAccount(
+      profileIdentifier: "Test",
+      name: "Coinstash",
+      provider: .coinstash,
+      token: "TOK123",
+      tokenStore: tokenStore)
+
+    #expect(account.name == "Coinstash")
+    #expect(account.type == .exchange)
+    #expect(account.exchangeProvider == .coinstash)
+    #expect(account.valuationMode == .calculatedFromTrades)
+    #expect(try tokenStore.token(for: account.id) == "TOK123")
+
+    tokenStore.delete(for: account.id)
+  }
+
+  @Test("createExchangeAccount rolls back the account when the token save fails")
+  func createExchangeAccountRollsBackOnTokenFailure() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    await #expect(throws: AutomationError.self) {
+      _ = try await service.createExchangeAccount(
+        profileIdentifier: "Test",
+        name: "Coinstash",
+        provider: .coinstash,
+        token: "TOK",
+        tokenStore: FailingExchangeTokenStore())
+    }
+
+    // `AccountStore.delete(id:)` is the codebase-wide soft-delete (flips
+    // `isHidden`), so the rolled-back row remains in `fetchAll()` but is
+    // hidden: assert no *visible* exchange account is left behind.
+    let accounts = try await service.fetchAccounts(profileIdentifier: "Test")
+    #expect(!accounts.contains { $0.type == .exchange && !$0.isHidden })
+  }
+}

--- a/MoolahTests/Automation/AutomationTestSession.swift
+++ b/MoolahTests/Automation/AutomationTestSession.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Shared factory for AutomationService tests: opens a fresh in-memory
+/// profile session and returns the service wired to it.
+@MainActor
+enum AutomationTestSession {
+  struct OpenSessionFailed: Error {}
+
+  static func make() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(
+      containerManager: containerManager,
+      profileIndexRepository: containerManager.profileIndexRepositoryForTesting)
+    let profile = Profile(label: "Test", currencyCode: "AUD", financialYearStartMonth: 7)
+    guard case .ready(let session) = await sessionManager.session(for: profile) else {
+      Issue.record("expected .ready")
+      throw OpenSessionFailed()
+    }
+    try await session.accountStore.waitForFirstEmission()
+    return (AutomationService(sessionManager: sessionManager), session)
+  }
+}


### PR DESCRIPTION
Extend the `create account` AppleScript command so a script can add the
account types that previously required the UI.

## What's new

- **Crypto wallet accounts** — `create account ... type crypto` now takes a
  `wallet address` and a `chain` (EVM chain id, e.g. 1, 10, 8453).
- **Exchange accounts** — `create account ... type exchange` now takes a
  `provider` (e.g. coinstash) and a `token` (read-only API key).

## Implementation

- `AutomationService.createCryptoAccount` and `createExchangeAccount` reuse
  the production `CryptoAccountCreationLogic` / `ExchangeAccountCreationLogic`
  — the same code the create-account sheet drives — so a script behaves
  exactly like the UI, including the exchange token-save **rollback** when the
  keychain write fails (no orphan account left behind).
- **`nil` sync store rationale:** neither method kicks off the initial sync.
  A script syncs explicitly with the `synchronize` command once the accounts
  exist, which is deterministic (the script can await completion) and keeps
  creation network-free.
- **Explicit token-store dependency:** `createExchangeAccount`'s `tokenStore`
  has no production default. The AppleScript command passes the production
  iCloud-synchronisable keychain store; tests inject a device-local or failing
  double — making the keychain dependency visible and the rollback path
  testable without entitlements.
- Crypto creation now guards an empty account name explicitly, and the
  invalid-address message no longer conflates the two outcomes.

## Tests

- New `AutomationServiceSyncedAccountTests` covers crypto creation (happy
  path, unsupported chain, invalid address) and exchange creation (happy path
  + token round-trip, rollback on token-save failure).
- A shared `AutomationTestSession.make()` factory replaces the duplicated
  per-suite session bootstrap in the automation account tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
