### PR TITLE
feat(automation): script merging two transactions into a transfer

### DIFF
--- a/Automation/AppleScript/Commands/MergeTransactionsCommand.swift
+++ b/Automation/AppleScript/Commands/MergeTransactionsCommand.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "MergeTransactionsCommand")
+
+  /// Handles: `merge txns profile "X" first "uuid" second "uuid"`
+  ///
+  /// Collapses the two referenced single-account transactions into one
+  /// cross-account transfer (see `AutomationService.mergeTransactions`).
+  class MergeTransactionsCommand: AppLevelScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        return fail("Missing profile specifier")
+      }
+      guard let args = evaluatedArguments,
+        let firstString = args["first"] as? String,
+        let secondString = args["second"] as? String
+      else {
+        return fail("Missing required parameters: first and second (transaction ids)")
+      }
+      guard let firstId = UUID(uuidString: firstString) else {
+        return fail("Invalid transaction id '\(firstString)' for 'first'")
+      }
+      guard let secondId = UUID(uuidString: secondString) else {
+        return fail("Invalid transaction id '\(secondString)' for 'second'")
+      }
+
+      let result: ScriptableTransaction? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableTransaction in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let merged = try await service.mergeTransactions(
+          profileIdentifier: profileName, firstId: firstId, secondId: secondId)
+        let session = try service.resolveSession(for: profileName)
+        return ScriptableTransaction(
+          transaction: merged,
+          profileName: profileName,
+          accountStore: session.accountStore,
+          categoryStore: session.categoryStore)
+      }
+      return result
+    }
+
+    private func fail(_ message: String) -> Any? {
+      scriptErrorNumber = -10000
+      scriptErrorString = message
+      return nil
+    }
+  }
+#endif

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -236,6 +236,18 @@
       <result type="txn" description="The paid txn."/>
     </command>
 
+    <command name="merge txns" code="Moolmgtx" description="Merge two opposing single-account transactions into one cross-account transfer.">
+      <cocoa class="Moolah.MergeTransactionsCommand"/>
+      <direct-parameter type="specifier" description="The profile containing the transactions."/>
+      <parameter name="first" code="Cfst" type="text" description="The id of the first transaction to merge.">
+        <cocoa key="first"/>
+      </parameter>
+      <parameter name="second" code="Csnd" type="text" description="The id of the second transaction to merge.">
+        <cocoa key="second"/>
+      </parameter>
+      <result type="txn" description="The merged transfer txn."/>
+    </command>
+
     <command name="refresh" code="Moolrefr" description="Refresh all data for a profile.">
       <cocoa class="Moolah.RefreshCommand"/>
       <direct-parameter type="specifier" optional="yes" description="The profile to refresh."/>

--- a/Automation/AutomationService+TransferMerge.swift
+++ b/Automation/AutomationService+TransferMerge.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+// Transfer-merge operation for `AutomationService`: collapse two opposing
+// single-account transactions into one cross-account transfer. Enables a
+// script to re-match a hand-entered bank transfer against a synced exchange
+// leg during a data migration. The member is `@MainActor` via the containing
+// class.
+extension AutomationService {
+
+  /// Merges two single-account transactions into one cross-account transfer.
+  ///
+  /// Both ids are resolved from the authoritative repository snapshot. The
+  /// pair must form a valid transfer (different accounts, same instrument,
+  /// opposite-equal value legs) or the merge throws. The two sources are
+  /// deleted and the merged transfer inserted atomically.
+  ///
+  /// Reuses `TransferMergeBuilder`, which carries each leg's `externalId`
+  /// (and `counterpartyAddress`) through to the merged transfer leg. This is
+  /// essential: `externalId` is the dedup key the wallet/exchange apply pass
+  /// matches on `(accountId, externalId)`, so a merged sync-owned leg that
+  /// kept its `externalId` is not re-imported as a duplicate on the next sync.
+  func mergeTransactions(
+    profileIdentifier: String,
+    firstId: UUID,
+    secondId: UUID
+  ) async throws -> Transaction {
+    let session = try resolveSession(for: profileIdentifier)
+
+    let transactions = try await session.backend.transactions.fetchAll(filter: TransactionFilter())
+    let first = try Self.transaction(id: firstId, in: transactions)
+    let second = try Self.transaction(id: secondId, in: transactions)
+
+    let merged: Transaction
+    do {
+      merged = try TransferMergeBuilder().merged(from: first, second)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Cannot merge: \(error.localizedDescription)")
+    }
+
+    do {
+      let created = try await session.backend.transactions.replace(
+        deletingIds: [firstId, secondId], creating: [merged])
+      guard let result = created.first else {
+        throw AutomationError.operationFailed("Merge produced no transaction")
+      }
+      return result
+    } catch let error as AutomationError {
+      throw error
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to merge transactions: \(error.localizedDescription)")
+    }
+  }
+
+  /// Finds a transaction by id within an already-fetched snapshot, throwing
+  /// `transactionNotFound` when absent.
+  private static func transaction(
+    id: UUID, in transactions: [Transaction]
+  ) throws -> Transaction {
+    guard let transaction = transactions.first(where: { $0.id == id }) else {
+      throw AutomationError.transactionNotFound(id.uuidString)
+    }
+    return transaction
+  }
+}

--- a/MoolahTests/Automation/AutomationServiceMergeTransactionsTests.swift
+++ b/MoolahTests/Automation/AutomationServiceMergeTransactionsTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AutomationService Merge Transactions")
+@MainActor
+struct AutomationServiceMergeTransactionsTests {
+  private struct OpenSessionFailed: Error {}
+
+  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(
+      containerManager: containerManager,
+      profileIndexRepository: containerManager.profileIndexRepositoryForTesting)
+    let profile = Profile(label: "Test", currencyCode: "AUD", financialYearStartMonth: 7)
+    guard case .ready(let session) = await sessionManager.session(for: profile) else {
+      Issue.record("expected .ready")
+      throw OpenSessionFailed()
+    }
+    try await session.accountStore.waitForFirstEmission()
+    return (AutomationService(sessionManager: sessionManager), session)
+  }
+
+  /// Persists a single-leg transaction directly through the repository so the
+  /// leg's `externalId` can be set (the create-transaction service surface
+  /// does not expose it). The leg sits in the profile's instrument; its
+  /// `.income` / `.expense` type follows the quantity's sign.
+  private func makeSingleLeg(
+    session: ProfileSession,
+    accountId: UUID,
+    quantity: Decimal,
+    payee: String,
+    externalId: String? = nil
+  ) async throws -> Transaction {
+    let transaction = Transaction(
+      id: UUID(),
+      date: Date(),
+      payee: payee,
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: session.profile.instrument,
+          quantity: quantity,
+          externalId: externalId,
+          type: quantity < 0 ? .expense : .income)
+      ])
+    return try await session.backend.transactions.create(transaction)
+  }
+
+  @Test("merges two opposite-equal single-account transactions into one transfer")
+  func mergesIntoTransfer() async throws {
+    let (service, session) = try await makeServiceWithSession()
+    let checking = try await service.createAccount(
+      profileIdentifier: "Test", name: "Checking", type: .bank)
+    let savings = try await service.createAccount(
+      profileIdentifier: "Test", name: "Savings", type: .bank)
+
+    let outgoing = try await makeSingleLeg(
+      session: session, accountId: checking.id, quantity: -100, payee: "Transfer out")
+    let incoming = try await makeSingleLeg(
+      session: session, accountId: savings.id, quantity: 100, payee: "Transfer in")
+
+    let merged = try await service.mergeTransactions(
+      profileIdentifier: "Test", firstId: outgoing.id, secondId: incoming.id)
+
+    let transferLegs = merged.legs.filter { $0.type == .transfer }
+    #expect(transferLegs.count == 2)
+    #expect(Set(transferLegs.compactMap(\.accountId)) == [checking.id, savings.id])
+    #expect(Set(transferLegs.map(\.quantity)) == [-100, 100])
+
+    // Both source transactions are gone.
+    let remaining = try await session.backend.transactions.fetchAll(filter: TransactionFilter())
+    let remainingIds = Set(remaining.map(\.id))
+    #expect(!remainingIds.contains(outgoing.id))
+    #expect(!remainingIds.contains(incoming.id))
+    #expect(remainingIds.contains(merged.id))
+  }
+
+  @Test("preserves a source leg's externalId on the merged transfer leg")
+  func preservesExternalId() async throws {
+    let (service, session) = try await makeServiceWithSession()
+    let bank = try await service.createAccount(
+      profileIdentifier: "Test", name: "Bank", type: .bank)
+    let exchange = try await service.createAccount(
+      profileIdentifier: "Test", name: "Exchange", type: .exchange)
+
+    let bankLeg = try await makeSingleLeg(
+      session: session, accountId: bank.id, quantity: -250, payee: "Bank transfer")
+    let syncedLeg = try await makeSingleLeg(
+      session: session, accountId: exchange.id, quantity: 250, payee: "Exchange deposit",
+      externalId: "chain-tx-hash-abc")
+
+    let merged = try await service.mergeTransactions(
+      profileIdentifier: "Test", firstId: bankLeg.id, secondId: syncedLeg.id)
+
+    let preserved = merged.legs.first { $0.externalId == "chain-tx-hash-abc" }
+    #expect(preserved != nil)
+    #expect(preserved?.type == .transfer)
+    #expect(preserved?.accountId == exchange.id)
+  }
+
+  @Test("throws when both transactions sit on the same account")
+  func sameAccountThrows() async throws {
+    let (service, session) = try await makeServiceWithSession()
+    let checking = try await service.createAccount(
+      profileIdentifier: "Test", name: "Checking", type: .bank)
+
+    let first = try await makeSingleLeg(
+      session: session, accountId: checking.id, quantity: -100, payee: "A")
+    let second = try await makeSingleLeg(
+      session: session, accountId: checking.id, quantity: 100, payee: "B")
+
+    await #expect(throws: AutomationError.self) {
+      _ = try await service.mergeTransactions(
+        profileIdentifier: "Test", firstId: first.id, secondId: second.id)
+    }
+  }
+
+  @Test("throws when a transaction id does not exist")
+  func missingTransactionThrows() async throws {
+    let (service, session) = try await makeServiceWithSession()
+    let checking = try await service.createAccount(
+      profileIdentifier: "Test", name: "Checking", type: .bank)
+
+    let existing = try await makeSingleLeg(
+      session: session, accountId: checking.id, quantity: -100, payee: "A")
+
+    await #expect(throws: AutomationError.self) {
+      _ = try await service.mergeTransactions(
+        profileIdentifier: "Test", firstId: existing.id, secondId: UUID())
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `merge txns` AppleScript command that collapses two opposing single-account transactions into one cross-account transfer. This enables scripting a data migration — re-pairing a hand-entered bank transfer against a synced exchange/wallet leg.

The new `AutomationService.mergeTransactions(profileIdentifier:firstId:secondId:)`:
- Resolves both transaction ids from the authoritative repository snapshot; a missing id throws `transactionNotFound`.
- Builds the merged transfer with `TransferMergeBuilder().merged(from:_:)`, which throws when the pair isn't a valid transfer (different accounts, same instrument, opposite-equal value legs) — surfaced as `AutomationError.operationFailed("Cannot merge: …")`.
- Persists atomically via `TransactionRepository.replace(deletingIds:creating:)` — deletes both sources and inserts the merged transfer in one write.

Reusing `TransferMergeBuilder` is essential: it carries each leg's `externalId` (and `counterpartyAddress`) through to the merged transfer leg. `externalId` is the dedup key the wallet/exchange apply pass matches on `(accountId, externalId)`, so a merged sync-owned leg keeps its id and is **not** re-imported as a duplicate on the next sync.

## AppleScript surface

```applescript
tell application "Moolah"
    set t to merge txns profile "Personal" first "UUID-1" second "UUID-2"
end tell
```

Returns the merged transfer txn.

- sdef command: `merge txns` — code `Moolmgtx`
- params: `first` (`Cfst`), `second` (`Csnd`) — both text (transaction id strings)

## Tests

New `AutomationServiceMergeTransactionsTests` (4 tests, all green on macOS):
- happy path: two opposite-equal single-account txns on different accounts merge into one txn with two `.transfer` legs on the two accounts; both sources are gone.
- externalId preservation: a synced source leg's `externalId` survives onto the merged transfer leg (proves sync-safety / `TransferMergeBuilder` reuse).
- same-account pair throws.
- missing-id throws.

Existing `AutomationServiceAccountTests` / `AutomationServiceTransactionTests` still pass. `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)