### PR TITLE
feat(automation): script clearing an account's investment-value history

### DIFF
--- a/Automation/AppleScript/Commands/ClearInvestmentValuesCommand.swift
+++ b/Automation/AppleScript/Commands/ClearInvestmentValuesCommand.swift
@@ -1,0 +1,42 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "ClearInvestmentValuesCommand")
+
+  /// Handles: `clear investment values of account "A" of profile "P"`
+  ///
+  /// Deletes every recorded investment value for the named account (see
+  /// `AutomationService.clearInvestmentValues`) and returns the number of
+  /// value rows removed.
+  class ClearInvestmentValuesCommand: AppLevelScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        return fail("Missing profile specifier")
+      }
+      guard let args = evaluatedArguments,
+        let accountName = args["account"] as? String, !accountName.isEmpty
+      else {
+        return fail("Missing required parameter: account")
+      }
+
+      let result: NSNumber? = runBlockingWithError { @MainActor () async throws -> NSNumber in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let count = try await service.clearInvestmentValues(
+          profileIdentifier: profileName, accountName: accountName)
+        return count as NSNumber
+      }
+      return result
+    }
+
+    private func fail(_ message: String) -> Any? {
+      scriptErrorNumber = -10000
+      scriptErrorString = message
+      return nil
+    }
+  }
+#endif

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -266,6 +266,15 @@
       <result type="txn" description="The merged transfer txn."/>
     </command>
 
+    <command name="clear investment values" code="Moolcliv" description="Delete every recorded investment value for an account, clearing its value-history snapshots (e.g. when retiring a manual investment account during a migration).">
+      <cocoa class="Moolah.ClearInvestmentValuesCommand"/>
+      <direct-parameter type="specifier" description="The profile containing the account."/>
+      <parameter name="account" code="Civa" type="text" description="The name of the account whose investment values to clear.">
+        <cocoa key="account"/>
+      </parameter>
+      <result type="integer" description="The number of investment values deleted."/>
+    </command>
+
     <command name="add leg" code="Mooladdl" description="Append a leg to an existing txn. Other legs are re-saved unchanged, so a sync-owned leg's external id survives.">
       <cocoa class="Moolah.AddLegCommand"/>
       <direct-parameter type="specifier" description="The profile containing the txn."/>

--- a/Automation/AutomationService+Investments.swift
+++ b/Automation/AutomationService+Investments.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// Investment-value operations for `AutomationService`. Lets a script clear an
+// account's recorded value-history snapshots in bulk — e.g. a migration that
+// retires a manual investment account and must not leave its value history
+// behind to double-count against replacement accounts in the investment-value
+// graph. The member is `@MainActor` via the containing class.
+extension AutomationService {
+
+  /// Clears every recorded investment value for the named account.
+  ///
+  /// Resolves the account by name (case-insensitive) from the authoritative
+  /// repository snapshot, then deletes all of its `investment_value` rows via
+  /// `InvestmentRepository.removeAllValues(accountId:)` — each deletion is
+  /// enqueued for CloudKit sync. Throws `.accountNotFound` when the name does
+  /// not resolve; other failures surface as `.operationFailed`.
+  /// - Returns: The number of value rows deleted.
+  func clearInvestmentValues(
+    profileIdentifier: String,
+    accountName: String
+  ) async throws -> Int {
+    let session = try resolveSession(for: profileIdentifier)
+    let account = try await resolveAccount(
+      named: accountName, profileIdentifier: profileIdentifier)
+    do {
+      return try await session.backend.investments.removeAllValues(accountId: account.id)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to clear investment values: \(error.localizedDescription)")
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -152,6 +152,29 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
     onRecordDeleted(InvestmentValueRow.recordType, deletedId)
   }
 
+  func removeAllValues(accountId: UUID) async throws -> Int {
+    // Collect the ids in the same transaction that deletes them so the
+    // CloudKit-deletion enqueue below covers exactly the rows removed.
+    // `removeValue` normalises to `startOfDay` and matches one row; this
+    // bulk path deletes every row for the account in one statement
+    // regardless of the stored time-of-day, so a per-date loop is wrong.
+    let deletedIds = try await database.write { database -> [UUID] in
+      let request =
+        InvestmentValueRow
+        .filter(InvestmentValueRow.Columns.accountId == accountId)
+      let ids =
+        try request
+        .select(InvestmentValueRow.Columns.id, as: UUID.self)
+        .fetchAll(database)
+      _ = try request.deleteAll(database)
+      return ids
+    }
+    for id in deletedIds {
+      onRecordDeleted(InvestmentValueRow.recordType, id)
+    }
+    return deletedIds.count
+  }
+
   func fetchDailyBalances(accountId: UUID) async throws -> [AccountDailyBalance] {
     let defaultInstrument = self.defaultInstrument
     // Resolve the instrument lookup table before opening the

--- a/Domain/Repositories/InvestmentRepository.swift
+++ b/Domain/Repositories/InvestmentRepository.swift
@@ -24,6 +24,16 @@ protocol InvestmentRepository: Sendable {
   ///   - date: The valuation date to remove
   func removeValue(accountId: UUID, date: Date) async throws
 
+  /// Remove every recorded investment value for an account, regardless of
+  /// date. Used to retire a manual investment account's value-history
+  /// snapshots in one shot (e.g. during a migration that replaces the
+  /// account) without leaving rows behind to double-count in the
+  /// investment-value graph. Each deleted row is enqueued for CloudKit
+  /// deletion, mirroring `removeValue(accountId:date:)` for a single row.
+  /// - Parameter accountId: The investment account whose values to clear.
+  /// - Returns: The number of value rows deleted.
+  func removeAllValues(accountId: UUID) async throws -> Int
+
   /// Fetch daily cumulative balances for an account, sorted by date ascending.
   /// Each entry represents the running total of transactions up to that date.
   /// - Parameters:

--- a/MoolahTests/Automation/AutomationServiceInvestmentsTests.swift
+++ b/MoolahTests/Automation/AutomationServiceInvestmentsTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AutomationService Investments")
+@MainActor
+struct AutomationServiceInvestmentsTests {
+
+  @Test("clearInvestmentValues deletes every value for the account and returns the count")
+  func clearsAllValues() async throws {
+    let (service, session) = try await AutomationTestSession.make()
+    let account = try await service.createAccount(
+      profileIdentifier: "Test", name: "Brokerage", type: .investment)
+
+    let amount = InstrumentAmount(quantity: Decimal(5000), instrument: session.profile.instrument)
+    let first = try #require(
+      Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 1)))
+    let second = try #require(
+      Calendar.current.date(from: DateComponents(year: 2024, month: 2, day: 1)))
+    try await session.backend.investments.setValue(
+      accountId: account.id, date: first, value: amount)
+    try await session.backend.investments.setValue(
+      accountId: account.id, date: second, value: amount)
+
+    let deletedCount = try await service.clearInvestmentValues(
+      profileIdentifier: "Test", accountName: "Brokerage")
+    #expect(deletedCount == 2)
+
+    let page = try await session.backend.investments.fetchValues(
+      accountId: account.id, page: 0, pageSize: 1000)
+    #expect(page.values.isEmpty)
+  }
+
+  @Test("clearInvestmentValues throws for an unknown account name")
+  func throwsForUnknownAccount() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+    await #expect(throws: AutomationError.self) {
+      _ = try await service.clearInvestmentValues(
+        profileIdentifier: "Test", accountName: "Does Not Exist")
+    }
+  }
+}

--- a/MoolahTests/Domain/InvestmentRemoveAllValuesContractTests.swift
+++ b/MoolahTests/Domain/InvestmentRemoveAllValuesContractTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("InvestmentRepository Remove All Values Contract")
+struct InvestmentRemoveAllValuesContractTests {
+
+  private func makeDate(year: Int, month: Int, day: Int) throws -> Date {
+    try makeContractTestDate(year: year, month: month, day: day)
+  }
+
+  /// Reads back every recorded value for an account by paging through
+  /// `fetchValues`, so a test can assert the table is empty afterwards.
+  private func allValues(
+    _ repo: any InvestmentRepository, accountId: UUID
+  ) async throws -> [InvestmentValue] {
+    try await repo.fetchValues(accountId: accountId, page: 0, pageSize: 1000).values
+  }
+
+  @Test("removeAllValues deletes every value for the account and leaves others untouched")
+  func testRemoveAllValues() async throws {
+    let accountA = UUID()
+    let accountB = UUID()
+    let instrument = Instrument.defaultTestInstrument
+    let amount = InstrumentAmount(quantity: Decimal(1000), instrument: instrument)
+
+    let repo = try makeCloudKitInvestmentRepository()
+
+    // Three values on A across distinct dates, two on B.
+    try await repo.setValue(
+      accountId: accountA, date: try makeDate(year: 2024, month: 1, day: 1), value: amount)
+    try await repo.setValue(
+      accountId: accountA, date: try makeDate(year: 2024, month: 2, day: 1), value: amount)
+    try await repo.setValue(
+      accountId: accountA, date: try makeDate(year: 2024, month: 3, day: 1), value: amount)
+    try await repo.setValue(
+      accountId: accountB, date: try makeDate(year: 2024, month: 1, day: 1), value: amount)
+    try await repo.setValue(
+      accountId: accountB, date: try makeDate(year: 2024, month: 2, day: 1), value: amount)
+
+    let deletedCount = try await repo.removeAllValues(accountId: accountA)
+    #expect(deletedCount == 3)
+
+    let remainingA = try await allValues(repo, accountId: accountA)
+    #expect(remainingA.isEmpty)
+
+    let remainingB = try await allValues(repo, accountId: accountB)
+    #expect(remainingB.count == 2)
+  }
+
+  @Test("removeAllValues on an account with no values returns zero")
+  func testRemoveAllValuesEmpty() async throws {
+    let repo = try makeCloudKitInvestmentRepository()
+    let deletedCount = try await repo.removeAllValues(accountId: UUID())
+    #expect(deletedCount == 0)
+  }
+}


### PR DESCRIPTION
## Summary

Adds an AppleScript-scriptable way to wipe an investment account's recorded value-history snapshots in bulk, so a migration that retires a manual investment account doesn't leave its `investment_value` rows behind to double-count against replacement accounts in the investment-value graph.

- **`InvestmentRepository.removeAllValues(accountId:) -> Int`** — bulk delete. In a single `database.write`, collects the ids of all `InvestmentValueRow` for the account, deletes them with one `deleteAll`, then fires `onRecordDeleted(...)` per id so every deletion syncs to CloudKit (mirrors `removeValue` for one row). Returns the count. Implemented in `GRDBInvestmentRepository` (the only conformer). A per-date loop would be wrong here: the data contains non-midnight rows, so the bulk path filters by account only and ignores time-of-day.
- **`AutomationService.clearInvestmentValues(profileIdentifier:accountName:)`** — resolves the session and the account by name (throws `.accountNotFound` if missing), calls the repository, maps other failures to `.operationFailed`.
- **`clear investment values` AppleScript command** — `clear investment values of account "A" of profile "P"`. Command code `Moolcliv`, `account` param code `Civa`; returns the deleted count as an integer.

## Tests

- `InvestmentRemoveAllValuesContractTests` — contract tests against CloudKitBackend + in-memory GRDB: multi-date values on two accounts; `removeAllValues(A)` returns the right count, empties A, leaves B; empty-account returns 0.
- `AutomationServiceInvestmentsTests` — clears values via the service (asserts count + empty `fetchValues`); unknown account name throws.

All green locally (17 tests across the new + related investment/automation suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)