### PR TITLE
fix(crypto): guard inverted price-fetch range at the cache's earliest day

### DIFF
--- a/MoolahTests/Shared/CryptoPriceServiceBoundaryRangeTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceBoundaryRangeTests.swift
@@ -1,0 +1,88 @@
+// MoolahTests/Shared/CryptoPriceServiceBoundaryRangeTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Regression cover for the inverted-range trap in
+/// `CryptoPriceService.extensionWindow`. The backward extension built
+/// `requestedDate...fetchEnd`, where `fetchEnd` is midnight of
+/// (`earliestDate` − 1) while `requestedDate` is a noon-anchored day
+/// token from the daily-balance walk. When the requested day is exactly
+/// that boundary day, `requestedDate` (noon) > `fetchEnd` (midnight of the
+/// same calendar day), so the `ClosedRange` initializer trapped
+/// (`EXC_BREAKPOINT`) — crashing on launch for any profile whose chart
+/// history reaches the day before a crypto price cache begins.
+@Suite("CryptoPriceService — boundary range")
+struct CryptoPriceServiceBoundaryRangeTests {
+  private let ethInstrument = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let ethMapping = CryptoProviderMapping(
+    instrumentId: "1:native", coingeckoId: "ethereum",
+    cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+  )
+
+  private func makeService(
+    prices: [String: [String: Decimal]] = [:],
+    database: DatabaseQueue,
+    now: @Sendable @escaping () -> Date
+  ) throws -> CryptoPriceService {
+    let client = FixedCryptoPriceClient(prices: prices)
+    let utc = try #require(TimeZone(identifier: "UTC"))
+    return CryptoPriceService(
+      clients: [client],
+      database: database,
+      resolutionClient: nil,
+      now: now,
+      timeZone: utc)
+  }
+
+  /// Midnight-UTC anchor for `YYYY-MM-DD`, matching the cache-key formatter.
+  private func midnight(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  /// Noon-UTC anchor — mirrors the day tokens produced by the daily-balance
+  /// walk (`FinancialMonth` / `Calendar.utc`), which is what reaches
+  /// `CryptoPriceService.price` in production and triggers the trap.
+  private func noon(_ string: String) throws -> Date {
+    try midnight(string).addingTimeInterval(12 * 60 * 60)
+  }
+
+  /// Before the fix this traps when the requested day is exactly the day
+  /// immediately before the cache's `earliestDate`: `requestedDate` (noon)
+  /// exceeds `fetchEnd` (midnight of the same day), inverting the range.
+  /// After the fix the branch falls through to the single-day window, which
+  /// fetches the boundary day and returns its price.
+  @Test
+  func noonRequestOnDayBeforeEarliestDoesNotTrap() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let frozen = try self.midnight("2025-09-01")
+
+    // Seed the shared database with a single day so the cache's
+    // `earliestDate` is exactly 2025-08-15. The seeding client only knows
+    // that day, so it can't accidentally widen the cached window backward.
+    let seeder = try makeService(
+      prices: ["1:native": ["2025-08-15": dec("1510.00")]],
+      database: database,
+      now: { frozen })
+    _ = try await seeder.price(
+      for: ethInstrument, mapping: ethMapping, on: try self.midnight("2025-08-15"))
+
+    // A fresh service hydrates the cache from the database (earliestDate =
+    // 2025-08-15) and then receives a noon-anchored request for the day
+    // immediately before it — the daily-balance-walk shape that traps. Its
+    // client knows 2025-08-14, so the single-day fallthrough returns it.
+    let reader = try makeService(
+      prices: ["1:native": ["2025-08-14": dec("1500.00")]],
+      database: database,
+      now: { frozen })
+    let price = try await reader.price(
+      for: ethInstrument, mapping: ethMapping, on: try self.noon("2025-08-14"))
+    #expect(price == dec("1500.00"))
+  }
+}

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -185,7 +185,12 @@ actor CryptoPriceService {
   ///   the next finalised close.
   /// - **Cache exists, requested date before `earliestDate`:** backward
   ///   extension from the requested date to the day before
-  ///   `earliestDate`.
+  ///   `earliestDate`. Guarded by `requestedDate <= fetchEnd` so that when
+  ///   the requested day is the one *immediately* before `earliestDate` —
+  ///   where `requestedDate` is a noon-anchored day token but `fetchEnd` is
+  ///   midnight of that same calendar day — the branch falls through to the
+  ///   single-day window instead of building an inverted (lower > upper)
+  ///   `ClosedRange`, which would trap.
   /// - **Cold cache (no entry for token):** 30-day surrounding window so
   ///   a first-ever request on a non-trading day can still fall back
   ///   to a recent prior price.
@@ -208,7 +213,8 @@ actor CryptoPriceService {
       }
       if dateString < cache.earliestDate,
         let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = calendar.date(byAdding: .day, value: -1, to: earliestDate)
+        let fetchEnd = calendar.date(byAdding: .day, value: -1, to: earliestDate),
+        requestedDate <= fetchEnd
       {
         return requestedDate...fetchEnd
       }
@@ -242,8 +248,14 @@ actor CryptoPriceService {
     if let cache = caches[tokenId] {
       if rangeStart < cache.earliestDate,
         let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate)
+        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate),
+        range.lowerBound <= fetchEnd
       {
+        // `fetchRange` builds `from...to` as a `ClosedRange` literal, so the
+        // same boundary-day inversion that traps `extensionWindow` (a
+        // noon-anchored `range.lowerBound` on the day immediately before
+        // `earliestDate`, where `fetchEnd` is midnight of that day) is
+        // guarded here too.
         try await fetchRange(
           instrument: instrument, mapping: mapping, from: range.lowerBound, to: fetchEnd)
       }


### PR DESCRIPTION
## Problem

The user's installed app **crashes on launch** (`EXC_BREAKPOINT` / `SIGTRAP`). The crash frame is `CryptoPriceService.extensionWindow(for:requestedDate:dateString:)`.

`extensionWindow`'s backward-extension branch built `requestedDate...fetchEnd`, where `fetchEnd` is **midnight** of (`earliestDate` − 1 day) but `requestedDate` is a **noon-anchored** day token arriving from the daily-balance analysis walk (`GRDBAnalysisRepository.walkDays` → `PositionBook.dailyBalance` → `FullConversionService` → `CryptoPriceService.price` → `extensionWindow`).

When the requested day is **exactly** the boundary day (`earliestDate` − 1), `requestedDate` (12:00) > `fetchEnd` (00:00 same day), so `requestedDate...fetchEnd` has `lower > upper` and the `ClosedRange` initializer traps — crashing on launch for any profile whose chart history reaches the day before a crypto price cache begins.

## Fix

Add `requestedDate <= fetchEnd` to the branch's condition. When it fails (the boundary-day case), control falls through to the existing safe single-day window `requestedDate...requestedDate`. For days strictly before `earliestDate − 1`, the guard still holds and the original branch is taken — behaviour unchanged.

The forward branch was already guarded (`fetchStart <= requestedDate`). The symmetric backward path in `prices(for:mapping:in:)` calls `fetchRange(from:to:)`, which itself builds a `from...to` `ClosedRange` literal and would trap on the same boundary-day inversion, so the same `range.lowerBound <= fetchEnd` guard is applied there too.

## Test

New `CryptoPriceServiceBoundaryRangeTests.noonRequestOnDayBeforeEarliestDoesNotTrap` seeds the cache so `earliestDate = 2025-08-15`, then issues a noon-anchored `price(...)` request for `2025-08-14`. Before the fix this traps and crashes the test process; after the fix it falls through to the single-day window, fetches the boundary day, and returns its price. Verified failing-before / passing-after; existing `CryptoPriceServiceTests` and `CryptoPriceServiceCapTests` suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)