### PR TITLE
feat(automation): register-instrument verb + lock investment accounts to calculated

### DIFF
--- a/Automation/AppleScript/Commands/RegisterInstrumentCommand.swift
+++ b/Automation/AppleScript/Commands/RegisterInstrumentCommand.swift
@@ -1,0 +1,60 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "RegisterInstrumentCommand")
+
+  /// Handles: `register instrument of profile "P" chain N contract "0x…"
+  /// symbol "STRK" name "Starknet" decimals 18 coingecko "starknet"`
+  ///
+  /// Registers (or upserts) a crypto token + its price-provider mapping (see
+  /// `AutomationService.registerCryptoInstrument`) so a subsequent
+  /// `add leg … instrument "<chain>:<contract>"` can resolve and value it.
+  /// Returns the registered instrument id.
+  class RegisterInstrumentCommand: AppLevelScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        return fail("Missing profile specifier")
+      }
+      guard let args = evaluatedArguments,
+        let chain = args["chain"] as? Int,
+        let symbol = args["symbol"] as? String, !symbol.isEmpty,
+        let name = args["name"] as? String, !name.isEmpty,
+        let decimals = args["decimals"] as? Int
+      else {
+        return fail("Missing required parameters: chain, symbol, name, decimals")
+      }
+      let contract = args["contract"] as? String
+      let coingecko = args["coingecko"] as? String
+      let cryptocompare = args["cryptocompare"] as? String
+      let binance = args["binance"] as? String
+
+      let result: String? = runBlockingWithError { @MainActor () async throws -> String in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let instrument = try await service.registerCryptoInstrument(
+          profileIdentifier: profileName,
+          spec: CryptoInstrumentSpec(
+            chainId: chain,
+            contractAddress: contract,
+            symbol: symbol,
+            name: name,
+            decimals: decimals,
+            coingeckoId: coingecko,
+            cryptocompareSymbol: cryptocompare,
+            binanceSymbol: binance))
+        return instrument.id
+      }
+      return result as NSString?
+    }
+
+    private func fail(_ message: String) -> Any? {
+      scriptErrorNumber = -10000
+      scriptErrorString = message
+      return nil
+    }
+  }
+#endif

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -275,6 +275,36 @@
       <result type="integer" description="The number of investment values deleted."/>
     </command>
 
+    <command name="register instrument" code="Moolregi" description="Register (or update) a crypto token and its price-provider mapping so token-denominated legs can resolve and be valued. Needed before adding legs in a token the profile has not yet seen (e.g. reconstructing a non-synced venue's history in real tokens).">
+      <cocoa class="Moolah.RegisterInstrumentCommand"/>
+      <direct-parameter type="specifier" description="The profile to register the instrument in."/>
+      <parameter name="chain" code="Rgch" type="integer" description="The chain id that forms the instrument id (e.g. 1 Ethereum, 10 Optimism; any integer for a token on an unsynced chain).">
+        <cocoa key="chain"/>
+      </parameter>
+      <parameter name="contract" code="Rgco" type="text" optional="yes" description="The token contract address (lower-cased into the id). Omit for a chain-native token (id becomes 'chain:native').">
+        <cocoa key="contract"/>
+      </parameter>
+      <parameter name="symbol" code="Rgsy" type="text" description="The token's short symbol (e.g. STRK).">
+        <cocoa key="symbol"/>
+      </parameter>
+      <parameter name="name" code="Rgnm" type="text" description="The token's display name (e.g. Starknet).">
+        <cocoa key="name"/>
+      </parameter>
+      <parameter name="decimals" code="Rgde" type="integer" description="The token's decimal places (e.g. 18).">
+        <cocoa key="decimals"/>
+      </parameter>
+      <parameter name="coingecko" code="Rgcg" type="text" optional="yes" description="CoinGecko id price source (e.g. starknet).">
+        <cocoa key="coingecko"/>
+      </parameter>
+      <parameter name="cryptocompare" code="Rgcc" type="text" optional="yes" description="CryptoCompare symbol price source.">
+        <cocoa key="cryptocompare"/>
+      </parameter>
+      <parameter name="binance" code="Rgbi" type="text" optional="yes" description="Binance symbol price source.">
+        <cocoa key="binance"/>
+      </parameter>
+      <result type="text" description="The registered instrument id (chain:contract or chain:native)."/>
+    </command>
+
     <command name="add leg" code="Mooladdl" description="Append a leg to an existing txn. Other legs are re-saved unchanged, so a sync-owned leg's external id survives.">
       <cocoa class="Moolah.AddLegCommand"/>
       <direct-parameter type="specifier" description="The profile containing the txn."/>

--- a/Automation/AutomationService+Instruments.swift
+++ b/Automation/AutomationService+Instruments.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// The fields needed to register a crypto token as a priced instrument.
+/// Bundled into one value so the registration call stays within the
+/// parameter-count budget and reads as a single request.
+struct CryptoInstrumentSpec: Sendable {
+  /// Chain id forming the instrument id prefix. Need not be a synced chain.
+  let chainId: Int
+  /// Token contract address, lower-cased into the id. Nil/blank → `:native`.
+  let contractAddress: String?
+  let symbol: String
+  let name: String
+  let decimals: Int
+  let coingeckoId: String?
+  let cryptocompareSymbol: String?
+  let binanceSymbol: String?
+}
+
+// Instrument registration for `AutomationService`. Scripts that reconstruct a
+// venue's history in real tokens (e.g. a migration that manually re-enters the
+// transactions of a wallet/exchange the app can't sync) need each token to
+// exist as a priced `Instrument` before a token-denominated leg can resolve —
+// `add leg … instrument "<chain>:<contract>"` throws on an unregistered crypto
+// id. This verb registers (or upserts) that token plus its price-provider
+// mapping, mirroring what the wallet-sync token-discovery path does
+// automatically for synced chains.
+extension AutomationService {
+
+  /// Registers (or upserts) a crypto token and its price-provider mapping in
+  /// the profile's instrument registry, returning the resulting `Instrument`.
+  ///
+  /// The instrument id is derived as `"\(chainId):\(contractAddress)"`
+  /// (lower-cased) or `"\(chainId):native"` when `contractAddress` is
+  /// nil/blank. `chainId` need not be a synced chain — a token held only on an
+  /// unsynced chain (Starknet, Scroll, …) is still valued from its provider
+  /// mapping, independent of wallet-sync support.
+  ///
+  /// At least one provider identifier (`coingeckoId`, `cryptocompareSymbol`,
+  /// `binanceSymbol`) must be supplied; without one the token can't be priced
+  /// and the call throws rather than register an unpriceable stub.
+  @discardableResult
+  func registerCryptoInstrument(
+    profileIdentifier: String,
+    spec: CryptoInstrumentSpec
+  ) async throws -> Instrument {
+    let session = try resolveSession(for: profileIdentifier)
+    guard let registry = session.instrumentRegistry else {
+      throw AutomationError.operationFailed(
+        "Instrument registry unavailable for profile '\(profileIdentifier)'")
+    }
+
+    let trimmedSymbol = spec.symbol.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedName = spec.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedSymbol.isEmpty, !trimmedName.isEmpty else {
+      throw AutomationError.invalidParameter("Instrument symbol and name must not be empty")
+    }
+    guard spec.decimals >= 0 else {
+      throw AutomationError.invalidParameter("Instrument decimals must be >= 0")
+    }
+
+    let instrument = Instrument.crypto(
+      chainId: spec.chainId,
+      contractAddress: nonEmpty(spec.contractAddress),
+      symbol: trimmedSymbol,
+      name: trimmedName,
+      decimals: spec.decimals)
+
+    let mapping = CryptoProviderMapping(
+      instrumentId: instrument.id,
+      coingeckoId: nonEmpty(spec.coingeckoId),
+      cryptocompareSymbol: nonEmpty(spec.cryptocompareSymbol),
+      binanceSymbol: nonEmpty(spec.binanceSymbol))
+    guard mapping.hasProviderMapping else {
+      throw AutomationError.invalidParameter(
+        "A crypto instrument needs at least one price source: "
+          + "coingecko id, cryptocompare symbol, or binance symbol")
+    }
+
+    do {
+      try await registry.registerCrypto(instrument, mapping: mapping)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to register instrument '\(instrument.id)': \(error.localizedDescription)")
+    }
+    return instrument
+  }
+
+  /// Trims whitespace and maps an empty/absent string to nil.
+  private func nonEmpty(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !trimmed.isEmpty
+    else { return nil }
+    return trimmed
+  }
+}

--- a/MoolahTests/Automation/AutomationServiceAccountTests.swift
+++ b/MoolahTests/Automation/AutomationServiceAccountTests.swift
@@ -33,6 +33,25 @@ struct AutomationServiceAccountTests {
     #expect(accounts.first?.name == "Savings")
   }
 
+  @Test("createAccount defaults a new investment account to calculatedFromTrades")
+  func createInvestmentDefaultsToCalculated() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    // The migration reconstructs non-synced venues as manual investment
+    // accounts that must value from positions, not a recorded mark. A scripted
+    // `create account type "investment"` must therefore land in
+    // `.calculatedFromTrades` — `AccountStore.create` promotes the default
+    // `.recordedValue` for investment accounts, so no recordedValue account is
+    // creatable through this path.
+    let account = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Manual Crypto",
+      type: .investment
+    )
+
+    #expect(account.valuationMode == .calculatedFromTrades)
+  }
+
   @Test("resolveAccount finds account by name case-insensitively")
   func resolveAccountByNameCaseInsensitive() async throws {
     let (service, _) = try await AutomationTestSession.make()

--- a/MoolahTests/Automation/AutomationServiceInstrumentsTests.swift
+++ b/MoolahTests/Automation/AutomationServiceInstrumentsTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AutomationService Instrument Registration")
+@MainActor
+struct AutomationServiceInstrumentsTests {
+
+  @Test("registerCryptoInstrument registers a priced token resolvable from the registry")
+  func registerToken() async throws {
+    let (service, session) = try await AutomationTestSession.make()
+
+    let instrument = try await service.registerCryptoInstrument(
+      profileIdentifier: "Test",
+      spec: CryptoInstrumentSpec(
+        chainId: 1,
+        contractAddress: "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
+        symbol: "STRK",
+        name: "Starknet",
+        decimals: 18,
+        coingeckoId: "starknet",
+        cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    // Id is chain:lowercased-contract.
+    #expect(instrument.id == "1:0xca14007eff0db1f8135f4c25b34de49ab0d42766")
+    #expect(instrument.kind == .cryptoToken)
+    #expect(instrument.ticker == "STRK")
+
+    let registry = try #require(session.instrumentRegistry)
+    let all = try await registry.all()
+    #expect(all.contains { $0.id == instrument.id })
+
+    let registration = try await registry.cryptoRegistration(byId: instrument.id)
+    #expect(registration?.mapping.coingeckoId == "starknet")
+  }
+
+  @Test("registerCryptoInstrument derives chain:native when no contract is given")
+  func nativeTokenId() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    let instrument = try await service.registerCryptoInstrument(
+      profileIdentifier: "Test",
+      spec: CryptoInstrumentSpec(
+        chainId: 324, contractAddress: nil, symbol: "ZK", name: "ZKsync",
+        decimals: 18, coingeckoId: "zksync", cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    #expect(instrument.id == "324:native")
+  }
+
+  @Test("registerCryptoInstrument treats a blank contract as native")
+  func blankContractIsNative() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    let instrument = try await service.registerCryptoInstrument(
+      profileIdentifier: "Test",
+      spec: CryptoInstrumentSpec(
+        chainId: 9999, contractAddress: "   ", symbol: "FUEL", name: "Fuel Network",
+        decimals: 9, coingeckoId: "fuel-network", cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    #expect(instrument.id == "9999:native")
+  }
+
+  @Test("registerCryptoInstrument throws when no price source is supplied")
+  func noPriceSourceThrows() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    await #expect(throws: AutomationError.self) {
+      try await service.registerCryptoInstrument(
+        profileIdentifier: "Test",
+        spec: CryptoInstrumentSpec(
+          chainId: 1, contractAddress: nil, symbol: "FOO", name: "Foo",
+          decimals: 18, coingeckoId: nil, cryptocompareSymbol: "   ", binanceSymbol: nil))
+    }
+  }
+
+  @Test("registerCryptoInstrument throws when symbol is empty")
+  func emptySymbolThrows() async throws {
+    let (service, _) = try await AutomationTestSession.make()
+
+    await #expect(throws: AutomationError.self) {
+      try await service.registerCryptoInstrument(
+        profileIdentifier: "Test",
+        spec: CryptoInstrumentSpec(
+          chainId: 1, contractAddress: nil, symbol: "  ", name: "Foo",
+          decimals: 18, coingeckoId: "foo", cryptocompareSymbol: nil, binanceSymbol: nil))
+    }
+  }
+
+  @Test("re-registering an id upserts its mapping rather than duplicating")
+  func reRegisterUpserts() async throws {
+    let (service, session) = try await AutomationTestSession.make()
+
+    _ = try await service.registerCryptoInstrument(
+      profileIdentifier: "Test",
+      spec: CryptoInstrumentSpec(
+        chainId: 1, contractAddress: "0xABC", symbol: "TIA", name: "Celestia",
+        decimals: 6, coingeckoId: "celestia", cryptocompareSymbol: nil, binanceSymbol: nil))
+    let second = try await service.registerCryptoInstrument(
+      profileIdentifier: "Test",
+      spec: CryptoInstrumentSpec(
+        chainId: 1, contractAddress: "0xabc", symbol: "TIA", name: "Celestia",
+        decimals: 6, coingeckoId: nil, cryptocompareSymbol: "TIA", binanceSymbol: nil))
+
+    let registry = try #require(session.instrumentRegistry)
+    let matches = try await registry.all().filter { $0.id == second.id }
+    #expect(matches.count == 1)
+    let registration = try await registry.cryptoRegistration(byId: second.id)
+    #expect(registration?.mapping.cryptocompareSymbol == "TIA")
+  }
+}


### PR DESCRIPTION
Tooling for the **Crypto account migration** (see `MIGRATION-DESIGN-NOTES.md` / `CRYPTO-MIGRATION-PLAN.md` in the migration repo). Two additive changes, both covered by the prior `#1069–#1073` migration-verb pattern.

## `register instrument` verb
Registers (or upserts) a crypto token + its price-provider mapping so a script can enter **token-denominated** legs for venues the app can't sync (Starknet/Scroll/zkSync airdrops, etc.) on a manually-reconstructed, position-valued account:

```
register instrument of profile "P" chain 1 \
  contract "0xca14007eff0db1f8135f4c25b34de49ab0d42766" \
  symbol "STRK" name "Starknet" decimals 18 coingecko "starknet"
```

- Id derives as `chain:lowercased-contract` or `chain:native` (chain need not be a synced chain — pricing comes from the mapping, independent of wallet-sync support).
- Requires ≥1 price source (coingecko / cryptocompare / binance); refuses an unpriceable stub.
- Upserts through `InstrumentRegistryRepository.registerCrypto`, so re-registering an id rewrites its mapping rather than duplicating.
- Inputs bundled in `CryptoInstrumentSpec` (parameter-count budget).

## Lock investment-account creation to calculated
Adds a test asserting `create account type "investment"` lands in `.calculatedFromTrades`. `AccountStore.create` already promotes the `recordedValue` default for investment accounts, so the reconstructed venue accounts value from positions, not a manual mark — locking the migration's assumption.

## Tests
6 new registration tests + 1 account lock-in test; full `AutomationServiceInstrumentsTests` + `AutomationServiceAccountTests` suites green (14/14). `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)