### PR TITLE
fix(sync): never let a fetched echo clobber an in-flight local edit

### DIFF
--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -17,10 +17,25 @@ extension ProfileDataSyncHandler {
   /// `ProfileIndexSyncHandler` on the profile-index zone and is logged
   /// and skipped if it reaches this path.
   /// Returns the set of changed record type strings.
+  /// `locallyPendingRecordNames` carries the record names that currently
+  /// have an un-uploaded local change queued in
+  /// `syncEngine.state.pendingRecordZoneChanges` (saves *and* deletes).
+  /// A fetched save for one of these is a stale server echo of an
+  /// earlier version — CloudKit re-delivers a device's own writes, and
+  /// on a single device that echo can arrive *after* the user has made a
+  /// newer local edit that hasn't uploaded yet. Applying its field
+  /// values would clobber the in-flight edit (the reported single-device
+  /// data-loss race). Such records are therefore excluded from the
+  /// field-value upsert and routed through a system-fields-only update:
+  /// the cached change tag advances (so the queued upload lands cleanly)
+  /// while the local field values — the newer edit — are preserved and
+  /// win on the next send. Records with no pending local change apply
+  /// normally (a genuine remote change, or a harmless no-op echo).
   nonisolated func applyRemoteChanges(
     saved: [CKRecord],
     deleted: [(CKRecord.ID, String)],
-    preExtractedSystemFields: [(String, Data)] = []
+    preExtractedSystemFields: [(String, Data)] = [],
+    locallyPendingRecordNames: Set<String> = []
   ) -> ApplyResult {
     let batchStart = ContinuousClock.now
     let signpostID = OSSignpostID(log: Signposts.sync)
@@ -33,8 +48,20 @@ extension ProfileDataSyncHandler {
 
     logIncomingBatch(saved: saved, deleted: deleted)
 
+    // Split off stale echoes of records with in-flight local edits so the
+    // field-value upsert can never overwrite a not-yet-uploaded change.
+    let (freshSaved, pendingEchoes) = Self.partitionPendingEchoes(
+      saved: saved, locallyPendingRecordNames: locallyPendingRecordNames)
+    if !pendingEchoes.isEmpty {
+      logger.info(
+        """
+        applyRemoteChanges: \(pendingEchoes.count) fetched save(s) match locally-pending \
+        records — applying system fields only, preserving in-flight local edits
+        """)
+    }
+
     let systemFields = Self.systemFieldsLookup(
-      saved: saved, preExtracted: preExtractedSystemFields)
+      saved: freshSaved, preExtracted: preExtractedSystemFields)
 
     // GRDB-routed batches throw on write failure so CKSyncEngine refetches
     // instead of advancing past a dropped record (silent data loss).
@@ -49,7 +76,7 @@ extension ProfileDataSyncHandler {
     // until the next observation tick landed.
     let upsertStart = ContinuousClock.now
     if let failure = runBatchApplyPhase(
-      saved: saved,
+      saved: freshSaved,
       systemFields: systemFields,
       deleted: deleted,
       signpostID: signpostID)
@@ -58,11 +85,49 @@ extension ProfileDataSyncHandler {
     }
     let upsertDuration = ContinuousClock.now - upsertStart
 
+    // System-fields-only update for the pending echoes runs *after* the
+    // outer write commits: the per-type setters open their own
+    // `database.write`, which cannot nest inside the batch transaction.
+    // A failure here is logged-and-continued inside
+    // `runBatchedSystemFieldsUpdate` rather than returned as
+    // `.saveFailed` — consistent with how system-fields failures are
+    // handled everywhere else. The only consequence is that the next
+    // upload of the pending edit carries a stale change tag and gets a
+    // recoverable `.serverRecordChanged` (handled by `SyncErrorRecovery`);
+    // the in-flight field values are never at risk.
+    if !pendingEchoes.isEmpty {
+      applySystemFieldsBatched(pendingEchoes)
+    }
+
     return reportSuccess(
-      saved: saved,
+      saved: freshSaved,
       deleted: deleted,
-      timing: BatchTiming(batchStart: batchStart, upsertDuration: upsertDuration),
+      timing: BatchTiming(
+        batchStart: batchStart,
+        upsertDuration: upsertDuration,
+        pendingEchoCount: pendingEchoes.count),
       signpostID: signpostID)
+  }
+
+  /// Partitions fetched saves into the records safe to upsert
+  /// (`fresh`) and the stale echoes of locally-pending records
+  /// (`pendingEchoes`) whose field values must not be overwritten.
+  /// The empty-set fast path keeps the common (no-pending) case
+  /// allocation-free.
+  nonisolated private static func partitionPendingEchoes(
+    saved: [CKRecord], locallyPendingRecordNames: Set<String>
+  ) -> (fresh: [CKRecord], pendingEchoes: [CKRecord]) {
+    guard !locallyPendingRecordNames.isEmpty else { return (saved, []) }
+    var fresh: [CKRecord] = []
+    var pendingEchoes: [CKRecord] = []
+    for record in saved {
+      if locallyPendingRecordNames.contains(record.recordID.recordName) {
+        pendingEchoes.append(record)
+      } else {
+        fresh.append(record)
+      }
+    }
+    return (fresh, pendingEchoes)
   }
 
   /// Bundles per-batch timing markers passed to `reportSuccess`. Both
@@ -71,6 +136,11 @@ extension ProfileDataSyncHandler {
   nonisolated struct BatchTiming {
     let batchStart: ContinuousClock.Instant
     let upsertDuration: Duration
+    /// Count of fetched saves routed to a system-fields-only update
+    /// because they echoed a locally-pending record. Logged alongside
+    /// the applied-save count so a duration line accounts for the whole
+    /// incoming batch, not just the rows whose field values changed.
+    let pendingEchoCount: Int
   }
 
   /// Runs `applyBatchSaves` and `applyBatchDeletions` inside a single
@@ -135,7 +205,8 @@ extension ProfileDataSyncHandler {
       batchStart: timing.batchStart,
       upsertDuration: timing.upsertDuration,
       saveCount: saved.count,
-      deleteCount: deleted.count)
+      deleteCount: deleted.count,
+      pendingEchoCount: timing.pendingEchoCount)
     let changedTypes = Set(saved.map(\.recordType) + deleted.map(\.1))
     // No `onInstrumentRemoteChange()` fan-out from the per-profile
     // path: every `InstrumentRecord` flows through the shared registry
@@ -257,15 +328,18 @@ extension ProfileDataSyncHandler {
     batchStart: ContinuousClock.Instant,
     upsertDuration: Duration,
     saveCount: Int,
-    deleteCount: Int
+    deleteCount: Int,
+    pendingEchoCount: Int
   ) {
     let batchMs = (ContinuousClock.now - batchStart).inMilliseconds
     guard batchMs > 100 else { return }
     let upsertMs = upsertDuration.inMilliseconds
+    let pendingSuffix =
+      pendingEchoCount > 0 ? ", \(pendingEchoCount) system-fields-only" : ""
     logger.info(
       """
       applyRemoteChanges took \(batchMs)ms \
-      (upsert: \(upsertMs)ms, \(saveCount) saves, \(deleteCount) deletes)
+      (upsert: \(upsertMs)ms, \(saveCount) saves, \(deleteCount) deletes\(pendingSuffix))
       """)
   }
 }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -130,7 +130,20 @@ extension ProfileDataSyncHandler {
   /// zone are straggler state (there is no per-profile `instrument`
   /// table) and are logged-and-skipped. Records with non-UUID
   /// recordNames are also skipped.
-  private func applySystemFieldsBatched(_ ckRecords: [CKRecord]) {
+  ///
+  /// `nonisolated` (and not `private`) so the off-main fetched-changes
+  /// apply path can reconcile stale echoes of locally-pending records
+  /// through it — updating only the cached change tag, never field
+  /// values. Touches only `nonisolated let` state (`logger`, `zoneID`,
+  /// `grdbRepositories`).
+  ///
+  /// - Precondition: Must not be called while a write transaction is
+  ///   open on `grdbRepositories.database`. Each per-type setter opens
+  ///   its own `database.write`; calling from inside an outer
+  ///   `database.write` on the same serial `DatabaseQueue` deadlocks.
+  ///   The fetched-changes caller invokes this only *after* its outer
+  ///   batch write commits.
+  nonisolated func applySystemFieldsBatched(_ ckRecords: [CKRecord]) {
     var updatesByType: [String: [(id: UUID, data: Data?)]] = [:]
     for ckRecord in ckRecords {
       if ckRecord.recordType == InstrumentRow.recordType {
@@ -189,7 +202,7 @@ extension ProfileDataSyncHandler {
   /// Dispatches one batch system-fields write through the GRDB repo
   /// for `recordType`. A miss on the dispatch table or a thrown error
   /// is logged at warning / error and the next type still runs.
-  private func runBatchedSystemFieldsUpdate(
+  nonisolated private func runBatchedSystemFieldsUpdate(
     recordType: String, updates: [(id: UUID, data: Data?)]
   ) {
     guard let setter = systemFieldsBatchSetter(for: recordType) else {
@@ -223,7 +236,7 @@ extension ProfileDataSyncHandler {
   /// reference data) and `domainSystemFieldsBatchSetter` (the
   /// financial-graph rows) so neither switch breaches the
   /// cyclomatic-complexity ceiling — same shape as `saveHandler`.
-  private func systemFieldsBatchSetter(
+  nonisolated private func systemFieldsBatchSetter(
     for recordType: String
   ) -> (([(id: UUID, data: Data?)]) throws -> Int)? {
     referenceSystemFieldsBatchSetter(for: recordType)
@@ -231,7 +244,7 @@ extension ProfileDataSyncHandler {
   }
 
   /// Reference-data side of the `systemFieldsBatchSetter` lookup.
-  private func referenceSystemFieldsBatchSetter(
+  nonisolated private func referenceSystemFieldsBatchSetter(
     for recordType: String
   ) -> (([(id: UUID, data: Data?)]) throws -> Int)? {
     let repos = grdbRepositories
@@ -254,7 +267,7 @@ extension ProfileDataSyncHandler {
   }
 
   /// Financial-graph side of the `systemFieldsBatchSetter` lookup.
-  private func domainSystemFieldsBatchSetter(
+  nonisolated private func domainSystemFieldsBatchSetter(
     for recordType: String
   ) -> (([(id: UUID, data: Data?)]) throws -> Int)? {
     let repos = grdbRepositories

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Lifecycle.swift
@@ -1,0 +1,85 @@
+@preconcurrency import CloudKit
+import Foundation
+
+// Queue-all-existing and local-data-deletion helpers for the
+// profile-index zone, split out of `ProfileIndexSyncHandler.swift` so
+// each file keeps a single focus (and stays under the file-length
+// ceiling). See `ProfileIndexSyncHandler+Instruments.swift` for the
+// record-type partitioning, and `ProfileIndexSyncHandler.swift` for the
+// apply / system-fields paths.
+extension ProfileIndexSyncHandler {
+  // MARK: - Queue All Existing Records
+
+  /// Scans every `ProfileRow` and (when wired) every `InstrumentRow`
+  /// in the local store and returns their CKRecord.IDs. Called on
+  /// first start when there's no saved sync state, and from the
+  /// startup self-heal path that re-queues rows whose
+  /// `encoded_system_fields` is NULL.
+  ///
+  /// SYNC_GUIDE Rule 14 (queue dependency order): the two record
+  /// types in this zone have no inter-record dependencies — a
+  /// `ProfileRow` does not reference an `InstrumentRow` and vice
+  /// versa. The combined list is therefore returned in
+  /// profile-then-instrument order purely for log readability; the
+  /// merge queue and CKSyncEngine treat the order as immaterial.
+  func queueAllExistingRecords() -> [CKRecord.ID] {
+    let profileRecordIDs = collectProfileRecordIDs()
+    let instrumentRecordIDs = collectInstrumentRecordIDs()
+    let combined = profileRecordIDs + instrumentRecordIDs
+    if !combined.isEmpty {
+      logger.info(
+        "Collected \(profileRecordIDs.count) profile + \(instrumentRecordIDs.count) instrument records for upload"
+      )
+    }
+    return combined
+  }
+
+  private func collectProfileRecordIDs() -> [CKRecord.ID] {
+    do {
+      let ids = try repository.allRowIdsSync()
+      return ids.map { id in
+        CKRecord.ID(
+          recordType: ProfileRow.recordType, uuid: id, zoneID: zoneID)
+      }
+    } catch {
+      logger.error(
+        "queueAllExistingRecords: failed to fetch profile row ids: \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  private func collectInstrumentRecordIDs() -> [CKRecord.ID] {
+    guard let instrumentRepository else { return [] }
+    do {
+      let ids = try instrumentRepository.allRowIdsSync()
+      return ids.map { id in
+        CKRecord.ID(recordName: id, zoneID: zoneID)
+      }
+    } catch {
+      logger.error(
+        "queueAllExistingRecords: failed to fetch instrument row ids: \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  // MARK: - Local Data Deletion
+
+  /// Deletes all local profile-index data — `profile`, `instrument`,
+  /// and the six rate-cache tables — atomically. Called on account
+  /// sign-out, account switch, zone deletion, and zone purge.
+  ///
+  /// Atomicity rationale: a process kill mid-wipe would otherwise
+  /// leave price-cache rows that reference instruments now gone, or
+  /// profiles whose instruments survived. Sign-out semantics demand
+  /// "the DB is empty"; partial wipes are not safe.
+  func deleteLocalData() {
+    do {
+      try repository.deleteAllProfileIndexDataSync()
+      logger.info("Deleted all profile-index data")
+    } catch {
+      logger.error("Failed to delete profile-index data: \(error, privacy: .public)")
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -82,8 +82,37 @@ final class ProfileIndexSyncHandler: Sendable {
   /// vice versa), so a partial-success outcome — profiles applied,
   /// instruments failed — is a recoverable state the next sync cycle
   /// re-attempts via `unsyncedRowIdsSync()`.
-  func applyRemoteChanges(saved: [CKRecord], deleted: [CKRecord.ID]) -> ApplyResult {
-    let savedSplit = Self.partitionSaved(saved, logger: logger)
+  ///
+  /// `locallyPendingRecordNames` carries the record names that currently
+  /// have an un-uploaded local change queued for this zone (saves *and*
+  /// deletes). A fetched save for one of these is a stale server echo of
+  /// an earlier version — applying its field values would clobber the
+  /// not-yet-uploaded local edit (e.g. a profile rename, or an instrument
+  /// pricing-status change). Such records are excluded from the
+  /// field-value upsert and routed through a system-fields-only update
+  /// (`writeSystemFields`), so the cached change tag advances while the
+  /// local field values win on the next send. Mirrors the guard in
+  /// `ProfileDataSyncHandler.applyRemoteChanges` (SYNC_GUIDE §2,
+  /// cross-handler review rule).
+  func applyRemoteChanges(
+    saved: [CKRecord],
+    deleted: [CKRecord.ID],
+    locallyPendingRecordNames: Set<String> = []
+  ) -> ApplyResult {
+    let (freshSaved, pendingEchoes) = Self.partitionPendingEchoes(
+      saved: saved, locallyPendingRecordNames: locallyPendingRecordNames)
+    if !pendingEchoes.isEmpty {
+      logger.info(
+        """
+        applyRemoteChanges: \(pendingEchoes.count) fetched save(s) match locally-pending \
+        records — applying system fields only, preserving in-flight local edits
+        """)
+      for record in pendingEchoes {
+        writeSystemFields(for: record.recordID, to: record.encodedSystemFields)
+      }
+    }
+
+    let savedSplit = Self.partitionSaved(freshSaved, logger: logger)
     let deletedSplit = Self.partitionDeleted(deleted, logger: logger)
 
     // Profiles first.
@@ -122,6 +151,29 @@ final class ProfileIndexSyncHandler: Sendable {
       changedTypes.insert(InstrumentRow.recordType)
     }
     return .success(changedTypes: changedTypes)
+  }
+
+  /// Partitions fetched saves into the records safe to upsert
+  /// (`fresh`) and the stale echoes of locally-pending records
+  /// (`pendingEchoes`) whose field values must not be overwritten.
+  /// The empty-set fast path keeps the common (no-pending) case
+  /// allocation-free. Mirrors the same-named helper on
+  /// `ProfileDataSyncHandler` (the two handlers are maintained
+  /// separately per SYNC_GUIDE §2).
+  static func partitionPendingEchoes(
+    saved: [CKRecord], locallyPendingRecordNames: Set<String>
+  ) -> (fresh: [CKRecord], pendingEchoes: [CKRecord]) {
+    guard !locallyPendingRecordNames.isEmpty else { return (saved, []) }
+    var fresh: [CKRecord] = []
+    var pendingEchoes: [CKRecord] = []
+    for record in saved {
+      if locallyPendingRecordNames.contains(record.recordID.recordName) {
+        pendingEchoes.append(record)
+      } else {
+        fresh.append(record)
+      }
+    }
+    return (fresh, pendingEchoes)
   }
 
   // MARK: - Building CKRecords
@@ -167,81 +219,6 @@ final class ProfileIndexSyncHandler: Sendable {
       }
     }
     return instrumentRecordToSave(for: recordID)
-  }
-
-  // MARK: - Queue All Existing Records
-
-  /// Scans every `ProfileRow` and (when wired) every `InstrumentRow`
-  /// in the local store and returns their CKRecord.IDs. Called on
-  /// first start when there's no saved sync state, and from the
-  /// startup self-heal path that re-queues rows whose
-  /// `encoded_system_fields` is NULL.
-  ///
-  /// SYNC_GUIDE Rule 14 (queue dependency order): the two record
-  /// types in this zone have no inter-record dependencies — a
-  /// `ProfileRow` does not reference an `InstrumentRow` and vice
-  /// versa. The combined list is therefore returned in
-  /// profile-then-instrument order purely for log readability; the
-  /// merge queue and CKSyncEngine treat the order as immaterial.
-  func queueAllExistingRecords() -> [CKRecord.ID] {
-    let profileRecordIDs = collectProfileRecordIDs()
-    let instrumentRecordIDs = collectInstrumentRecordIDs()
-    let combined = profileRecordIDs + instrumentRecordIDs
-    if !combined.isEmpty {
-      logger.info(
-        "Collected \(profileRecordIDs.count) profile + \(instrumentRecordIDs.count) instrument records for upload"
-      )
-    }
-    return combined
-  }
-
-  private func collectProfileRecordIDs() -> [CKRecord.ID] {
-    do {
-      let ids = try repository.allRowIdsSync()
-      return ids.map { id in
-        CKRecord.ID(
-          recordType: ProfileRow.recordType, uuid: id, zoneID: zoneID)
-      }
-    } catch {
-      logger.error(
-        "queueAllExistingRecords: failed to fetch profile row ids: \(error, privacy: .public)"
-      )
-      return []
-    }
-  }
-
-  private func collectInstrumentRecordIDs() -> [CKRecord.ID] {
-    guard let instrumentRepository else { return [] }
-    do {
-      let ids = try instrumentRepository.allRowIdsSync()
-      return ids.map { id in
-        CKRecord.ID(recordName: id, zoneID: zoneID)
-      }
-    } catch {
-      logger.error(
-        "queueAllExistingRecords: failed to fetch instrument row ids: \(error, privacy: .public)"
-      )
-      return []
-    }
-  }
-
-  // MARK: - Local Data Deletion
-
-  /// Deletes all local profile-index data — `profile`, `instrument`,
-  /// and the six rate-cache tables — atomically. Called on account
-  /// sign-out, account switch, zone deletion, and zone purge.
-  ///
-  /// Atomicity rationale: a process kill mid-wipe would otherwise
-  /// leave price-cache rows that reference instruments now gone, or
-  /// profiles whose instruments survived. Sign-out semantics demand
-  /// "the DB is empty"; partial wipes are not safe.
-  func deleteLocalData() {
-    do {
-      try repository.deleteAllProfileIndexDataSync()
-      logger.info("Deleted all profile-index data")
-    } catch {
-      logger.error("Failed to delete profile-index data: \(error, privacy: .public)")
-    }
   }
 
   // MARK: - System Fields Management

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -104,8 +104,16 @@ extension SyncCoordinator {
     deleted: [(CKRecord.ID, String)]
   ) async {
     let deletedIDs = deleted.map(\.0)
+    // Snapshot the index zone's locally-pending record names on the main
+    // actor before the off-main apply, so a stale echo of a not-yet-
+    // uploaded profile rename / instrument edit can't clobber it. Same
+    // guard as the profile-data path (SYNC_GUIDE §2, cross-handler rule).
+    let pendingNames = await MainActor.run {
+      locallyPendingRecordNames(in: profileIndexHandler.zoneID)
+    }
     // Index upsert is fast (few records), run off-main
-    let indexResult = profileIndexHandler.applyRemoteChanges(saved: saved, deleted: deletedIDs)
+    let indexResult = profileIndexHandler.applyRemoteChanges(
+      saved: saved, deleted: deletedIDs, locallyPendingRecordNames: pendingNames)
     switch indexResult {
     case .success:
       await MainActor.run {
@@ -144,15 +152,23 @@ extension SyncCoordinator {
     // No invariant violations can reach this point — the coordinator
     // constructs its own handler bundle, so `profileNotRegistered` is
     // unreachable on the apply path.
-    let handler: ProfileDataSyncHandler? = await MainActor.run {
-      do {
-        return try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
-      } catch {
-        logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
-        return nil
+    // Resolve the handler and snapshot the locally-pending record names
+    // in the same MainActor hop — both read @MainActor-isolated state
+    // (`syncEngine.state`). The snapshot lets the off-main apply skip
+    // overwriting field values for any record that still has an
+    // un-uploaded local edit (the single-device echo race).
+    let resolved: (handler: ProfileDataSyncHandler, pendingNames: Set<String>)? =
+      await MainActor.run {
+        do {
+          let handler = try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+          return (handler, locallyPendingRecordNames(in: zoneID))
+        } catch {
+          logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
+          return nil
+        }
       }
-    }
-    guard let handler else { return }
+    guard let resolved else { return }
+    let handler = resolved.handler
 
     // Filter pre-extracted system fields to this zone (off-main)
     let savedNames = Set(saved.map { $0.recordID.recordName })
@@ -169,7 +185,8 @@ extension SyncCoordinator {
 
     // Heavy upsert/delete/save runs off-main via nonisolated method
     let result = handler.applyRemoteChanges(
-      saved: saved, deleted: deleted, preExtractedSystemFields: zonePreExtracted)
+      saved: saved, deleted: deleted, preExtractedSystemFields: zonePreExtracted,
+      locallyPendingRecordNames: resolved.pendingNames)
 
     switch result {
     case .success:
@@ -343,5 +360,31 @@ extension SyncCoordinator {
   func refreshPendingUploadsMirror() {
     guard let syncEngine else { return }
     progress.updatePendingUploads(syncEngine.state.pendingRecordZoneChanges.count)
+  }
+
+  /// Record names in `zoneID` that currently have an un-uploaded local
+  /// change queued (saves *and* deletes). A fetched save for one of
+  /// these is a stale server echo of an earlier version: applying its
+  /// field values would clobber the in-flight local edit, so the apply
+  /// path routes them through a system-fields-only update instead. See
+  /// `ProfileDataSyncHandler.applyRemoteChanges(…:locallyPendingRecordNames:)`.
+  /// Returns empty when the engine hasn't started (e.g. under
+  /// `--ui-testing`), which disables the guard and applies everything —
+  /// correct, since nothing is pending.
+  @MainActor
+  func locallyPendingRecordNames(in zoneID: CKRecordZone.ID) -> Set<String> {
+    guard let syncEngine else { return [] }
+    var names: Set<String> = []
+    for change in syncEngine.state.pendingRecordZoneChanges {
+      switch change {
+      case .saveRecord(let recordID) where recordID.zoneID == zoneID:
+        names.insert(recordID.recordName)
+      case .deleteRecord(let recordID) where recordID.zoneID == zoneID:
+        names.insert(recordID.recordName)
+      default:
+        break
+      }
+    }
+    return names
   }
 }

--- a/MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift
+++ b/MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift
@@ -1,0 +1,169 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Guards against the single-device data-loss race: when CloudKit echoes
+/// back a record this device just uploaded (delivered via
+/// `fetchedRecordZoneChanges`) while the user has since made a *newer*
+/// local edit that is still queued for upload, the stale echo must not
+/// clobber the in-flight local edit.
+///
+/// The fix routes such records through a system-fields-only update — the
+/// echo updates the cached change tag but never overwrites field values
+/// for any record name that is locally pending. Records with no pending
+/// local change apply normally (genuine remote changes from another
+/// device, or harmless no-op echoes).
+@Suite("Apply remote changes preserves in-flight local edits")
+struct ApplyRemoteChangesPendingGuardTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  // MARK: - Account (simple single-row type)
+
+  @Test("Stale account echo does not overwrite a pending local edit")
+  func accountEchoSkippedWhilePending() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+
+    // Local state reflects the user's *newer* edit (edit #2), not yet uploaded.
+    let localRow = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "LOCAL EDIT 2", encodedSystemFields: nil)
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try localRow.insert(database)
+    }
+
+    // Stale server echo carries edit #1's value.
+    let staleEcho = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "STALE SERVER EDIT 1"
+    ).toCKRecord(in: Self.zoneID)
+    let echoSystemFields = staleEcho.encodedSystemFields
+
+    let result = harness.handler.applyRemoteChanges(
+      saved: [staleEcho],
+      deleted: [],
+      locallyPendingRecordNames: [AccountRow.recordName(for: id)])
+
+    if case .saveFailed(let message) = result {
+      Issue.record("Expected success, got .saveFailed(\(message))")
+    }
+
+    let saved = try await harness.database.read { database in
+      try AccountRow.fetchOne(database, key: id)
+    }
+    let row = try #require(saved)
+    // Field values preserved — the in-flight local edit wins.
+    #expect(row.name == "LOCAL EDIT 2")
+    // System fields *were* updated from the echo (only system fields).
+    #expect(row.encodedSystemFields == echoSystemFields)
+  }
+
+  @Test("Account echo applies normally when no local edit is pending")
+  func accountEchoAppliedWhenNotPending() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+
+    let localRow = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "OLD LOCAL", encodedSystemFields: nil)
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try localRow.insert(database)
+    }
+
+    let remote = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "GENUINE REMOTE CHANGE"
+    ).toCKRecord(in: Self.zoneID)
+
+    let result = harness.handler.applyRemoteChanges(
+      saved: [remote], deleted: [], locallyPendingRecordNames: [])
+
+    if case .saveFailed(let message) = result {
+      Issue.record("Expected success, got .saveFailed(\(message))")
+    }
+
+    let saved = try await harness.database.read { database in
+      try AccountRow.fetchOne(database, key: id)
+    }
+    // No pending edit — a genuine remote change must apply.
+    #expect(try #require(saved).name == "GENUINE REMOTE CHANGE")
+  }
+
+  // MARK: - Transaction (the user's reported case)
+
+  @Test("Stale transaction echo does not overwrite a pending local edit")
+  func transactionEchoSkippedWhilePending() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+    let localRow = ProfileDataSyncHandlerTestSupport.transactionRow(
+      id: id, date: date, payee: "LOCAL EDIT 2", encodedSystemFields: nil)
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try localRow.insert(database)
+    }
+
+    let staleEcho = ProfileDataSyncHandlerTestSupport.transactionRow(
+      id: id, date: date, payee: "STALE SERVER EDIT 1"
+    ).toCKRecord(in: Self.zoneID)
+
+    let result = harness.handler.applyRemoteChanges(
+      saved: [staleEcho],
+      deleted: [],
+      locallyPendingRecordNames: [TransactionRow.recordName(for: id)])
+
+    if case .saveFailed(let message) = result {
+      Issue.record("Expected success, got .saveFailed(\(message))")
+    }
+
+    let saved = try await harness.database.read { database in
+      try TransactionRow.fetchOne(database, key: id)
+    }
+    #expect(try #require(saved).payee == "LOCAL EDIT 2")
+  }
+
+  @Test("Stale transaction-leg echo does not overwrite a pending local edit")
+  func transactionLegEchoSkippedWhilePending() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let transactionId = UUID()
+
+    // Legs are the most frequently mutated per-profile record type —
+    // every transaction amount/account/category edit touches them.
+    let localRow = ProfileDataSyncHandlerTestSupport.transactionLegRow(
+      id: id, transactionId: transactionId, accountId: nil, quantity: 200,
+      encodedSystemFields: nil)
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try localRow.insert(database)
+    }
+
+    let staleEcho = ProfileDataSyncHandlerTestSupport.transactionLegRow(
+      id: id, transactionId: transactionId, accountId: nil, quantity: 100
+    ).toCKRecord(in: Self.zoneID)
+    let echoSystemFields = staleEcho.encodedSystemFields
+
+    let result = harness.handler.applyRemoteChanges(
+      saved: [staleEcho],
+      deleted: [],
+      locallyPendingRecordNames: [TransactionLegRow.recordName(for: id)])
+
+    if case .saveFailed(let message) = result {
+      Issue.record("Expected success, got .saveFailed(\(message))")
+    }
+
+    let saved = try await harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: id)
+    }
+    let row = try #require(saved)
+    #expect(row.quantity == 200)
+    #expect(row.encodedSystemFields == echoSystemFields)
+  }
+}

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
@@ -76,6 +76,44 @@ struct ProfileIndexSyncHandlerTests {
     #expect(row.financialYearStartMonth == 1)
   }
 
+  // MARK: - Pending-Echo Guard
+
+  @Test("Stale profile echo does not overwrite a pending local rename")
+  func pendingProfileEchoPreservesLocalRename() throws {
+    let (handler, repository) = try makeHandler()
+
+    let profileId = UUID()
+    // Local state reflects the user's newer rename (edit #2), not yet uploaded.
+    let local = Profile(
+      id: profileId,
+      label: "LOCAL RENAME",
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    try repository.applyRemoteChangesSync(saved: [ProfileRow(domain: local)], deleted: [])
+
+    // Stale server echo carries the pre-rename label.
+    let staleEcho = CKRecord(
+      recordType: ProfileRow.recordType,
+      recordID: CKRecord.ID(
+        recordType: ProfileRow.recordType, uuid: profileId, zoneID: handler.zoneID)
+    )
+    staleEcho["label"] = "STALE OLD LABEL" as CKRecordValue
+    staleEcho["currencyCode"] = "AUD" as CKRecordValue
+    staleEcho["financialYearStartMonth"] = 7 as CKRecordValue
+    staleEcho["createdAt"] = Date() as CKRecordValue
+
+    _ = handler.applyRemoteChanges(
+      saved: [staleEcho],
+      deleted: [],
+      locallyPendingRecordNames: [staleEcho.recordID.recordName])
+
+    let row = try #require(try repository.fetchRowSync(id: profileId))
+    // The in-flight rename wins; only system fields were updated.
+    #expect(row.label == "LOCAL RENAME")
+    #expect(row.encodedSystemFields == staleEcho.encodedSystemFields)
+  }
+
   // MARK: - Remote Deletion
 
   @Test


### PR DESCRIPTION
## Problem

Single-device data-loss race when editing multiple fields in quick succession (reported for transactions, but it affected **every** record type). Sequence:

1. User edits a record → edit #1 uploads to iCloud.
2. User edits the same record again locally → edit #2 is committed locally but still queued in `state.pendingRecordZoneChanges`.
3. CloudKit re-delivers the device's **own** earlier write back via `fetchedRecordZoneChanges` (a device's write generates a zone-change push to itself).
4. The apply path did a blind full-row `upsert` (`INSERT OR REPLACE`), so the stale server copy **overwrote edit #2**.

## Root cause

The two paths one would suspect were already safe — the `savedRecords` echo in `handleSentRecordZoneChanges` and the `.serverRecordChanged` conflict path both only ever write the `encodedSystemFields` column, never field values. The **only** remote field-value write is the fetched-changes apply (`applyRemoteChanges` → `applyBatchSaves` → per-repo `applyRemoteChangesSync` → `row.upsert`), and it had **no guard** for rows carrying un-uploaded local edits. (Apple's `sample-cloudkit-sync-engine` doesn't blind-upsert either — it field-merges.)

## Fix

A pending-changes guard, enforcing the invariant *"an echo may only update system fields for a record with an in-flight local edit; it may never overwrite that record's field values."*

- `SyncCoordinator.locallyPendingRecordNames(in:)` snapshots the zone's queued saves+deletes on the MainActor, in the same hop that resolves the handler, and passes them into `applyRemoteChanges`.
- `partitionPendingEchoes` splits incoming saves:
  - **pending** (un-uploaded local edit) → skip the field-value upsert; apply **system fields only** (advances the change tag so the queued upload lands without a needless `.serverRecordChanged`). The local edit wins and re-uploads.
  - **not pending** → apply normally (genuine remote change, or a harmless no-op echo).
- Applied to **both** `ProfileDataSyncHandler` and `ProfileIndexSyncHandler` (SYNC_GUIDE §2 cross-handler rule) — profile rename and instrument pricing-status edits had the identical bug on the profile-index zone.

`ProfileIndexSyncHandler.swift` was over the 400-line limit after the change, so the queue/delete helpers moved to a new `ProfileIndexSyncHandler+Lifecycle.swift` (pure code movement).

## Tests

New `ApplyRemoteChangesPendingGuardTests`: stale-echo-while-pending preservation for **Account**, **Transaction**, and **TransactionLeg**, plus a **control** proving a genuine remote change still applies when nothing is pending. New `ProfileIndexSyncHandlerTests` case covers a pending **profile rename**.

- Full macOS suite: **3894 tests / 672 suites passed**.
- `just format-check` clean.
- Reviewed by `sync-review` and `concurrency-review`; their Critical (index-handler coverage) and Important (leg test, logging accuracy, doc preconditions) findings are addressed in this PR.

## Known limitation

A much narrower residual window remains: a local edit queued in the gap between the MainActor pending-snapshot and the off-main GRDB commit isn't covered. It's far smaller than the previous always-clobber; fully closing it would require a transactional dirty-marker read inside the GRDB write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)