### PR TITLE
refactor(sync): drop nonisolated(unsafe) from RecordTypeRegistry.allTypes

### DIFF
--- a/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
+++ b/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
@@ -2,7 +2,13 @@ import CloudKit
 import Foundation
 
 /// Protocol for bidirectional conversion between record types and CKRecords.
-protocol CloudKitRecordConvertible {
+///
+/// `Sendable` so `RecordTypeRegistry.allTypes` — a dictionary of conformer
+/// metatypes held in an immutable global — is provably concurrency-safe
+/// without a `nonisolated(unsafe)` escape hatch. Every conformer is a GRDB
+/// row value type whose stored properties are all `Sendable`, so the bound
+/// is satisfied by the compiler-synthesised conformance.
+protocol CloudKitRecordConvertible: Sendable {
   static var recordType: String { get }
 
   /// Converts this record to a CKRecord in the given zone.
@@ -91,7 +97,7 @@ extension CKRecord {
 
 /// Maps CKRecord.recordType strings to the corresponding record types for dispatching.
 enum RecordTypeRegistry: Sendable {
-  nonisolated(unsafe) static let allTypes: [String: any CloudKitRecordConvertible.Type] = [
+  static let allTypes: [String: any CloudKitRecordConvertible.Type] = [
     // Every record type dispatches to its GRDB row type. The CloudKit
     // wire `recordType` strings are frozen contracts that the schema
     // depends on; do not rename them when refactoring the local Swift


### PR DESCRIPTION
## Problem

`RecordTypeRegistry.allTypes` (`Backends/CloudKit/Sync/CloudKitRecordConvertible.swift`) is an immutable global dictionary of conformer metatypes, but it used `nonisolated(unsafe)` to satisfy the global-shared-state Sendable check. `nonisolated(unsafe)` in production code is a CONCURRENCY_GUIDE §2 anti-pattern (escape hatch that allows data races) — and here the value was never actually mutable, so the hatch was hiding nothing real but still banned. Flagged by `concurrency-review` during PR #1079.

## Fix

Add a `Sendable` bound to `CloudKitRecordConvertible`. Every conformer is a GRDB row value type whose stored properties are all `Sendable`, so the bound is satisfied by the compiler-synthesised conformance. The existential-metatype dictionary is then provably concurrency-safe and the `nonisolated(unsafe)` is removed.

## Verification

- `just build-mac` succeeds under `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES` — confirms every conformer satisfies the new `Sendable` requirement (no row type carries a non-Sendable property).
- `just format-check` clean.
- Sync round-trip + apply suites pass (20 tests / 4 suites).

Follow-up to #1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)