### PR TITLE
fix(sync): fully close the #1081 echo race with a transactional needs_push dirty flag

### DIFF
--- a/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
+++ b/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
@@ -91,6 +91,25 @@ extension CKRecord {
     coder.requiresSecureCoding = true
     return CKRecord(coder: coder)
   }
+
+  /// True when `self` and `other` carry identical user-field values
+  /// (system fields / change tag ignored). Used by the upload-ack path to
+  /// decide whether a row changed locally since the version that was
+  /// uploaded: if the current row's `toCKRecord` still matches the saved
+  /// record, the local edit has been confirmed and `needs_push` can be
+  /// cleared; if a field differs, a newer edit is pending and the flag
+  /// stays set (issue #1081). CKRecord user values are CloudKit-native
+  /// types bridged to `NSObject` (`NSString`/`NSNumber`/`NSData`/`NSDate`),
+  /// so `isEqual` compares them correctly.
+  func hasSameUserFields(as other: CKRecord) -> Bool {
+    let keys = Set(allKeys()).union(other.allKeys())
+    for key in keys {
+      let lhs = self[key] as? NSObject
+      let rhs = other[key] as? NSObject
+      if lhs != rhs { return false }
+    }
+    return true
+  }
 }
 
 // MARK: - Lookup Helper

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
@@ -72,6 +72,68 @@ extension ProfileDataSyncHandler {
     }
   }
 
+  // MARK: - needs_push conditional clear (issue #1081)
+
+  /// Clears `needs_push` for `ids` of `recordType` (each repo's
+  /// `clearNeedsPushBatchSync` opens its own write). Called from the
+  /// upload-ack path only for ids whose current row still matches the
+  /// uploaded version. Unknown record types are a no-op. Dispatch is
+  /// split into reference / domain halves for the same complexity reason
+  /// as `dirtyIds`.
+  nonisolated func clearNeedsPush(recordType: String, ids: [UUID]) throws {
+    guard
+      let clear = referenceNeedsPushClearer(for: recordType)
+        ?? domainNeedsPushClearer(for: recordType)
+    else { return }
+    _ = try clear(ids)
+  }
+
+  /// Reference-data side of the `clearNeedsPush` dispatch.
+  nonisolated private func referenceNeedsPushClearer(
+    for recordType: String
+  ) -> (([UUID]) throws -> Int)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case CSVImportProfileRow.recordType:
+      return { try repos.csvImportProfiles.clearNeedsPushBatchSync($0) }
+    case ImportRuleRow.recordType:
+      return { try repos.importRules.clearNeedsPushBatchSync($0) }
+    case CategoryRow.recordType:
+      return { try repos.categories.clearNeedsPushBatchSync($0) }
+    case TransferSuggestionRow.recordType:
+      return { try repos.transferSuggestions.clearNeedsPushBatchSync($0) }
+    case AccountGroupRow.recordType:
+      return { try repos.accountGroups.clearNeedsPushBatchSync($0) }
+    case InsightDismissalRow.recordType:
+      return { try repos.insightDismissals.clearNeedsPushBatchSync($0) }
+    default:
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the `clearNeedsPush` dispatch.
+  nonisolated private func domainNeedsPushClearer(
+    for recordType: String
+  ) -> (([UUID]) throws -> Int)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType:
+      return { try repos.accounts.clearNeedsPushBatchSync($0) }
+    case EarmarkRow.recordType:
+      return { try repos.earmarks.clearNeedsPushBatchSync($0) }
+    case EarmarkBudgetItemRow.recordType:
+      return { try repos.earmarkBudgetItems.clearNeedsPushBatchSync($0) }
+    case InvestmentValueRow.recordType:
+      return { try repos.investmentValues.clearNeedsPushBatchSync($0) }
+    case TransactionRow.recordType:
+      return { try repos.transactions.clearNeedsPushBatchSync($0) }
+    case TransactionLegRow.recordType:
+      return { try repos.transactionLegs.clearNeedsPushBatchSync($0) }
+    default:
+      return nil
+    }
+  }
+
   /// Writes a system-fields-only update (change tag, no field values) for
   /// the dirty echoes of `recordType` **inside** the active apply write
   /// `database`, sharing the transaction that read `needs_push`. Skips

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
@@ -88,6 +88,67 @@ extension ProfileDataSyncHandler {
     _ = try clear(ids)
   }
 
+  /// In-transaction counterpart to `clearNeedsPush(recordType:ids:)`.
+  /// Clears the flag **inside** the caller's active `database` so the
+  /// upload-ack path's compare and clear share one write transaction,
+  /// leaving no window for a concurrent edit to interleave between them
+  /// (issue #1081). Unknown record types are a no-op.
+  nonisolated func clearNeedsPush(
+    recordType: String, ids: [UUID], in database: Database
+  ) throws {
+    guard
+      let clear = referenceNeedsPushClearer(for: recordType, in: database)
+        ?? domainNeedsPushClearer(for: recordType, in: database)
+    else { return }
+    _ = try clear(ids)
+  }
+
+  /// Reference-data side of the in-transaction `clearNeedsPush` dispatch.
+  nonisolated private func referenceNeedsPushClearer(
+    for recordType: String, in database: Database
+  ) -> (([UUID]) throws -> Int)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case CSVImportProfileRow.recordType:
+      return { try repos.csvImportProfiles.clearNeedsPushBatchSync($0, in: database) }
+    case ImportRuleRow.recordType:
+      return { try repos.importRules.clearNeedsPushBatchSync($0, in: database) }
+    case CategoryRow.recordType:
+      return { try repos.categories.clearNeedsPushBatchSync($0, in: database) }
+    case TransferSuggestionRow.recordType:
+      return { try repos.transferSuggestions.clearNeedsPushBatchSync($0, in: database) }
+    case AccountGroupRow.recordType:
+      return { try repos.accountGroups.clearNeedsPushBatchSync($0, in: database) }
+    case InsightDismissalRow.recordType:
+      return { try repos.insightDismissals.clearNeedsPushBatchSync($0, in: database) }
+    default:
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the in-transaction `clearNeedsPush` dispatch.
+  nonisolated private func domainNeedsPushClearer(
+    for recordType: String, in database: Database
+  ) -> (([UUID]) throws -> Int)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType:
+      return { try repos.accounts.clearNeedsPushBatchSync($0, in: database) }
+    case EarmarkRow.recordType:
+      return { try repos.earmarks.clearNeedsPushBatchSync($0, in: database) }
+    case EarmarkBudgetItemRow.recordType:
+      return { try repos.earmarkBudgetItems.clearNeedsPushBatchSync($0, in: database) }
+    case InvestmentValueRow.recordType:
+      return { try repos.investmentValues.clearNeedsPushBatchSync($0, in: database) }
+    case TransactionRow.recordType:
+      return { try repos.transactions.clearNeedsPushBatchSync($0, in: database) }
+    case TransactionLegRow.recordType:
+      return { try repos.transactionLegs.clearNeedsPushBatchSync($0, in: database) }
+    default:
+      return nil
+    }
+  }
+
   /// Reference-data side of the `clearNeedsPush` dispatch.
   nonisolated private func referenceNeedsPushClearer(
     for recordType: String

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
@@ -1,0 +1,145 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+
+extension ProfileDataSyncHandler {
+  // MARK: - needs_push apply guard (issue #1081)
+
+  /// Returns the subset of `ids` whose `recordType` row currently has
+  /// `needs_push = 1`, read **inside** the active apply write `database`
+  /// (no separate read). A dirty row carries an in-flight local edit not
+  /// yet confirmed uploaded; the apply path skips its field-value upsert
+  /// and advances only its change tag so a stale echo can never clobber
+  /// the newer local edit. Unknown record types report no dirty ids.
+  ///
+  /// The lookup is split between `referenceDirtyIdsReader` (reference
+  /// data) and `domainDirtyIdsReader` (financial-graph rows) so neither
+  /// switch breaches the cyclomatic-complexity ceiling — same shape as
+  /// `saveHandler`.
+  nonisolated func dirtyIds(
+    recordType: String, ids: [UUID], in database: Database
+  ) throws -> Set<UUID> {
+    guard
+      let reader = referenceDirtyIdsReader(for: recordType)
+        ?? domainDirtyIdsReader(for: recordType)
+    else { return [] }
+    return try reader(ids, database)
+  }
+
+  /// Reference-data side of the `dirtyIds` lookup.
+  nonisolated private func referenceDirtyIdsReader(
+    for recordType: String
+  ) -> (([UUID], Database) throws -> Set<UUID>)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case CSVImportProfileRow.recordType:
+      return { try repos.csvImportProfiles.dirtyIdsSync(from: $0, in: $1) }
+    case ImportRuleRow.recordType:
+      return { try repos.importRules.dirtyIdsSync(from: $0, in: $1) }
+    case CategoryRow.recordType:
+      return { try repos.categories.dirtyIdsSync(from: $0, in: $1) }
+    case TransferSuggestionRow.recordType:
+      return { try repos.transferSuggestions.dirtyIdsSync(from: $0, in: $1) }
+    case AccountGroupRow.recordType:
+      return { try repos.accountGroups.dirtyIdsSync(from: $0, in: $1) }
+    case InsightDismissalRow.recordType:
+      return { try repos.insightDismissals.dirtyIdsSync(from: $0, in: $1) }
+    default:
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the `dirtyIds` lookup.
+  nonisolated private func domainDirtyIdsReader(
+    for recordType: String
+  ) -> (([UUID], Database) throws -> Set<UUID>)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType:
+      return { try repos.accounts.dirtyIdsSync(from: $0, in: $1) }
+    case EarmarkRow.recordType:
+      return { try repos.earmarks.dirtyIdsSync(from: $0, in: $1) }
+    case EarmarkBudgetItemRow.recordType:
+      return { try repos.earmarkBudgetItems.dirtyIdsSync(from: $0, in: $1) }
+    case InvestmentValueRow.recordType:
+      return { try repos.investmentValues.dirtyIdsSync(from: $0, in: $1) }
+    case TransactionRow.recordType:
+      return { try repos.transactions.dirtyIdsSync(from: $0, in: $1) }
+    case TransactionLegRow.recordType:
+      return { try repos.transactionLegs.dirtyIdsSync(from: $0, in: $1) }
+    default:
+      return nil
+    }
+  }
+
+  /// Writes a system-fields-only update (change tag, no field values) for
+  /// the dirty echoes of `recordType` **inside** the active apply write
+  /// `database`, sharing the transaction that read `needs_push`. Skips
+  /// records with no UUID component and unknown record types. Dispatch is
+  /// split into reference / domain halves for the same complexity reason
+  /// as `dirtyIds`.
+  nonisolated func applySystemFieldsInTransaction(
+    recordType: String, ckRecords: [CKRecord], in database: Database
+  ) throws {
+    let updates: [(id: UUID, data: Data?)] = ckRecords.compactMap { ckRecord in
+      guard let uuid = ckRecord.recordID.uuid else { return nil }
+      return (id: uuid, data: ckRecord.encodedSystemFields)
+    }
+    guard !updates.isEmpty else { return }
+    guard
+      let setter = referenceInTransactionSystemFieldsSetter(for: recordType)
+        ?? domainInTransactionSystemFieldsSetter(for: recordType)
+    else {
+      Self.batchLogger.warning(
+        "applySystemFieldsInTransaction: unknown record type '\(recordType)' — skipping")
+      return
+    }
+    _ = try setter(updates, database)
+  }
+
+  /// Reference-data side of the in-transaction system-fields setter lookup.
+  nonisolated private func referenceInTransactionSystemFieldsSetter(
+    for recordType: String
+  ) -> (([(id: UUID, data: Data?)], Database) throws -> Int)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case CSVImportProfileRow.recordType:
+      return { try repos.csvImportProfiles.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case ImportRuleRow.recordType:
+      return { try repos.importRules.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case CategoryRow.recordType:
+      return { try repos.categories.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case TransferSuggestionRow.recordType:
+      return { try repos.transferSuggestions.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case AccountGroupRow.recordType:
+      return { try repos.accountGroups.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case InsightDismissalRow.recordType:
+      return { try repos.insightDismissals.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    default:
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the in-transaction system-fields setter lookup.
+  nonisolated private func domainInTransactionSystemFieldsSetter(
+    for recordType: String
+  ) -> (([(id: UUID, data: Data?)], Database) throws -> Int)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType:
+      return { try repos.accounts.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case EarmarkRow.recordType:
+      return { try repos.earmarks.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case EarmarkBudgetItemRow.recordType:
+      return { try repos.earmarkBudgetItems.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case InvestmentValueRow.recordType:
+      return { try repos.investmentValues.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case TransactionRow.recordType:
+      return { try repos.transactions.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    case TransactionLegRow.recordType:
+      return { try repos.transactionLegs.setEncodedSystemFieldsBatchSync($0, in: $1) }
+    default:
+      return nil
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -17,25 +17,18 @@ extension ProfileDataSyncHandler {
   /// `ProfileIndexSyncHandler` on the profile-index zone and is logged
   /// and skipped if it reaches this path.
   /// Returns the set of changed record type strings.
-  /// `locallyPendingRecordNames` carries the record names that currently
-  /// have an un-uploaded local change queued in
-  /// `syncEngine.state.pendingRecordZoneChanges` (saves *and* deletes).
-  /// A fetched save for one of these is a stale server echo of an
-  /// earlier version — CloudKit re-delivers a device's own writes, and
-  /// on a single device that echo can arrive *after* the user has made a
-  /// newer local edit that hasn't uploaded yet. Applying its field
-  /// values would clobber the in-flight edit (the reported single-device
-  /// data-loss race). Such records are therefore excluded from the
-  /// field-value upsert and routed through a system-fields-only update:
-  /// the cached change tag advances (so the queued upload lands cleanly)
-  /// while the local field values — the newer edit — are preserved and
-  /// win on the next send. Records with no pending local change apply
-  /// normally (a genuine remote change, or a harmless no-op echo).
+  ///
+  /// The single-device echo race (issue #1081) is guarded entirely inside
+  /// the apply write transaction: `applyBatchSaves` reads each incoming
+  /// row's `needs_push` flag and refuses to overwrite the field values of
+  /// any row that carries an un-uploaded local edit (it takes a
+  /// system-fields-only update instead, advancing the change tag). There
+  /// is no main-actor pre-snapshot — the transactional check is the sole
+  /// guard.
   nonisolated func applyRemoteChanges(
     saved: [CKRecord],
     deleted: [(CKRecord.ID, String)],
-    preExtractedSystemFields: [(String, Data)] = [],
-    locallyPendingRecordNames: Set<String> = []
+    preExtractedSystemFields: [(String, Data)] = []
   ) -> ApplyResult {
     let batchStart = ContinuousClock.now
     let signpostID = OSSignpostID(log: Signposts.sync)
@@ -48,20 +41,8 @@ extension ProfileDataSyncHandler {
 
     logIncomingBatch(saved: saved, deleted: deleted)
 
-    // Split off stale echoes of records with in-flight local edits so the
-    // field-value upsert can never overwrite a not-yet-uploaded change.
-    let (freshSaved, pendingEchoes) = Self.partitionPendingEchoes(
-      saved: saved, locallyPendingRecordNames: locallyPendingRecordNames)
-    if !pendingEchoes.isEmpty {
-      logger.info(
-        """
-        applyRemoteChanges: \(pendingEchoes.count) fetched save(s) match locally-pending \
-        records — applying system fields only, preserving in-flight local edits
-        """)
-    }
-
     let systemFields = Self.systemFieldsLookup(
-      saved: freshSaved, preExtracted: preExtractedSystemFields)
+      saved: saved, preExtracted: preExtractedSystemFields)
 
     // GRDB-routed batches throw on write failure so CKSyncEngine refetches
     // instead of advancing past a dropped record (silent data loss).
@@ -76,7 +57,7 @@ extension ProfileDataSyncHandler {
     // until the next observation tick landed.
     let upsertStart = ContinuousClock.now
     if let failure = runBatchApplyPhase(
-      saved: freshSaved,
+      saved: saved,
       systemFields: systemFields,
       deleted: deleted,
       signpostID: signpostID)
@@ -85,49 +66,13 @@ extension ProfileDataSyncHandler {
     }
     let upsertDuration = ContinuousClock.now - upsertStart
 
-    // System-fields-only update for the pending echoes runs *after* the
-    // outer write commits: the per-type setters open their own
-    // `database.write`, which cannot nest inside the batch transaction.
-    // A failure here is logged-and-continued inside
-    // `runBatchedSystemFieldsUpdate` rather than returned as
-    // `.saveFailed` — consistent with how system-fields failures are
-    // handled everywhere else. The only consequence is that the next
-    // upload of the pending edit carries a stale change tag and gets a
-    // recoverable `.serverRecordChanged` (handled by `SyncErrorRecovery`);
-    // the in-flight field values are never at risk.
-    if !pendingEchoes.isEmpty {
-      applySystemFieldsBatched(pendingEchoes)
-    }
-
     return reportSuccess(
-      saved: freshSaved,
+      saved: saved,
       deleted: deleted,
       timing: BatchTiming(
         batchStart: batchStart,
-        upsertDuration: upsertDuration,
-        pendingEchoCount: pendingEchoes.count),
+        upsertDuration: upsertDuration),
       signpostID: signpostID)
-  }
-
-  /// Partitions fetched saves into the records safe to upsert
-  /// (`fresh`) and the stale echoes of locally-pending records
-  /// (`pendingEchoes`) whose field values must not be overwritten.
-  /// The empty-set fast path keeps the common (no-pending) case
-  /// allocation-free.
-  nonisolated private static func partitionPendingEchoes(
-    saved: [CKRecord], locallyPendingRecordNames: Set<String>
-  ) -> (fresh: [CKRecord], pendingEchoes: [CKRecord]) {
-    guard !locallyPendingRecordNames.isEmpty else { return (saved, []) }
-    var fresh: [CKRecord] = []
-    var pendingEchoes: [CKRecord] = []
-    for record in saved {
-      if locallyPendingRecordNames.contains(record.recordID.recordName) {
-        pendingEchoes.append(record)
-      } else {
-        fresh.append(record)
-      }
-    }
-    return (fresh, pendingEchoes)
   }
 
   /// Bundles per-batch timing markers passed to `reportSuccess`. Both
@@ -136,11 +81,6 @@ extension ProfileDataSyncHandler {
   nonisolated struct BatchTiming {
     let batchStart: ContinuousClock.Instant
     let upsertDuration: Duration
-    /// Count of fetched saves routed to a system-fields-only update
-    /// because they echoed a locally-pending record. Logged alongside
-    /// the applied-save count so a duration line accounts for the whole
-    /// incoming batch, not just the rows whose field values changed.
-    let pendingEchoCount: Int
   }
 
   /// Runs `applyBatchSaves` and `applyBatchDeletions` inside a single
@@ -205,8 +145,7 @@ extension ProfileDataSyncHandler {
       batchStart: timing.batchStart,
       upsertDuration: timing.upsertDuration,
       saveCount: saved.count,
-      deleteCount: deleted.count,
-      pendingEchoCount: timing.pendingEchoCount)
+      deleteCount: deleted.count)
     let changedTypes = Set(saved.map(\.recordType) + deleted.map(\.1))
     // No `onInstrumentRemoteChange()` fan-out from the per-profile
     // path: every `InstrumentRecord` flows through the shared registry
@@ -365,18 +304,15 @@ extension ProfileDataSyncHandler {
     batchStart: ContinuousClock.Instant,
     upsertDuration: Duration,
     saveCount: Int,
-    deleteCount: Int,
-    pendingEchoCount: Int
+    deleteCount: Int
   ) {
     let batchMs = (ContinuousClock.now - batchStart).inMilliseconds
     guard batchMs > 100 else { return }
     let upsertMs = upsertDuration.inMilliseconds
-    let pendingSuffix =
-      pendingEchoCount > 0 ? ", \(pendingEchoCount) system-fields-only" : ""
     logger.info(
       """
       applyRemoteChanges took \(batchMs)ms \
-      (upsert: \(upsertMs)ms, \(saveCount) saves, \(deleteCount) deletes\(pendingSuffix))
+      (upsert: \(upsertMs)ms, \(saveCount) saves, \(deleteCount) deletes)
       """)
   }
 }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -230,25 +230,62 @@ extension ProfileDataSyncHandler {
   /// Throws when a GRDB-routed batch fails to write so the caller can
   /// return `.saveFailed(...)` and CKSyncEngine refetches instead of
   /// advancing past the dropped record (silent data loss).
+  ///
+  /// Within the transaction each per-type group is split by an
+  /// in-transaction `needs_push` read (issue #1081): rows flagged dirty
+  /// carry an in-flight local edit not yet confirmed uploaded, so their
+  /// field values are NOT overwritten — they receive a system-fields-only
+  /// update (advancing the change tag) in the same transaction via
+  /// `applySystemFieldsInTransaction`, while clean rows take the normal
+  /// `applyGRDBBatchSave` upsert. The dirty read, the clean upsert and the
+  /// dirty system-fields write all share this one `database` transaction,
+  /// so a fetched echo can never clobber a concurrent local edit.
   nonisolated func applyBatchSaves(
     _ records: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let grouped = Dictionary(grouping: records, by: \.recordType)
     for (recordType, ckRecords) in grouped {
+      let ids = ckRecords.compactMap { $0.recordID.uuid }
+      let dirty = try dirtyIds(recordType: recordType, ids: ids, in: database)
+      let (clean, echoed) = Self.splitByDirtiness(ckRecords, dirty: dirty)
+
+      if !echoed.isEmpty {
+        try applySystemFieldsInTransaction(
+          recordType: recordType, ckRecords: echoed, in: database)
+      }
       if try applyGRDBBatchSave(
         recordType: recordType,
-        ckRecords: ckRecords,
+        ckRecords: clean,
         systemFields: systemFields,
         in: database)
       {
         continue
       }
-      if recordType != ProfileRow.recordType {
+      if recordType != ProfileRow.recordType && !clean.isEmpty {
         // The profile record type is handled by ProfileIndexSyncHandler.
         Self.batchLogger.warning(
           "applyBatchSaves: unknown record type '\(recordType)' — skipping")
       }
     }
+  }
+
+  /// Splits a per-type group into the clean records (safe to upsert) and
+  /// the dirty echoes (system-fields only). The empty-`dirty` fast path
+  /// keeps the common no-pending case allocation-free.
+  nonisolated private static func splitByDirtiness(
+    _ ckRecords: [CKRecord], dirty: Set<UUID>
+  ) -> (clean: [CKRecord], echoed: [CKRecord]) {
+    guard !dirty.isEmpty else { return (ckRecords, []) }
+    var clean: [CKRecord] = []
+    var echoed: [CKRecord] = []
+    for record in ckRecords {
+      if let uuid = record.recordID.uuid, dirty.contains(uuid) {
+        echoed.append(record)
+      } else {
+        clean.append(record)
+      }
+    }
+    return (clean, echoed)
   }
 
   /// Handles batch deletions. Groups by record type then routes through

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
@@ -1,0 +1,90 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+
+// In-transaction current-row → CKRecord builder for the upload-ack
+// compare-and-clear path (issue #1081). Split out of
+// `ProfileDataSyncHandler+RecordLookup.swift` to keep that file under the
+// 400-line limit.
+
+extension ProfileDataSyncHandler {
+  /// In-transaction counterpart to `currentCKRecord(recordType:id:)`.
+  /// Reads the current row **inside** the caller's active `database` so
+  /// the upload-ack path can re-fetch, compare, and clear `needs_push`
+  /// without releasing the write transaction — leaving no window for a
+  /// concurrent edit to commit between the compare and the clear (issue
+  /// #1081). Returns `nil` for a missing row or an unknown record type;
+  /// errors propagate so the surrounding transaction rolls back.
+  nonisolated func currentCKRecord(
+    recordType: String, id: UUID, in database: Database
+  ) throws -> CKRecord? {
+    if let referenceResult = try fetchAndBuildReference(
+      recordType: recordType, uuid: id, in: database)
+    {
+      return referenceResult
+    }
+    if let domainResult = try fetchAndBuildDomain(
+      recordType: recordType, uuid: id, in: database)
+    {
+      return domainResult
+    }
+    logger.warning(
+      "currentCKRecord: unknown recordType '\(recordType, privacy: .public)' — skipping")
+    return nil
+  }
+
+  /// Reference-data side of the in-transaction `currentCKRecord` dispatch.
+  /// Outer `.none` = "not this half's record type"; inner `nil` =
+  /// "handled, no such row".
+  nonisolated private func fetchAndBuildReference(
+    recordType: String, uuid: UUID, in database: Database
+  ) throws -> CKRecord?? {
+    let repos = grdbRepositories
+    switch recordType {
+    case CategoryRow.recordType:
+      return try repos.categories.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case TransferSuggestionRow.recordType:
+      return try repos.transferSuggestions.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case AccountGroupRow.recordType:
+      return try repos.accountGroups.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case InsightDismissalRow.recordType:
+      return try repos.insightDismissals.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case CSVImportProfileRow.recordType:
+      return try repos.csvImportProfiles.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case ImportRuleRow.recordType:
+      return try repos.importRules.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    default:
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the in-transaction `currentCKRecord` dispatch.
+  nonisolated private func fetchAndBuildDomain(
+    recordType: String, uuid: UUID, in database: Database
+  ) throws -> CKRecord?? {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType:
+      return try repos.accounts.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case TransactionRow.recordType:
+      return try repos.transactions.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case TransactionLegRow.recordType:
+      return try repos.transactionLegs.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case EarmarkRow.recordType:
+      return try repos.earmarks.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case EarmarkBudgetItemRow.recordType:
+      return try repos.earmarkBudgetItems.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    case InvestmentValueRow.recordType:
+      return try repos.investmentValues.fetchRowSync(id: uuid, in: database).map(builtRecord)
+    default:
+      return nil
+    }
+  }
+
+  /// Builds the upload `CKRecord` for a fetched row, carrying its cached
+  /// system fields. Shared by both in-transaction dispatch halves.
+  nonisolated private func builtRecord<T>(_ row: T) -> CKRecord
+  where T: CloudKitRecordConvertible & ValueTypeSystemFieldsReadable {
+    buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
+  }
+}

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
@@ -65,6 +65,19 @@ extension ProfileDataSyncHandler {
     #endif
   }
 
+  // MARK: - Current Record for Ack Comparison
+
+  /// Builds the `CKRecord` for the current local row of `recordType` /
+  /// `id`, or `nil` if no such row exists or the type is unknown. Used by
+  /// the upload-ack path to compare the current row's user fields against
+  /// the version that was just confirmed saved: if they match, the local
+  /// edit is confirmed and `needs_push` can be cleared; if they differ, a
+  /// newer edit is pending and the flag stays set (issue #1081). Reuses
+  /// the same per-type `fetchAndBuild` dispatch as the upload path.
+  func currentCKRecord(recordType: String, id: UUID) -> CKRecord? {
+    fetchAndBuild(recordType: recordType, uuid: id)
+  }
+
   // MARK: - Per-Type Dispatch
 
   /// Single-record dispatcher. Returns nil for unknown recordType

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
@@ -1,5 +1,6 @@
 @preconcurrency import CloudKit
 import Foundation
+import GRDB
 
 extension ProfileDataSyncHandler {
   // MARK: - Batch Record Lookup
@@ -77,6 +78,9 @@ extension ProfileDataSyncHandler {
   func currentCKRecord(recordType: String, id: UUID) -> CKRecord? {
     fetchAndBuild(recordType: recordType, uuid: id)
   }
+
+  // The in-transaction counterpart `currentCKRecord(recordType:id:in:)`
+  // lives in `ProfileDataSyncHandler+CurrentRecordInTransaction.swift`.
 
   // MARK: - Per-Type Dispatch
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -113,32 +113,50 @@ extension ProfileDataSyncHandler {
   /// Clears `needs_push` for each saved record whose current local row
   /// still matches the uploaded version. If the row changed since the
   /// send (a newer edit), the flag stays set — CKSyncEngine has already
-  /// re-queued that edit, and its own later ack clears the flag. Race-free
-  /// under the serial write queue: a wrongly-cleared flag is re-set by the
-  /// newer edit's own write (issue #1081). Clearing only on an exact
-  /// user-field match is the safe direction — an under-clear is a harmless
-  /// extra deferral, while an over-clear could let a later echo clobber a
-  /// pending newer edit (data loss).
+  /// re-queued that edit, and its own later ack clears the flag. Clearing
+  /// only on an exact user-field match is the safe direction — an
+  /// under-clear is a harmless extra deferral, while an over-clear could
+  /// let a later echo clobber a pending newer edit (data loss).
+  ///
+  /// **Atomicity (issue #1081).** The current-row read, the user-field
+  /// compare, and the conditional clear all run inside ONE
+  /// `grdbRepositories.database.write` transaction. Because that write
+  /// holds the serial GRDB queue for its whole duration, no concurrent
+  /// local edit can commit (and re-raise `needs_push`) between the compare
+  /// and the clear — the previous read-then-separate-write shape had a
+  /// TOCTOU window where exactly such an interleaving could clear the flag
+  /// over a newer edit, losing its protection.
+  ///
+  /// - Precondition: call on `@MainActor` (matches `updateSystemFieldsForSaved`).
+  ///   The single `database.write` is the only transaction opened, so this
+  ///   must not be nested inside another write on the same queue.
   private func clearNeedsPushForConfirmed(_ savedRecords: [CKRecord]) {
-    var clearByType: [String: [UUID]] = [:]
-    for saved in savedRecords {
-      guard let uuid = saved.recordID.uuid else { continue }
-      guard let current = currentCKRecord(recordType: saved.recordType, id: uuid)
-      else { continue }
-      if current.hasSameUserFields(as: saved) {
-        clearByType[saved.recordType, default: []].append(uuid)
+    do {
+      try grdbRepositories.database.write { database in
+        var clearByType: [String: [UUID]] = [:]
+        for saved in savedRecords {
+          guard let uuid = saved.recordID.uuid else { continue }
+          // Re-fetch the CURRENT row inside this transaction and compare.
+          guard
+            let current = try self.currentCKRecord(
+              recordType: saved.recordType, id: uuid, in: database)
+          else { continue }
+          if current.hasSameUserFields(as: saved) {
+            clearByType[saved.recordType, default: []].append(uuid)
+          }
+        }
+        // Clear in the SAME transaction so no edit interleaves between the
+        // compare above and the clear below.
+        for (recordType, ids) in clearByType {
+          try self.clearNeedsPush(recordType: recordType, ids: ids, in: database)
+        }
       }
-    }
-    for (recordType, ids) in clearByType {
-      do {
-        try clearNeedsPush(recordType: recordType, ids: ids)
-      } catch {
-        logger.error(
-          """
-          clearNeedsPush failed for \(recordType, privacy: .public): \
-          \(error.localizedDescription, privacy: .public)
-          """)
-      }
+    } catch {
+      logger.error(
+        """
+        clearNeedsPushForConfirmed failed: \
+        \(error.localizedDescription, privacy: .public)
+        """)
     }
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -84,6 +84,7 @@ extension ProfileDataSyncHandler {
   ) -> SyncErrorRecovery.ClassifiedFailures {
     if !savedRecords.isEmpty {
       updateSystemFieldsForSaved(savedRecords)
+      clearNeedsPushForConfirmed(savedRecords)
     }
 
     let failures = SyncErrorRecovery.classify(
@@ -107,6 +108,38 @@ extension ProfileDataSyncHandler {
   private func updateSystemFieldsForSaved(_ savedRecords: [CKRecord]) {
     applySystemFieldsBatched(savedRecords)
     logger.info("Applied system fields for \(savedRecords.count) saved records")
+  }
+
+  /// Clears `needs_push` for each saved record whose current local row
+  /// still matches the uploaded version. If the row changed since the
+  /// send (a newer edit), the flag stays set — CKSyncEngine has already
+  /// re-queued that edit, and its own later ack clears the flag. Race-free
+  /// under the serial write queue: a wrongly-cleared flag is re-set by the
+  /// newer edit's own write (issue #1081). Clearing only on an exact
+  /// user-field match is the safe direction — an under-clear is a harmless
+  /// extra deferral, while an over-clear could let a later echo clobber a
+  /// pending newer edit (data loss).
+  private func clearNeedsPushForConfirmed(_ savedRecords: [CKRecord]) {
+    var clearByType: [String: [UUID]] = [:]
+    for saved in savedRecords {
+      guard let uuid = saved.recordID.uuid else { continue }
+      guard let current = currentCKRecord(recordType: saved.recordType, id: uuid)
+      else { continue }
+      if current.hasSameUserFields(as: saved) {
+        clearByType[saved.recordType, default: []].append(uuid)
+      }
+    }
+    for (recordType, ids) in clearByType {
+      do {
+        try clearNeedsPush(recordType: recordType, ids: ids)
+      } catch {
+        logger.error(
+          """
+          clearNeedsPush failed for \(recordType, privacy: .public): \
+          \(error.localizedDescription, privacy: .public)
+          """)
+      }
+    }
   }
 
   /// Reconciles system fields after conflicts (adopt the server copy)

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -61,7 +61,11 @@ final class ProfileDataSyncHandler {
   /// they are discarded and the record is uploaded as a fresh create
   /// in the handler's zone — defence-in-depth against cross-zone
   /// system-fields corruption.
-  func buildCKRecord<T: CloudKitRecordConvertible>(
+  /// `nonisolated` so the off-main fetched-changes apply path and the
+  /// in-transaction ack-clear compare (issue #1081) can build the upload
+  /// record without hopping to the main actor. Touches only the
+  /// `nonisolated let zoneID`.
+  nonisolated func buildCKRecord<T: CloudKitRecordConvertible>(
     from record: T, encodedSystemFields: Data?
   ) -> CKRecord {
     let freshRecord = record.toCKRecord(in: zoneID)

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
@@ -48,30 +48,35 @@ extension ProfileIndexSyncHandler {
   /// local row still matches the uploaded version. If the row changed
   /// since the send (a newer edit), the flag stays set — CKSyncEngine
   /// has already re-queued that edit, and its own later ack clears the
-  /// flag. Race-free under GRDB's serial write queue: a wrongly-cleared
-  /// flag is re-set by the newer edit's own write (issue #1081).
-  /// Instrument-typed saved records are ignored (shared registry).
+  /// flag. Instrument-typed saved records are ignored (shared registry).
+  ///
+  /// **Atomicity (issue #1081).** The current-row read, the user-field
+  /// compare, and the conditional clear all share ONE
+  /// `repository.database.write` transaction, so no concurrent profile
+  /// rename can commit (and re-raise `needs_push`) between the compare and
+  /// the clear — the prior read-then-separate-write shape had a TOCTOU
+  /// window where such an interleaving could clear the flag over a newer
+  /// rename, losing its protection.
   func clearNeedsPushForConfirmed(_ savedRecords: [CKRecord]) {
-    var confirmed: [UUID] = []
-    for saved in savedRecords where saved.recordType == ProfileRow.recordType {
-      guard let profileId = saved.recordID.uuid else { continue }
-      do {
-        guard let current = try repository.fetchRowSync(id: profileId) else { continue }
-        if buildCKRecord(for: current).hasSameUserFields(as: saved) {
-          confirmed.append(profileId)
-        }
-      } catch {
-        logger.error(
-          "clearNeedsPushForConfirmed: failed to fetch profile row \(profileId, privacy: .public): \(error, privacy: .public)"
-        )
-      }
-    }
-    guard !confirmed.isEmpty else { return }
     do {
-      _ = try repository.clearNeedsPushBatchSync(confirmed)
+      try repository.database.write { database in
+        var confirmed: [UUID] = []
+        for saved in savedRecords where saved.recordType == ProfileRow.recordType {
+          guard let profileId = saved.recordID.uuid else { continue }
+          // Re-read the CURRENT row inside this transaction and compare.
+          guard let current = try self.repository.fetchRowSync(id: profileId, in: database)
+          else { continue }
+          if self.buildCKRecord(for: current).hasSameUserFields(as: saved) {
+            confirmed.append(profileId)
+          }
+        }
+        // Clear in the SAME transaction so no rename interleaves between
+        // the compare above and the clear below.
+        _ = try self.repository.clearNeedsPushBatchSync(confirmed, in: database)
+      }
     } catch {
       logger.error(
-        "clearNeedsPushForConfirmed: clear failed: \(error, privacy: .public)")
+        "clearNeedsPushForConfirmed: failed: \(error, privacy: .public)")
     }
   }
 }

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
@@ -43,4 +43,35 @@ extension ProfileIndexSyncHandler {
       }
     }
   }
+
+  /// Clears `needs_push` for each saved profile record whose current
+  /// local row still matches the uploaded version. If the row changed
+  /// since the send (a newer edit), the flag stays set — CKSyncEngine
+  /// has already re-queued that edit, and its own later ack clears the
+  /// flag. Race-free under GRDB's serial write queue: a wrongly-cleared
+  /// flag is re-set by the newer edit's own write (issue #1081).
+  /// Instrument-typed saved records are ignored (shared registry).
+  func clearNeedsPushForConfirmed(_ savedRecords: [CKRecord]) {
+    var confirmed: [UUID] = []
+    for saved in savedRecords where saved.recordType == ProfileRow.recordType {
+      guard let profileId = saved.recordID.uuid else { continue }
+      do {
+        guard let current = try repository.fetchRowSync(id: profileId) else { continue }
+        if buildCKRecord(for: current).hasSameUserFields(as: saved) {
+          confirmed.append(profileId)
+        }
+      } catch {
+        logger.error(
+          "clearNeedsPushForConfirmed: failed to fetch profile row \(profileId, privacy: .public): \(error, privacy: .public)"
+        )
+      }
+    }
+    guard !confirmed.isEmpty else { return }
+    do {
+      _ = try repository.clearNeedsPushBatchSync(confirmed)
+    } catch {
+      logger.error(
+        "clearNeedsPushForConfirmed: clear failed: \(error, privacy: .public)")
+    }
+  }
 }

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
@@ -1,0 +1,46 @@
+@preconcurrency import CloudKit
+import Foundation
+
+// MARK: - needs_push conditional clear (issue #1081)
+//
+// Split out of `ProfileIndexSyncHandler.swift` to keep the main file
+// under the 400-line limit (it is already split into +Lifecycle and
+// +Instruments). Mirrors the per-profile path's conditional clear in
+// `ProfileDataSyncHandler+SystemFields.swift`.
+
+extension ProfileIndexSyncHandler {
+  /// Applies the profile leg of a fetched batch in ONE transaction: the
+  /// dirty check, the clean-row upsert, and the dirty-row system-fields
+  /// write all share a single `repository.database.write` so an in-flight
+  /// profile rename can never be clobbered by a fetched echo (issue
+  /// #1081 — no main-actor snapshot gap, no accepted residual). A dirty
+  /// profile row skips its field-value upsert and takes its change tag
+  /// only; a clean one upserts normally. The instrument leg is applied
+  /// separately by the caller (separate shared-registry database).
+  ///
+  /// `freshSaved` is the original `[CKRecord]` batch after the #1079
+  /// pending-echo partition; the dirty echoes' system-fields blob is
+  /// sourced from it so the cached change tag advances.
+  func applyProfilesGuarded(
+    profileRows: [ProfileRow],
+    deletedProfileIds: [UUID],
+    freshSaved: [CKRecord]
+  ) throws {
+    try repository.database.write { database in
+      let profileIds = profileRows.map(\.id)
+      let dirty = try repository.dirtyIdsSync(from: profileIds, in: database)
+      let clean = profileRows.filter { !dirty.contains($0.id) }
+      try repository.applyRemoteChangesSync(
+        saved: clean, deleted: deletedProfileIds, in: database)
+      let echoes = freshSaved.compactMap { record -> (id: UUID, data: Data?)? in
+        guard let uuid = record.recordID.uuid, dirty.contains(uuid),
+          record.recordType == ProfileRow.recordType
+        else { return nil }
+        return (uuid, record.encodedSystemFields)
+      }
+      if !echoes.isEmpty {
+        try repository.setEncodedSystemFieldsBatchSync(echoes, in: database)
+      }
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
@@ -18,13 +18,13 @@ extension ProfileIndexSyncHandler {
   /// only; a clean one upserts normally. The instrument leg is applied
   /// separately by the caller (separate shared-registry database).
   ///
-  /// `freshSaved` is the original `[CKRecord]` batch after the #1079
-  /// pending-echo partition; the dirty echoes' system-fields blob is
-  /// sourced from it so the cached change tag advances.
+  /// `saved` is the original fetched `[CKRecord]` batch; the dirty
+  /// echoes' system-fields blob is sourced from it so the cached change
+  /// tag advances even though their field values are not written.
   func applyProfilesGuarded(
     profileRows: [ProfileRow],
     deletedProfileIds: [UUID],
-    freshSaved: [CKRecord]
+    saved: [CKRecord]
   ) throws {
     try repository.database.write { database in
       let profileIds = profileRows.map(\.id)
@@ -32,7 +32,7 @@ extension ProfileIndexSyncHandler {
       let clean = profileRows.filter { !dirty.contains($0.id) }
       try repository.applyRemoteChangesSync(
         saved: clean, deleted: deletedProfileIds, in: database)
-      let echoes = freshSaved.compactMap { record -> (id: UUID, data: Data?)? in
+      let echoes = saved.compactMap { record -> (id: UUID, data: Data?)? in
         guard let uuid = record.recordID.uuid, dirty.contains(uuid),
           record.recordType == ProfileRow.recordType
         else { return nil }

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -266,6 +266,7 @@ final class ProfileIndexSyncHandler: Sendable {
     failedDeletes: [(CKRecord.ID, CKError)]
   ) -> SyncErrorRecovery.ClassifiedFailures {
     persistSystemFields(for: savedRecords)
+    clearNeedsPushForConfirmed(savedRecords)
     let failures = SyncErrorRecovery.classify(
       failedSaves: failedSaves,
       failedDeletes: failedDeletes,

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -115,10 +115,13 @@ final class ProfileIndexSyncHandler: Sendable {
     let savedSplit = Self.partitionSaved(freshSaved, logger: logger)
     let deletedSplit = Self.partitionDeleted(deleted, logger: logger)
 
-    // Profiles first.
+    // Profiles first, guarded by `needs_push` inside ONE transaction
+    // (see `applyProfilesGuarded`).
     do {
-      try repository.applyRemoteChangesSync(
-        saved: savedSplit.profileRows, deleted: deletedSplit.profileIds)
+      try applyProfilesGuarded(
+        profileRows: savedSplit.profileRows,
+        deletedProfileIds: deletedSplit.profileIds,
+        freshSaved: freshSaved)
     } catch {
       logger.error("Failed to save remote profile changes: \(error, privacy: .public)")
       return .saveFailed(error.localizedDescription)

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -83,36 +83,20 @@ final class ProfileIndexSyncHandler: Sendable {
   /// instruments failed — is a recoverable state the next sync cycle
   /// re-attempts via `unsyncedRowIdsSync()`.
   ///
-  /// `locallyPendingRecordNames` carries the record names that currently
-  /// have an un-uploaded local change queued for this zone (saves *and*
-  /// deletes). A fetched save for one of these is a stale server echo of
-  /// an earlier version — applying its field values would clobber the
-  /// not-yet-uploaded local edit (e.g. a profile rename, or an instrument
-  /// pricing-status change). Such records are excluded from the
-  /// field-value upsert and routed through a system-fields-only update
-  /// (`writeSystemFields`), so the cached change tag advances while the
-  /// local field values win on the next send. Mirrors the guard in
+  /// The single-device echo race (issue #1081) is guarded entirely inside
+  /// the apply write transaction by `applyProfilesGuarded`, which reads
+  /// each incoming profile row's `needs_push` flag and refuses to
+  /// overwrite the field values of any row carrying an un-uploaded local
+  /// edit (e.g. a profile rename). There is no main-actor pre-snapshot —
+  /// the transactional check is the sole guard. Mirrors the guard in
   /// `ProfileDataSyncHandler.applyRemoteChanges` (SYNC_GUIDE §2,
-  /// cross-handler review rule).
+  /// cross-handler review rule). Instrument rows live in the separate
+  /// shared-registry database and are out of scope for the profile guard.
   func applyRemoteChanges(
     saved: [CKRecord],
-    deleted: [CKRecord.ID],
-    locallyPendingRecordNames: Set<String> = []
+    deleted: [CKRecord.ID]
   ) -> ApplyResult {
-    let (freshSaved, pendingEchoes) = Self.partitionPendingEchoes(
-      saved: saved, locallyPendingRecordNames: locallyPendingRecordNames)
-    if !pendingEchoes.isEmpty {
-      logger.info(
-        """
-        applyRemoteChanges: \(pendingEchoes.count) fetched save(s) match locally-pending \
-        records — applying system fields only, preserving in-flight local edits
-        """)
-      for record in pendingEchoes {
-        writeSystemFields(for: record.recordID, to: record.encodedSystemFields)
-      }
-    }
-
-    let savedSplit = Self.partitionSaved(freshSaved, logger: logger)
+    let savedSplit = Self.partitionSaved(saved, logger: logger)
     let deletedSplit = Self.partitionDeleted(deleted, logger: logger)
 
     // Profiles first, guarded by `needs_push` inside ONE transaction
@@ -121,7 +105,7 @@ final class ProfileIndexSyncHandler: Sendable {
       try applyProfilesGuarded(
         profileRows: savedSplit.profileRows,
         deletedProfileIds: deletedSplit.profileIds,
-        freshSaved: freshSaved)
+        saved: saved)
     } catch {
       logger.error("Failed to save remote profile changes: \(error, privacy: .public)")
       return .saveFailed(error.localizedDescription)
@@ -154,29 +138,6 @@ final class ProfileIndexSyncHandler: Sendable {
       changedTypes.insert(InstrumentRow.recordType)
     }
     return .success(changedTypes: changedTypes)
-  }
-
-  /// Partitions fetched saves into the records safe to upsert
-  /// (`fresh`) and the stale echoes of locally-pending records
-  /// (`pendingEchoes`) whose field values must not be overwritten.
-  /// The empty-set fast path keeps the common (no-pending) case
-  /// allocation-free. Mirrors the same-named helper on
-  /// `ProfileDataSyncHandler` (the two handlers are maintained
-  /// separately per SYNC_GUIDE §2).
-  static func partitionPendingEchoes(
-    saved: [CKRecord], locallyPendingRecordNames: Set<String>
-  ) -> (fresh: [CKRecord], pendingEchoes: [CKRecord]) {
-    guard !locallyPendingRecordNames.isEmpty else { return (saved, []) }
-    var fresh: [CKRecord] = []
-    var pendingEchoes: [CKRecord] = []
-    for record in saved {
-      if locallyPendingRecordNames.contains(record.recordID.recordName) {
-        pendingEchoes.append(record)
-      } else {
-        fresh.append(record)
-      }
-    }
-    return (fresh, pendingEchoes)
   }
 
   // MARK: - Building CKRecords

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -104,16 +104,12 @@ extension SyncCoordinator {
     deleted: [(CKRecord.ID, String)]
   ) async {
     let deletedIDs = deleted.map(\.0)
-    // Snapshot the index zone's locally-pending record names on the main
-    // actor before the off-main apply, so a stale echo of a not-yet-
-    // uploaded profile rename / instrument edit can't clobber it. Same
-    // guard as the profile-data path (SYNC_GUIDE §2, cross-handler rule).
-    let pendingNames = await MainActor.run {
-      locallyPendingRecordNames(in: profileIndexHandler.zoneID)
-    }
-    // Index upsert is fast (few records), run off-main
+    // Index upsert is fast (few records), run off-main. The single-device
+    // echo race is guarded transactionally inside the handler's apply
+    // write via the `needs_push` flag (issue #1081), so no main-actor
+    // pre-snapshot is needed.
     let indexResult = profileIndexHandler.applyRemoteChanges(
-      saved: saved, deleted: deletedIDs, locallyPendingRecordNames: pendingNames)
+      saved: saved, deleted: deletedIDs)
     switch indexResult {
     case .success:
       await MainActor.run {
@@ -152,23 +148,20 @@ extension SyncCoordinator {
     // No invariant violations can reach this point — the coordinator
     // constructs its own handler bundle, so `profileNotRegistered` is
     // unreachable on the apply path.
-    // Resolve the handler and snapshot the locally-pending record names
-    // in the same MainActor hop — both read @MainActor-isolated state
-    // (`syncEngine.state`). The snapshot lets the off-main apply skip
-    // overwriting field values for any record that still has an
-    // un-uploaded local edit (the single-device echo race).
-    let resolved: (handler: ProfileDataSyncHandler, pendingNames: Set<String>)? =
+    //
+    // The single-device echo race is guarded transactionally inside the
+    // handler's apply write via the `needs_push` flag (issue #1081), so
+    // no main-actor pending-record snapshot is taken here.
+    let handler: ProfileDataSyncHandler? =
       await MainActor.run {
         do {
-          let handler = try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
-          return (handler, locallyPendingRecordNames(in: zoneID))
+          return try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
         } catch {
           logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
           return nil
         }
       }
-    guard let resolved else { return }
-    let handler = resolved.handler
+    guard let handler else { return }
 
     // Filter pre-extracted system fields to this zone (off-main)
     let savedNames = Set(saved.map { $0.recordID.recordName })
@@ -185,8 +178,7 @@ extension SyncCoordinator {
 
     // Heavy upsert/delete/save runs off-main via nonisolated method
     let result = handler.applyRemoteChanges(
-      saved: saved, deleted: deleted, preExtractedSystemFields: zonePreExtracted,
-      locallyPendingRecordNames: resolved.pendingNames)
+      saved: saved, deleted: deleted, preExtractedSystemFields: zonePreExtracted)
 
     switch result {
     case .success:
@@ -362,29 +354,4 @@ extension SyncCoordinator {
     progress.updatePendingUploads(syncEngine.state.pendingRecordZoneChanges.count)
   }
 
-  /// Record names in `zoneID` that currently have an un-uploaded local
-  /// change queued (saves *and* deletes). A fetched save for one of
-  /// these is a stale server echo of an earlier version: applying its
-  /// field values would clobber the in-flight local edit, so the apply
-  /// path routes them through a system-fields-only update instead. See
-  /// `ProfileDataSyncHandler.applyRemoteChanges(…:locallyPendingRecordNames:)`.
-  /// Returns empty when the engine hasn't started (e.g. under
-  /// `--ui-testing`), which disables the guard and applies everything —
-  /// correct, since nothing is pending.
-  @MainActor
-  func locallyPendingRecordNames(in zoneID: CKRecordZone.ID) -> Set<String> {
-    guard let syncEngine else { return [] }
-    var names: Set<String> = []
-    for change in syncEngine.state.pendingRecordZoneChanges {
-      switch change {
-      case .saveRecord(let recordID) where recordID.zoneID == zoneID:
-        names.insert(recordID.recordName)
-      case .deleteRecord(let recordID) where recordID.zoneID == zoneID:
-        names.insert(recordID.recordName)
-      default:
-        break
-      }
-    }
-    return names
-  }
 }

--- a/Backends/GRDB/ProfileIndexSchema+NeedsPush.swift
+++ b/Backends/GRDB/ProfileIndexSchema+NeedsPush.swift
@@ -6,8 +6,13 @@ extension ProfileIndexSchema {
   /// table (mirrors the per-profile v17 migration; see
   /// `ProfileSchema+NeedsPush.swift`). Instrument rows live in the shared
   /// registry and are out of scope.
+  /// `needs_push` is a boolean (0/1), so the column carries a
+  /// `CHECK (needs_push IN (0, 1))` (matching the v6 `valuation_mode`
+  /// precedent and the per-profile v17 migration). String literal — no
+  /// interpolation — per `guides/DATABASE_CODE_GUIDE.md` §4.
   static func addNeedsPush(_ database: Database) throws {
     try database.execute(
-      sql: "ALTER TABLE profile ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0;")
+      sql: "ALTER TABLE profile ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
   }
 }

--- a/Backends/GRDB/ProfileIndexSchema+NeedsPush.swift
+++ b/Backends/GRDB/ProfileIndexSchema+NeedsPush.swift
@@ -1,0 +1,13 @@
+import Foundation
+import GRDB
+
+extension ProfileIndexSchema {
+  /// v4 — adds the local-only `needs_push` dirty flag to the `profile`
+  /// table (mirrors the per-profile v17 migration; see
+  /// `ProfileSchema+NeedsPush.swift`). Instrument rows live in the shared
+  /// registry and are out of scope.
+  static func addNeedsPush(_ database: Database) throws {
+    try database.execute(
+      sql: "ALTER TABLE profile ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0;")
+  }
+}

--- a/Backends/GRDB/ProfileIndexSchema.swift
+++ b/Backends/GRDB/ProfileIndexSchema.swift
@@ -25,6 +25,9 @@ import GRDB
 ///   resolutions, and price-cache rows propagate across every profile on
 ///   the same iCloud account. See
 ///   `ProfileIndexSchema+SharedInstrumentRegistry.swift`.
+/// `v4_needs_push`                 — adds the local-only `needs_push`
+///   dirty flag to the `profile` table (mirrors the per-profile v17
+///   migration; issue #1081). See `ProfileIndexSchema+NeedsPush.swift`.
 ///
 /// Each migration body is registered here. Once shipped, migration IDs
 /// are frozen forever; splitting later is fine, merging post-ship is
@@ -38,7 +41,7 @@ enum ProfileIndexSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 3
+  static let version = 4
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -53,6 +56,7 @@ enum ProfileIndexSchema {
     migrator.registerMigration(
       "v3_shared_instrument_registry",
       migrate: createSharedInstrumentRegistryTables)
+    migrator.registerMigration("v4_needs_push", migrate: addNeedsPush)
 
     return migrator
   }

--- a/Backends/GRDB/ProfileSchema+NeedsPush.swift
+++ b/Backends/GRDB/ProfileSchema+NeedsPush.swift
@@ -1,0 +1,26 @@
+import Foundation
+import GRDB
+
+extension ProfileSchema {
+  /// v17 — adds the local-only `needs_push` dirty flag to every syncable
+  /// per-profile table. `needs_push = 1` means the row has a local change
+  /// not yet confirmed uploaded to CloudKit; the fetched-changes apply
+  /// path reads it inside its write transaction and refuses to overwrite
+  /// such a row's field values (issue #1081). The column never crosses
+  /// the CloudKit wire and is absent from every Row struct's CodingKeys,
+  /// so `upsert` leaves it untouched. Existing rows default to 0 (clean):
+  /// any genuinely-unpushed row already has `encoded_system_fields IS NULL`
+  /// and is re-queued by the first-start self-heal, so a 0 default cannot
+  /// lose an edit at migration time.
+  static func addNeedsPush(_ database: Database) throws {
+    let tables = [
+      "account", "account_group", "category", "earmark", "earmark_budget_item",
+      "investment_value", "\"transaction\"", "transaction_leg",
+      "transfer_suggestion", "insight_dismissal", "csv_import_profile", "import_rule",
+    ]
+    for table in tables {
+      try database.execute(
+        sql: "ALTER TABLE \(table) ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0;")
+    }
+  }
+}

--- a/Backends/GRDB/ProfileSchema+NeedsPush.swift
+++ b/Backends/GRDB/ProfileSchema+NeedsPush.swift
@@ -12,15 +12,47 @@ extension ProfileSchema {
   /// any genuinely-unpushed row already has `encoded_system_fields IS NULL`
   /// and is re-queued by the first-start self-heal, so a 0 default cannot
   /// lose an edit at migration time.
+  /// `needs_push` is a boolean (0/1), so each column carries a
+  /// `CHECK (needs_push IN (0, 1))` — matching the v6 `valuation_mode`
+  /// precedent. Every statement is a string literal (no `\(table)`
+  /// interpolation) per `guides/DATABASE_CODE_GUIDE.md` §4.
   static func addNeedsPush(_ database: Database) throws {
-    let tables = [
-      "account", "account_group", "category", "earmark", "earmark_budget_item",
-      "investment_value", "\"transaction\"", "transaction_leg",
-      "transfer_suggestion", "insight_dismissal", "csv_import_profile", "import_rule",
-    ]
-    for table in tables {
-      try database.execute(
-        sql: "ALTER TABLE \(table) ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0;")
-    }
+    try database.execute(
+      sql: "ALTER TABLE account ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE account_group ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE category ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE earmark ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE earmark_budget_item ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE investment_value ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    // `transaction` is a SQL keyword and must stay double-quoted.
+    try database.execute(
+      sql: "ALTER TABLE \"transaction\" ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE transaction_leg ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE transfer_suggestion ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE insight_dismissal ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE csv_import_profile ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
+    try database.execute(
+      sql: "ALTER TABLE import_rule ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0 "
+        + "CHECK (needs_push IN (0, 1));")
   }
 }

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -85,6 +85,11 @@ import GRDB
 /// `UNIQUE`; the primary key is a deterministic UUID derived from `kind`
 /// so the same kind resolves to the same record on every device. See
 /// `ProfileSchema+InsightDismissals.swift`.
+/// `v17_needs_push` — adds the local-only `needs_push` dirty flag to
+/// every syncable per-profile table so the fetched-changes apply path
+/// can refuse to clobber an in-flight local edit (issue #1081). The
+/// column never crosses the CloudKit wire. See
+/// `ProfileSchema+NeedsPush.swift`.
 ///
 /// **Retention policy for the cache tables.** The six rate-cache
 /// tables are kept forever — needed for historic-conversion
@@ -105,7 +110,7 @@ enum ProfileSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 16
+  static let version = 17
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -145,6 +150,7 @@ enum ProfileSchema {
       "v15_account_group_ui_state", migrate: addAccountGroupUIState)
     migrator.registerMigration(
       "v16_insight_dismissals", migrate: addInsightDismissals)
+    migrator.registerMigration("v17_needs_push", migrate: addNeedsPush)
 
     return migrator
   }

--- a/Backends/GRDB/Records/AccountGroupRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/AccountGroupRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension AccountGroupRow {
   /// duplicate allowlist to maintain.
   static var observableRegion: QueryInterfaceRequest<AccountGroupRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/AccountGroupRow.swift
+++ b/Backends/GRDB/Records/AccountGroupRow.swift
@@ -19,6 +19,7 @@ struct AccountGroupRow {
     case instrumentId = "instrument_id"
     case position
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/AccountRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/AccountRow+ObservableRegion.swift
@@ -5,14 +5,15 @@ import GRDB
 
 extension AccountRow {
   /// Column-restricted region UI `ValueObservation`s pass to
-  /// `tracking(regions:fetch:)`. Excludes `encoded_system_fields` so the
-  /// per-batch sync-bookkeeping write CKSyncEngine performs after a
-  /// successful send does not re-fire UI observers. See issue #865.
-  /// `Columns: CaseIterable` means new columns auto-enrol — no
-  /// duplicate allowlist to maintain.
+  /// `tracking(regions:fetch:)`. Excludes `encoded_system_fields` and the
+  /// local-only `needs_push` flag so the per-batch sync-bookkeeping
+  /// writes CKSyncEngine / the apply + ack paths perform do not re-fire
+  /// UI observers. See issues #865 and #1081. `Columns: CaseIterable`
+  /// means new data columns auto-enrol — no duplicate allowlist to
+  /// maintain.
   static var observableRegion: QueryInterfaceRequest<AccountRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/AccountRow.swift
+++ b/Backends/GRDB/Records/AccountRow.swift
@@ -27,6 +27,12 @@ struct AccountRow {
     case chainId = "chain_id"
     case exchangeProvider = "exchange_provider"
     case groupId = "group_id"
+    /// Local-only dirty flag (issue #1081). Absent from `CodingKeys` so
+    /// it never crosses the wire and `upsert` leaves it untouched; set
+    /// via the query builder only. Excluded from `observableRegion` (see
+    /// `AccountRow+ObservableRegion.swift`) so the sync-bookkeeping write
+    /// that toggles it never re-fires UI observers (issue #865).
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/CSVImportProfileRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/CSVImportProfileRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension CSVImportProfileRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<CSVImportProfileRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/CSVImportProfileRow.swift
+++ b/Backends/GRDB/Records/CSVImportProfileRow.swift
@@ -27,6 +27,7 @@ struct CSVImportProfileRow {
     case dateFormatRawValue = "date_format_raw_value"
     case columnRoleRawValuesEncoded = "column_role_raw_values_encoded"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/CategoryRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/CategoryRow+ObservableRegion.swift
@@ -11,7 +11,7 @@ extension CategoryRow {
   /// shared pattern and issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<CategoryRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/CategoryRow.swift
+++ b/Backends/GRDB/Records/CategoryRow.swift
@@ -13,6 +13,7 @@ struct CategoryRow {
     case name
     case parentId = "parent_id"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/EarmarkBudgetItemRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/EarmarkBudgetItemRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension EarmarkBudgetItemRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<EarmarkBudgetItemRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/EarmarkBudgetItemRow.swift
+++ b/Backends/GRDB/Records/EarmarkBudgetItemRow.swift
@@ -16,6 +16,7 @@ struct EarmarkBudgetItemRow {
     case amount
     case instrumentId = "instrument_id"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/EarmarkRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/EarmarkRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension EarmarkRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<EarmarkRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/EarmarkRow.swift
+++ b/Backends/GRDB/Records/EarmarkRow.swift
@@ -26,6 +26,7 @@ struct EarmarkRow {
     case savingsStartDate = "savings_start_date"
     case savingsEndDate = "savings_end_date"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/ImportRuleRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/ImportRuleRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension ImportRuleRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<ImportRuleRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/ImportRuleRow.swift
+++ b/Backends/GRDB/Records/ImportRuleRow.swift
@@ -25,6 +25,7 @@ struct ImportRuleRow {
     case actionsJSON = "actions_json"
     case accountScope = "account_scope"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/InsightDismissalRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/InsightDismissalRow+ObservableRegion.swift
@@ -9,7 +9,7 @@ extension InsightDismissalRow {
   /// See issue #865.
   static var observableRegion: QueryInterfaceRequest<InsightDismissalRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/InsightDismissalRow.swift
+++ b/Backends/GRDB/Records/InsightDismissalRow.swift
@@ -14,6 +14,7 @@ struct InsightDismissalRow {
     case kind
     case count
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/InvestmentValueRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/InvestmentValueRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension InvestmentValueRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<InvestmentValueRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/InvestmentValueRow.swift
+++ b/Backends/GRDB/Records/InvestmentValueRow.swift
@@ -20,6 +20,7 @@ struct InvestmentValueRow {
     case value
     case instrumentId = "instrument_id"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/ProfileRow.swift
+++ b/Backends/GRDB/Records/ProfileRow.swift
@@ -25,6 +25,7 @@ struct ProfileRow {
     case createdAt = "created_at"
     case encodedSystemFields = "encoded_system_fields"
     case dataFormatVersion = "data_format_version"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/TransactionLegRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/TransactionLegRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension TransactionLegRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<TransactionLegRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/TransactionLegRow.swift
+++ b/Backends/GRDB/Records/TransactionLegRow.swift
@@ -24,6 +24,7 @@ struct TransactionLegRow {
     case encodedSystemFields = "encoded_system_fields"
     case externalId = "external_id"
     case counterpartyAddress = "counterparty_address"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/TransactionRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/TransactionRow+ObservableRegion.swift
@@ -10,7 +10,7 @@ extension TransactionRow {
   /// issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<TransactionRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/TransactionRow.swift
+++ b/Backends/GRDB/Records/TransactionRow.swift
@@ -43,6 +43,7 @@ struct TransactionRow {
     case importOriginIncomingSourceFilename = "import_origin_incoming_source_filename"
     case importOriginIncomingParserIdentifier = "import_origin_incoming_parser_identifier"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Records/TransferSuggestionRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/TransferSuggestionRow+ObservableRegion.swift
@@ -9,7 +9,7 @@ extension TransferSuggestionRow {
   /// shared pattern and issue #865 for the motivation.
   static var observableRegion: QueryInterfaceRequest<TransferSuggestionRow> {
     let columns: [any SQLSelectable] = Columns.allCases
-      .filter { $0 != .encodedSystemFields }
+      .filter { $0 != .encodedSystemFields && $0 != .needsPush }
       .map { $0 as any SQLSelectable }
     return select(columns)
   }

--- a/Backends/GRDB/Records/TransferSuggestionRow.swift
+++ b/Backends/GRDB/Records/TransferSuggestionRow.swift
@@ -14,6 +14,7 @@ struct TransferSuggestionRow {
     case transactionIdB = "transaction_id_b"
     case suggestedAt = "suggested_at"
     case encodedSystemFields = "encoded_system_fields"
+    case needsPush = "needs_push"
   }
 
   enum CodingKeys: String, CodingKey {

--- a/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
@@ -27,4 +27,43 @@ extension GRDBAccountGroupRepository {
       return updatedCount
     }
   }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try AccountGroupRow
+      .filter(AccountGroupRow.Columns.id == id)
+      .updateAll(database, [AccountGroupRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try AccountGroupRow
+      .filter(idSet.contains(AccountGroupRow.Columns.id))
+      .filter(AccountGroupRow.Columns.needsPush == true)
+      .select(AccountGroupRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try AccountGroupRow
+        .filter(Set(ids).contains(AccountGroupRow.Columns.id))
+        .updateAll(database, [AccountGroupRow.Columns.needsPush.set(to: false)])
+    }
+  }
 }

--- a/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
@@ -80,9 +80,19 @@ extension GRDBAccountGroupRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try AccountGroupRow
-        .filter(Set(ids).contains(AccountGroupRow.Columns.id))
-        .updateAll(database, [AccountGroupRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try AccountGroupRow
+      .filter(Set(ids).contains(AccountGroupRow.Columns.id))
+      .updateAll(database, [AccountGroupRow.Columns.needsPush.set(to: false)])
   }
 }

--- a/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
@@ -28,6 +28,25 @@ extension GRDBAccountGroupRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try AccountGroupRow
+        .filter(AccountGroupRow.Columns.id == id)
+        .updateAll(database, [AccountGroupRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBAccountGroupRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountGroupRepository.swift
@@ -167,10 +167,15 @@ final class GRDBAccountGroupRepository: AccountGroupRepository, @unchecked Senda
   /// the sync handler.
   func fetchRowSync(id: UUID) throws -> AccountGroupRow? {
     try database.read { database in
-      try AccountGroupRow
-        .filter(AccountGroupRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> AccountGroupRow? {
+    try AccountGroupRow
+      .filter(AccountGroupRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBAccountGroupRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountGroupRepository.swift
@@ -57,6 +57,7 @@ final class GRDBAccountGroupRepository: AccountGroupRepository, @unchecked Senda
     let row = AccountGroupRow(domain: group)
     try await database.write { database in
       try row.insert(database)
+      try markNeedsPushSync(id: group.id, in: database)
     }
     onRecordChanged(AccountGroupRow.recordType, group.id)
     return group
@@ -78,6 +79,7 @@ final class GRDBAccountGroupRepository: AccountGroupRepository, @unchecked Senda
       existing.instrumentId = group.instrument.id
       existing.position = group.position
       try existing.update(database)
+      try markNeedsPushSync(id: group.id, in: database)
     }
     onRecordChanged(AccountGroupRow.recordType, group.id)
     return group

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
@@ -31,8 +31,9 @@ extension GRDBAccountRepository {
     try accountRow.insert(database)
     // Mark the freshly-inserted row dirty in the same transaction so the
     // apply path (issue #1081) never clobbers it before its first upload.
-    try AccountRow.filter(AccountRow.Columns.id == account.id)
-      .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+    // Uses the canonical mark helper (consistent with every other mutation
+    // path) rather than an inline `updateAll`.
+    try markAccountNeedsPush(id: account.id, in: database)
 
     // No opening balance — only the account row was inserted.
     guard let openingBalance, !openingBalance.isZero else {
@@ -45,13 +46,23 @@ extension GRDBAccountRepository {
     try makeOpeningBalanceLegRow(
       id: legId, transactionId: txnId, account: account, openingBalance: openingBalance
     ).insert(database)
-    // Cross-table marks for the opening-balance transaction + leg (own by
-    // the transaction / leg repos) inside this same write transaction.
-    try TransactionRow.filter(TransactionRow.Columns.id == txnId)
-      .updateAll(database, [TransactionRow.Columns.needsPush.set(to: true)])
-    try TransactionLegRow.filter(TransactionLegRow.Columns.id == legId)
-      .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
+    // Cross-table marks for the opening-balance transaction + leg (owned by
+    // the transaction / leg repos) inside this same write transaction, via
+    // those repos' canonical static mark helpers.
+    try GRDBTransactionRepository.markTransactionNeedsPush(id: txnId, in: database)
+    try GRDBTransactionRepository.markLegNeedsPush(id: legId, in: database)
     return OpeningBalanceInserts(transactionId: txnId, legId: legId)
+  }
+
+  /// Static `needs_push = 1` mark for an account row, callable from the
+  /// `static` `performAccountInsert` pipeline (mirrors the instance
+  /// `markNeedsPushSync(id:in:)` and the transaction repo's static
+  /// helpers; issue #1081).
+  static func markAccountNeedsPush(id: UUID, in database: Database) throws {
+    _ =
+      try AccountRow
+      .filter(AccountRow.Columns.id == id)
+      .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
   }
 
   private static func makeOpeningBalanceTxnRow(id: UUID, date: Date) -> TransactionRow {

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
@@ -29,6 +29,10 @@ extension GRDBAccountRepository {
   ) throws -> OpeningBalanceInserts {
     let accountRow = AccountRow(domain: account)
     try accountRow.insert(database)
+    // Mark the freshly-inserted row dirty in the same transaction so the
+    // apply path (issue #1081) never clobbers it before its first upload.
+    try AccountRow.filter(AccountRow.Columns.id == account.id)
+      .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
 
     // No opening balance — only the account row was inserted.
     guard let openingBalance, !openingBalance.isZero else {
@@ -41,6 +45,12 @@ extension GRDBAccountRepository {
     try makeOpeningBalanceLegRow(
       id: legId, transactionId: txnId, account: account, openingBalance: openingBalance
     ).insert(database)
+    // Cross-table marks for the opening-balance transaction + leg (own by
+    // the transaction / leg repos) inside this same write transaction.
+    try TransactionRow.filter(TransactionRow.Columns.id == txnId)
+      .updateAll(database, [TransactionRow.Columns.needsPush.set(to: true)])
+    try TransactionLegRow.filter(TransactionLegRow.Columns.id == legId)
+      .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
     return OpeningBalanceInserts(transactionId: txnId, legId: legId)
   }
 

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
@@ -82,6 +82,47 @@ extension GRDBAccountRepository {
     }
   }
 
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// Called from every mutation so the apply path (issue #1081) can detect
+  /// an in-flight local edit transactionally.
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try AccountRow
+      .filter(AccountRow.Columns.id == id)
+      .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Returns the subset of `ids` whose row currently has `needs_push = 1`.
+  /// Read inside the apply write transaction (pass that `database`); the
+  /// overload without `database` opens its own read for non-apply callers.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try AccountRow
+      .filter(idSet.contains(AccountRow.Columns.id))
+      .filter(AccountRow.Columns.needsPush == true)
+      .select(AccountRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try AccountRow
+        .filter(Set(ids).contains(AccountRow.Columns.id))
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: false)])
+    }
+  }
+
   /// Clears `encoded_system_fields` on every row. Used after an
   /// `encryptedDataReset`.
   func clearAllSystemFieldsSync() throws {

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
@@ -136,10 +136,23 @@ extension GRDBAccountRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try AccountRow
-        .filter(Set(ids).contains(AccountRow.Columns.id))
-        .updateAll(database, [AccountRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)`. Runs
+  /// against the caller's active `database` (no nested write) so the
+  /// upload-ack path can re-read the current row, compare it to the sent
+  /// record, and clear the flag all inside one transaction — leaving no
+  /// window for a concurrent edit to interleave between compare and clear
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try AccountRow
+      .filter(Set(ids).contains(AccountRow.Columns.id))
+      .updateAll(database, [AccountRow.Columns.needsPush.set(to: false)])
   }
 
   /// Clears `encoded_system_fields` on every row. Used after an
@@ -177,10 +190,17 @@ extension GRDBAccountRepository {
   /// the sync handler.
   func fetchRowSync(id: UUID) throws -> AccountRow? {
     try database.read { database in
-      try AccountRow
-        .filter(AccountRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)`. Reads against the
+  /// caller's active `database` so the upload-ack path's compare-and-clear
+  /// shares one transaction (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> AccountRow? {
+    try AccountRow
+      .filter(AccountRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
@@ -82,6 +82,25 @@ extension GRDBAccountRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try AccountRow
+        .filter(AccountRow.Columns.id == id)
+        .updateAll(database, [AccountRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// Called from every mutation so the apply path (issue #1081) can detect
   /// an in-flight local edit transactionally.

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -198,6 +198,7 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       existing.valuationMode = account.valuationMode.rawValue
       existing.groupId = account.groupId
       try existing.update(database)
+      try markNeedsPushSync(id: account.id, in: database)
 
       let positions = try Self.computePositions(
         database: database, instruments: instruments, accountId: account.id)
@@ -261,6 +262,7 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       }
       existing.isHidden = true
       try existing.update(database)
+      try markNeedsPushSync(id: id, in: database)
     }
     onRecordChanged(AccountRow.recordType, id)
   }

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
@@ -238,10 +238,20 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try CSVImportProfileRow
-        .filter(Set(ids).contains(CSVImportProfileRow.Columns.id))
-        .updateAll(database, [CSVImportProfileRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try CSVImportProfileRow
+      .filter(Set(ids).contains(CSVImportProfileRow.Columns.id))
+      .updateAll(database, [CSVImportProfileRow.Columns.needsPush.set(to: false)])
   }
 
   /// Clears `encoded_system_fields` on every row. Used after an
@@ -279,10 +289,15 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
   /// `ProfileDataSyncHandler+RecordLookup`.
   func fetchRowSync(id: UUID) throws -> CSVImportProfileRow? {
     try database.read { database in
-      try CSVImportProfileRow
-        .filter(CSVImportProfileRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> CSVImportProfileRow? {
+    try CSVImportProfileRow
+      .filter(CSVImportProfileRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
@@ -70,6 +70,7 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
     let row = CSVImportProfileRow(domain: profile)
     try await database.write { database in
       try row.insert(database)
+      try markNeedsPushSync(id: profile.id, in: database)
     }
     onRecordChanged(CSVImportProfileRow.recordType, profile.id)
     return row.toDomain()
@@ -100,6 +101,7 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
       existing.dateFormatRawValue = fresh.dateFormatRawValue
       existing.columnRoleRawValuesEncoded = fresh.columnRoleRawValuesEncoded
       try existing.update(database)
+      try markNeedsPushSync(id: profile.id, in: database)
       return existing
     }
     onRecordChanged(CSVImportProfileRow.recordType, profile.id)
@@ -180,6 +182,45 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
             [CSVImportProfileRow.Columns.encodedSystemFields.set(to: data)])
       }
       return updatedCount
+    }
+  }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try CSVImportProfileRow
+      .filter(CSVImportProfileRow.Columns.id == id)
+      .updateAll(database, [CSVImportProfileRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try CSVImportProfileRow
+      .filter(idSet.contains(CSVImportProfileRow.Columns.id))
+      .filter(CSVImportProfileRow.Columns.needsPush == true)
+      .select(CSVImportProfileRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try CSVImportProfileRow
+        .filter(Set(ids).contains(CSVImportProfileRow.Columns.id))
+        .updateAll(database, [CSVImportProfileRow.Columns.needsPush.set(to: false)])
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
@@ -185,6 +185,26 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try CSVImportProfileRow
+        .filter(CSVImportProfileRow.Columns.id == id)
+        .updateAll(
+          database, [CSVImportProfileRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository+Sync.swift
@@ -4,6 +4,38 @@ import Foundation
 import GRDB
 
 extension GRDBCategoryRepository {
+  /// Marks every row whose *field values* were changed by a category
+  /// delete (children re-parented, legs re-categorised, budgets
+  /// re-pointed) `needs_push = 1`, inside the caller's delete transaction,
+  /// so the apply path (issue #1081) can't clobber the local edit. The
+  /// deleted category and any deleted budget items are removals — out of
+  /// `needs_push` scope, which guards saves only.
+  static func markDeleteSideEffectsNeedsPush(
+    orphanedChildIds: [UUID],
+    reassignedLegIds: [UUID],
+    updatedBudgetIds: [UUID],
+    in database: Database
+  ) throws {
+    for childId in orphanedChildIds {
+      _ =
+        try CategoryRow
+        .filter(CategoryRow.Columns.id == childId)
+        .updateAll(database, [CategoryRow.Columns.needsPush.set(to: true)])
+    }
+    for legId in reassignedLegIds {
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == legId)
+        .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
+    }
+    for budgetId in updatedBudgetIds {
+      _ =
+        try EarmarkBudgetItemRow
+        .filter(EarmarkBudgetItemRow.Columns.id == budgetId)
+        .updateAll(database, [EarmarkBudgetItemRow.Columns.needsPush.set(to: true)])
+    }
+  }
+
   /// Batch counterpart to `setEncodedSystemFieldsSync` — writes every
   /// update in a single GRDB transaction so `databaseDidCommit` fires
   /// once rather than once per row. See the doc on
@@ -25,6 +57,45 @@ extension GRDBCategoryRepository {
             [CategoryRow.Columns.encodedSystemFields.set(to: data)])
       }
       return updatedCount
+    }
+  }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try CategoryRow
+      .filter(CategoryRow.Columns.id == id)
+      .updateAll(database, [CategoryRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try CategoryRow
+      .filter(idSet.contains(CategoryRow.Columns.id))
+      .filter(CategoryRow.Columns.needsPush == true)
+      .select(CategoryRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try CategoryRow
+        .filter(Set(ids).contains(CategoryRow.Columns.id))
+        .updateAll(database, [CategoryRow.Columns.needsPush.set(to: false)])
     }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository+Sync.swift
@@ -112,9 +112,26 @@ extension GRDBCategoryRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try CategoryRow
-        .filter(Set(ids).contains(CategoryRow.Columns.id))
-        .updateAll(database, [CategoryRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try CategoryRow
+      .filter(Set(ids).contains(CategoryRow.Columns.id))
+      .updateAll(database, [CategoryRow.Columns.needsPush.set(to: false)])
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> CategoryRow? {
+    try CategoryRow
+      .filter(CategoryRow.Columns.id == id)
+      .fetchOne(database)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository+Sync.swift
@@ -60,6 +60,25 @@ extension GRDBCategoryRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try CategoryRow
+        .filter(CategoryRow.Columns.id == id)
+        .updateAll(database, [CategoryRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository.swift
@@ -67,6 +67,7 @@ final class GRDBCategoryRepository: CategoryRepository, @unchecked Sendable {
     let row = CategoryRow(domain: category)
     try await database.write { database in
       try row.insert(database)
+      try markNeedsPushSync(id: category.id, in: database)
     }
     onRecordChanged(CategoryRow.recordType, category.id)
     return row.toDomain()
@@ -85,6 +86,7 @@ final class GRDBCategoryRepository: CategoryRepository, @unchecked Sendable {
       existing.name = category.name
       existing.parentId = category.parentId
       try existing.update(database)
+      try markNeedsPushSync(id: category.id, in: database)
       return existing
     }
     onRecordChanged(CategoryRow.recordType, category.id)
@@ -109,6 +111,11 @@ final class GRDBCategoryRepository: CategoryRepository, @unchecked Sendable {
         from: id, to: replacementId, in: database)
 
       try existing.delete(database)
+      try Self.markDeleteSideEffectsNeedsPush(
+        orphanedChildIds: orphanedChildIds,
+        reassignedLegIds: reassignedLegIds,
+        updatedBudgetIds: budgetOutcome.updated,
+        in: database)
 
       return DeleteOutcome(
         orphanedChildIds: orphanedChildIds,

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository.swift
@@ -346,11 +346,11 @@ final class GRDBCategoryRepository: CategoryRepository, @unchecked Sendable {
   /// the sync handler.
   func fetchRowSync(id: UUID) throws -> CategoryRow? {
     try database.read { database in
-      try CategoryRow
-        .filter(CategoryRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
   }
+
+  // `fetchRowSync(id:in:)` lives in `GRDBCategoryRepository+Sync.swift`.
 
   /// Batch lookup by ids — used by the batch-build phase of the sync
   /// handler.

--- a/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
@@ -106,6 +106,26 @@ final class GRDBEarmarkBudgetItemRepository: @unchecked Sendable {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try EarmarkBudgetItemRow
+        .filter(EarmarkBudgetItemRow.Columns.id == id)
+        .updateAll(
+          database, [EarmarkBudgetItemRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
@@ -106,6 +106,45 @@ final class GRDBEarmarkBudgetItemRepository: @unchecked Sendable {
     }
   }
 
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try EarmarkBudgetItemRow
+      .filter(EarmarkBudgetItemRow.Columns.id == id)
+      .updateAll(database, [EarmarkBudgetItemRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try EarmarkBudgetItemRow
+      .filter(idSet.contains(EarmarkBudgetItemRow.Columns.id))
+      .filter(EarmarkBudgetItemRow.Columns.needsPush == true)
+      .select(EarmarkBudgetItemRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try EarmarkBudgetItemRow
+        .filter(Set(ids).contains(EarmarkBudgetItemRow.Columns.id))
+        .updateAll(database, [EarmarkBudgetItemRow.Columns.needsPush.set(to: false)])
+    }
+  }
+
   /// Clears `encoded_system_fields` on every row. Used after an
   /// `encryptedDataReset`.
   func clearAllSystemFieldsSync() throws {

--- a/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
@@ -159,10 +159,20 @@ final class GRDBEarmarkBudgetItemRepository: @unchecked Sendable {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try EarmarkBudgetItemRow
-        .filter(Set(ids).contains(EarmarkBudgetItemRow.Columns.id))
-        .updateAll(database, [EarmarkBudgetItemRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try EarmarkBudgetItemRow
+      .filter(Set(ids).contains(EarmarkBudgetItemRow.Columns.id))
+      .updateAll(database, [EarmarkBudgetItemRow.Columns.needsPush.set(to: false)])
   }
 
   /// Clears `encoded_system_fields` on every row. Used after an
@@ -200,10 +210,15 @@ final class GRDBEarmarkBudgetItemRepository: @unchecked Sendable {
   /// in the sync handler.
   func fetchRowSync(id: UUID) throws -> EarmarkBudgetItemRow? {
     try database.read { database in
-      try EarmarkBudgetItemRow
-        .filter(EarmarkBudgetItemRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> EarmarkBudgetItemRow? {
+    try EarmarkBudgetItemRow
+      .filter(EarmarkBudgetItemRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Sync.swift
@@ -90,9 +90,19 @@ extension GRDBEarmarkRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try EarmarkRow
-        .filter(Set(ids).contains(EarmarkRow.Columns.id))
-        .updateAll(database, [EarmarkRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try EarmarkRow
+      .filter(Set(ids).contains(EarmarkRow.Columns.id))
+      .updateAll(database, [EarmarkRow.Columns.needsPush.set(to: false)])
   }
 }

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Sync.swift
@@ -38,6 +38,25 @@ extension GRDBEarmarkRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try EarmarkRow
+        .filter(EarmarkRow.Columns.id == id)
+        .updateAll(database, [EarmarkRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Sync.swift
@@ -4,6 +4,16 @@ import Foundation
 import GRDB
 
 extension GRDBEarmarkRepository {
+  /// Static `needs_push = 1` mark for a budget-item row (cross-table
+  /// relative to this repo's own `earmark` table), callable from the
+  /// `static` `setBudget` pipeline helper (issue #1081).
+  static func markBudgetItemNeedsPush(id: UUID, in database: Database) throws {
+    _ =
+      try EarmarkBudgetItemRow
+      .filter(EarmarkBudgetItemRow.Columns.id == id)
+      .updateAll(database, [EarmarkBudgetItemRow.Columns.needsPush.set(to: true)])
+  }
+
   /// Batch counterpart to `setEncodedSystemFieldsSync` — writes every
   /// update in a single GRDB transaction so `databaseDidCommit` fires
   /// once rather than once per row. See the doc on
@@ -25,6 +35,45 @@ extension GRDBEarmarkRepository {
             [EarmarkRow.Columns.encodedSystemFields.set(to: data)])
       }
       return updatedCount
+    }
+  }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try EarmarkRow
+      .filter(EarmarkRow.Columns.id == id)
+      .updateAll(database, [EarmarkRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try EarmarkRow
+      .filter(idSet.contains(EarmarkRow.Columns.id))
+      .filter(EarmarkRow.Columns.needsPush == true)
+      .select(EarmarkRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try EarmarkRow
+        .filter(Set(ids).contains(EarmarkRow.Columns.id))
+        .updateAll(database, [EarmarkRow.Columns.needsPush.set(to: false)])
     }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
@@ -122,6 +122,7 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
     let row = EarmarkRow(domain: earmark)
     try await database.write { database in
       try row.insert(database)
+      try markNeedsPushSync(id: earmark.id, in: database)
     }
     onRecordChanged(EarmarkRow.recordType, earmark.id)
     return earmark
@@ -146,6 +147,7 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       existing.savingsStartDate = earmark.savingsStartDate
       existing.savingsEndDate = earmark.savingsEndDate
       try existing.update(database)
+      try markNeedsPushSync(id: earmark.id, in: database)
     }
     onRecordChanged(EarmarkRow.recordType, earmark.id)
     return earmark
@@ -251,6 +253,7 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       existing.amount = amount.storageValue
       existing.instrumentId = amount.instrument.id
       try existing.update(database)
+      try markBudgetItemNeedsPush(id: existing.id, in: database)
       return SetBudgetOutcome(changedId: existing.id, deletedId: nil)
     }
 
@@ -260,6 +263,7 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       amount: amount)
     let row = EarmarkBudgetItemRow(domain: newItem, earmarkId: earmarkId)
     try row.insert(database)
+    try markBudgetItemNeedsPush(id: row.id, in: database)
     return SetBudgetOutcome(changedId: row.id, deletedId: nil)
   }
 

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
@@ -362,10 +362,15 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
   /// the sync handler.
   func fetchRowSync(id: UUID) throws -> EarmarkRow? {
     try database.read { database in
-      try EarmarkRow
-        .filter(EarmarkRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> EarmarkRow? {
+    try EarmarkRow
+      .filter(EarmarkRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
@@ -61,6 +61,7 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
     let row = ImportRuleRow(domain: rule)
     try await database.write { database in
       try row.insert(database)
+      try markNeedsPushSync(id: rule.id, in: database)
     }
     onRecordChanged(ImportRuleRow.recordType, rule.id)
     return try row.toDomain()
@@ -85,6 +86,7 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
       existing.actionsJSON = fresh.actionsJSON
       existing.accountScope = fresh.accountScope
       try existing.update(database)
+      try markNeedsPushSync(id: rule.id, in: database)
       return existing
     }
     onRecordChanged(ImportRuleRow.recordType, rule.id)
@@ -122,6 +124,7 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
         if row.position != newPosition {
           row.position = newPosition
           try row.update(database)
+          try markNeedsPushSync(id: row.id, in: database)
           changed.append(row.id)
         }
       }
@@ -190,6 +193,45 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
             [ImportRuleRow.Columns.encodedSystemFields.set(to: data)])
       }
       return updatedCount
+    }
+  }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try ImportRuleRow
+      .filter(ImportRuleRow.Columns.id == id)
+      .updateAll(database, [ImportRuleRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try ImportRuleRow
+      .filter(idSet.contains(ImportRuleRow.Columns.id))
+      .filter(ImportRuleRow.Columns.needsPush == true)
+      .select(ImportRuleRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try ImportRuleRow
+        .filter(Set(ids).contains(ImportRuleRow.Columns.id))
+        .updateAll(database, [ImportRuleRow.Columns.needsPush.set(to: false)])
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
@@ -248,10 +248,20 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try ImportRuleRow
-        .filter(Set(ids).contains(ImportRuleRow.Columns.id))
-        .updateAll(database, [ImportRuleRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try ImportRuleRow
+      .filter(Set(ids).contains(ImportRuleRow.Columns.id))
+      .updateAll(database, [ImportRuleRow.Columns.needsPush.set(to: false)])
   }
 
   func clearAllSystemFieldsSync() throws {
@@ -283,10 +293,15 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
 
   func fetchRowSync(id: UUID) throws -> ImportRuleRow? {
     try database.read { database in
-      try ImportRuleRow
-        .filter(ImportRuleRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> ImportRuleRow? {
+    try ImportRuleRow
+      .filter(ImportRuleRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   func fetchRowsSync(ids: [UUID]) throws -> [ImportRuleRow] {

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
@@ -196,6 +196,25 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try ImportRuleRow
+        .filter(ImportRuleRow.Columns.id == id)
+        .updateAll(database, [ImportRuleRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBInsightDismissalRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDismissalRepository+Sync.swift
@@ -76,9 +76,19 @@ extension GRDBInsightDismissalRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try InsightDismissalRow
-        .filter(Set(ids).contains(InsightDismissalRow.Columns.id))
-        .updateAll(database, [InsightDismissalRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try InsightDismissalRow
+      .filter(Set(ids).contains(InsightDismissalRow.Columns.id))
+      .updateAll(database, [InsightDismissalRow.Columns.needsPush.set(to: false)])
   }
 }

--- a/Backends/GRDB/Repositories/GRDBInsightDismissalRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDismissalRepository+Sync.swift
@@ -23,6 +23,26 @@ extension GRDBInsightDismissalRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try InsightDismissalRow
+        .filter(InsightDismissalRow.Columns.id == id)
+        .updateAll(
+          database, [InsightDismissalRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBInsightDismissalRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDismissalRepository+Sync.swift
@@ -22,4 +22,43 @@ extension GRDBInsightDismissalRepository {
       return updatedCount
     }
   }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try InsightDismissalRow
+      .filter(InsightDismissalRow.Columns.id == id)
+      .updateAll(database, [InsightDismissalRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try InsightDismissalRow
+      .filter(idSet.contains(InsightDismissalRow.Columns.id))
+      .filter(InsightDismissalRow.Columns.needsPush == true)
+      .select(InsightDismissalRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try InsightDismissalRow
+        .filter(Set(ids).contains(InsightDismissalRow.Columns.id))
+        .updateAll(database, [InsightDismissalRow.Columns.needsPush.set(to: false)])
+    }
+  }
 }

--- a/Backends/GRDB/Repositories/GRDBInsightDismissalRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDismissalRepository.swift
@@ -49,6 +49,7 @@ final class GRDBInsightDismissalRepository: InsightDismissalRepository, @uncheck
         .fetchOne(database) ?? InsightDismissalRow(kind: kind, count: 0)
       row.count += 1
       try row.upsert(database)
+      try markNeedsPushSync(id: row.id, in: database)
       return row
     }
     onRecordChanged(InsightDismissalRow.recordType, row.id)

--- a/Backends/GRDB/Repositories/GRDBInsightDismissalRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDismissalRepository.swift
@@ -117,10 +117,15 @@ final class GRDBInsightDismissalRepository: InsightDismissalRepository, @uncheck
 
   func fetchRowSync(id: UUID) throws -> InsightDismissalRow? {
     try database.read { database in
-      try InsightDismissalRow
-        .filter(InsightDismissalRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> InsightDismissalRow? {
+    try InsightDismissalRow
+      .filter(InsightDismissalRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   func fetchRowsSync(ids: [UUID]) throws -> [InsightDismissalRow] {

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository+Sync.swift
@@ -1,0 +1,27 @@
+import Foundation
+import GRDB
+
+// In-transaction sync helpers for the upload-ack compare-and-clear path
+// (issue #1081). Split out of `GRDBInvestmentRepository.swift` to keep
+// that type's body under the 250-line limit.
+
+extension GRDBInvestmentRepository {
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try InvestmentValueRow
+      .filter(Set(ids).contains(InvestmentValueRow.Columns.id))
+      .updateAll(database, [InvestmentValueRow.Columns.needsPush.set(to: false)])
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> InvestmentValueRow? {
+    try InvestmentValueRow
+      .filter(InvestmentValueRow.Columns.id == id)
+      .fetchOne(database)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -312,11 +312,12 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try InvestmentValueRow
-        .filter(Set(ids).contains(InvestmentValueRow.Columns.id))
-        .updateAll(database, [InvestmentValueRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
   }
+
+  // `clearNeedsPushBatchSync(_:in:)` and `fetchRowSync(id:in:)` live in
+  // `GRDBInvestmentRepository+Sync.swift`.
 
   /// Clears `encoded_system_fields` on every row. Used after an
   /// `encryptedDataReset`.
@@ -353,9 +354,7 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
   /// the sync handler.
   func fetchRowSync(id: UUID) throws -> InvestmentValueRow? {
     try database.read { database in
-      try InvestmentValueRow
-        .filter(InvestmentValueRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -259,6 +259,26 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try InvestmentValueRow
+        .filter(InvestmentValueRow.Columns.id == id)
+        .updateAll(
+          database, [InvestmentValueRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -113,6 +113,7 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
         existing.value = value.storageValue
         existing.instrumentId = value.instrument.id
         try existing.update(database)
+        try markNeedsPushSync(id: existing.id, in: database)
         return existing.id
       }
 
@@ -126,6 +127,7 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
         instrumentId: value.instrument.id,
         encodedSystemFields: nil)
       try row.insert(database)
+      try markNeedsPushSync(id: id, in: database)
       return id
     }
     onRecordChanged(InvestmentValueRow.recordType, changedId)
@@ -254,6 +256,45 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
             [InvestmentValueRow.Columns.encodedSystemFields.set(to: data)])
       }
       return updatedCount
+    }
+  }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try InvestmentValueRow
+      .filter(InvestmentValueRow.Columns.id == id)
+      .updateAll(database, [InvestmentValueRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try InvestmentValueRow
+      .filter(idSet.contains(InvestmentValueRow.Columns.id))
+      .filter(InvestmentValueRow.Columns.needsPush == true)
+      .select(InvestmentValueRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try InvestmentValueRow
+        .filter(Set(ids).contains(InvestmentValueRow.Columns.id))
+        .updateAll(database, [InvestmentValueRow.Columns.needsPush.set(to: false)])
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
@@ -20,6 +20,38 @@ extension GRDBProfileIndexRepository {
       .updateAll(database, [ProfileRow.Columns.needsPush.set(to: true)])
   }
 
+  /// Self-opening convenience for callers outside an apply transaction
+  /// (tests, and the upload-ack path's clear). Opens its own write.
+  func markNeedsPushSync(id: UUID) throws {
+    try database.write { database in try markNeedsPushSync(id: id, in: database) }
+  }
+
+  /// In-transaction profile upsert/delete (mirrors the self-write
+  /// `applyRemoteChangesSync(saved:deleted:)` on the main repository).
+  /// Runs against the caller's `database` so the dirty check and the
+  /// upsert share one transaction (issue #1081 — no echo race).
+  func applyRemoteChangesSync(
+    saved rows: [ProfileRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows { try row.upsert(database) }
+    for id in ids { _ = try ProfileRow.deleteOne(database, id: id) }
+  }
+
+  /// In-transaction system-fields-only write (change tag), for dirty
+  /// profile echoes that must NOT have their field values overwritten.
+  /// Runs against the caller's `database` so it shares the apply
+  /// transaction (issue #1081).
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws {
+    for (id, data) in updates {
+      _ =
+        try ProfileRow
+        .filter(ProfileRow.Columns.id == id)
+        .updateAll(database, [ProfileRow.Columns.encodedSystemFields.set(to: data)])
+    }
+  }
+
   /// Subset of `ids` whose profile row currently has `needs_push = 1`,
   /// read inside the caller's transaction.
   func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
@@ -75,9 +75,30 @@ extension GRDBProfileIndexRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try ProfileRow
-        .filter(Set(ids).contains(ProfileRow.Columns.id))
-        .updateAll(database, [ProfileRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)`. Runs
+  /// against the caller's active `database` so the upload-ack path can
+  /// re-read the profile row, compare it to the sent record, and clear the
+  /// flag all inside one transaction — no window for a concurrent rename
+  /// to interleave between compare and clear (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try ProfileRow
+      .filter(Set(ids).contains(ProfileRow.Columns.id))
+      .updateAll(database, [ProfileRow.Columns.needsPush.set(to: false)])
+  }
+
+  /// In-transaction row lookup, mirroring the main repository's
+  /// `fetchRowSync(id:)` self-read. Reads against the caller's `database`
+  /// so the ack-clear compare-and-clear shares one transaction (#1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> ProfileRow? {
+    try ProfileRow
+      .filter(ProfileRow.Columns.id == id)
+      .fetchOne(database)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
@@ -1,0 +1,51 @@
+// Backends/GRDB/Repositories/GRDBProfileIndexRepository+Sync.swift
+
+import Foundation
+import GRDB
+
+// MARK: - needs_push dirty-flag helpers (issue #1081)
+//
+// Mirror the per-profile repositories' `+Sync.swift` helpers. The
+// `profile` table carries the same local-only `needs_push` column (v4
+// migration). Kept in a separate file from the main repository so the
+// main file stays under the 400-line limit.
+
+extension GRDBProfileIndexRepository {
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try ProfileRow
+      .filter(ProfileRow.Columns.id == id)
+      .updateAll(database, [ProfileRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose profile row currently has `needs_push = 1`,
+  /// read inside the caller's transaction.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    return Set(
+      try ProfileRow
+        .filter(idSet.contains(ProfileRow.Columns.id))
+        .filter(ProfileRow.Columns.needsPush == true)
+        .select(ProfileRow.Columns.id, as: UUID.self)
+        .fetchAll(database))
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try ProfileRow
+        .filter(Set(ids).contains(ProfileRow.Columns.id))
+        .updateAll(database, [ProfileRow.Columns.needsPush.set(to: false)])
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
@@ -54,7 +54,7 @@ final class GRDBProfileIndexRepository {
     var onRecordDeleted: @Sendable (UUID) -> Void
   }
 
-  private let database: any DatabaseWriter
+  let database: any DatabaseWriter
   private let hooks: OSAllocatedUnfairLock<HookState>
 
   init(
@@ -126,6 +126,7 @@ final class GRDBProfileIndexRepository {
         row.encodedSystemFields = existing.encodedSystemFields
       }
       try row.upsert(database)
+      try markNeedsPushSync(id: profile.id, in: database)
     }
     // Capture the closure under the lock, release, then invoke.
     // `OSAllocatedUnfairLock` is non-reentrant, so calling an arbitrary

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
@@ -54,6 +54,11 @@ final class GRDBProfileIndexRepository {
     var onRecordDeleted: @Sendable (UUID) -> Void
   }
 
+  /// Internal (not `private`) so `ProfileIndexSyncHandler+NeedsPush` can
+  /// open one `database.write` spanning the dirty check, the clean-row
+  /// upsert, and the dirty-row system-fields write in `applyProfilesGuarded`
+  /// — and the compare-and-clear in `clearNeedsPushForConfirmed` — keeping
+  /// each fully transactional with no echo race (issue #1081).
   let database: any DatabaseWriter
   private let hooks: OSAllocatedUnfairLock<HookState>
 

--- a/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
@@ -104,6 +104,26 @@ final class GRDBTransactionLegRepository: @unchecked Sendable {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == id)
+        .updateAll(
+          database, [TransactionLegRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
@@ -104,6 +104,45 @@ final class GRDBTransactionLegRepository: @unchecked Sendable {
     }
   }
 
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try TransactionLegRow
+      .filter(TransactionLegRow.Columns.id == id)
+      .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try TransactionLegRow
+      .filter(idSet.contains(TransactionLegRow.Columns.id))
+      .filter(TransactionLegRow.Columns.needsPush == true)
+      .select(TransactionLegRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try TransactionLegRow
+        .filter(Set(ids).contains(TransactionLegRow.Columns.id))
+        .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: false)])
+    }
+  }
+
   /// Clears `encoded_system_fields` on every row. Used after an
   /// `encryptedDataReset`.
   func clearAllSystemFieldsSync() throws {

--- a/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
@@ -157,10 +157,20 @@ final class GRDBTransactionLegRepository: @unchecked Sendable {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try TransactionLegRow
-        .filter(Set(ids).contains(TransactionLegRow.Columns.id))
-        .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try TransactionLegRow
+      .filter(Set(ids).contains(TransactionLegRow.Columns.id))
+      .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: false)])
   }
 
   /// Clears `encoded_system_fields` on every row. Used after an
@@ -198,10 +208,15 @@ final class GRDBTransactionLegRepository: @unchecked Sendable {
   /// in the sync handler.
   func fetchRowSync(id: UUID) throws -> TransactionLegRow? {
     try database.read { database in
-      try TransactionLegRow
-        .filter(TransactionLegRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> TransactionLegRow? {
+    try TransactionLegRow
+      .filter(TransactionLegRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
@@ -45,6 +45,7 @@ extension GRDBTransactionRepository {
     for transaction in transactions {
       let txnRow = TransactionRow(domain: transaction)
       try txnRow.insert(database)
+      try markTransactionNeedsPush(id: transaction.id, in: database)
 
       for (index, leg) in transaction.legs.enumerated() {
         let legRow = TransactionLegRow(
@@ -53,6 +54,7 @@ extension GRDBTransactionRepository {
           transactionId: transaction.id,
           sortOrder: index)
         try legRow.insert(database)
+        try markLegNeedsPush(id: leg.id, in: database)
         legIds.append(leg.id)
       }
     }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
@@ -147,10 +147,20 @@ extension GRDBTransactionRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try TransactionRow
-        .filter(Set(ids).contains(TransactionRow.Columns.id))
-        .updateAll(database, [TransactionRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try TransactionRow
+      .filter(Set(ids).contains(TransactionRow.Columns.id))
+      .updateAll(database, [TransactionRow.Columns.needsPush.set(to: false)])
   }
 
   /// Clears `encoded_system_fields` on every row. Used after an
@@ -188,10 +198,15 @@ extension GRDBTransactionRepository {
   /// in the sync handler.
   func fetchRowSync(id: UUID) throws -> TransactionRow? {
     try database.read { database in
-      try TransactionRow
-        .filter(TransactionRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> TransactionRow? {
+    try TransactionRow
+      .filter(TransactionRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
@@ -95,6 +95,25 @@ extension GRDBTransactionRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try TransactionRow
+        .filter(TransactionRow.Columns.id == id)
+        .updateAll(database, [TransactionRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
@@ -12,6 +12,24 @@ import GRDB
 // `@MainActor`.
 
 extension GRDBTransactionRepository {
+  /// Static `needs_push = 1` mark for a transaction row, callable from the
+  /// `static` create/update pipeline helpers (issue #1081).
+  static func markTransactionNeedsPush(id: UUID, in database: Database) throws {
+    _ =
+      try TransactionRow
+      .filter(TransactionRow.Columns.id == id)
+      .updateAll(database, [TransactionRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Static `needs_push = 1` mark for a transaction-leg row (cross-table
+  /// relative to this repo), callable from the `static` pipeline helpers.
+  static func markLegNeedsPush(id: UUID, in database: Database) throws {
+    _ =
+      try TransactionLegRow
+      .filter(TransactionLegRow.Columns.id == id)
+      .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
+  }
+
   func applyRemoteChangesSync(saved rows: [TransactionRow], deleted ids: [UUID]) throws {
     try database.write { database in
       try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
@@ -74,6 +92,45 @@ extension GRDBTransactionRepository {
             [TransactionRow.Columns.encodedSystemFields.set(to: data)])
       }
       return updatedCount
+    }
+  }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try TransactionRow
+      .filter(TransactionRow.Columns.id == id)
+      .updateAll(database, [TransactionRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try TransactionRow
+      .filter(idSet.contains(TransactionRow.Columns.id))
+      .filter(TransactionRow.Columns.needsPush == true)
+      .select(TransactionRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try TransactionRow
+        .filter(Set(ids).contains(TransactionRow.Columns.id))
+        .updateAll(database, [TransactionRow.Columns.needsPush.set(to: false)])
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
@@ -73,6 +73,7 @@ extension GRDBTransactionRepository {
     }
     applyMetadata(of: transaction, to: &existing)
     try existing.update(database)
+    try markTransactionNeedsPush(id: transaction.id, in: database)
 
     let newLegIds: Set<UUID> = Set(transaction.legs.map(\.id))
     let diff = try Self.computeLegDiff(
@@ -104,6 +105,7 @@ extension GRDBTransactionRepository {
         legRow.encodedSystemFields = existingFields
       }
       try legRow.upsert(database)
+      try markLegNeedsPush(id: leg.id, in: database)
       upsertedLegIds.append(leg.id)
     }
 

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -187,6 +187,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     let legIds = try await database.write { database -> [UUID] in
       let txnRow = TransactionRow(domain: transaction)
       try txnRow.insert(database)
+      try markNeedsPushSync(id: transaction.id, in: database)
 
       var legIds: [UUID] = []
       legIds.reserveCapacity(transaction.legs.count)
@@ -197,6 +198,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
           transactionId: transaction.id,
           sortOrder: index)
         try legRow.insert(database)
+        try Self.markLegNeedsPush(id: leg.id, in: database)
         legIds.append(leg.id)
       }
       return legIds

--- a/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository+Sync.swift
@@ -25,4 +25,43 @@ extension GRDBTransferSuggestionRepository {
       return updatedCount
     }
   }
+
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try TransferSuggestionRow
+      .filter(TransferSuggestionRow.Columns.id == id)
+      .updateAll(database, [TransferSuggestionRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Subset of `ids` whose row currently has `needs_push = 1`. See
+  /// `GRDBAccountRepository.dirtyIdsSync(from:in:)`.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try TransferSuggestionRow
+      .filter(idSet.contains(TransferSuggestionRow.Columns.id))
+      .filter(TransferSuggestionRow.Columns.needsPush == true)
+      .select(TransferSuggestionRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { database in try dirtyIdsSync(from: ids, in: database) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try TransferSuggestionRow
+        .filter(Set(ids).contains(TransferSuggestionRow.Columns.id))
+        .updateAll(database, [TransferSuggestionRow.Columns.needsPush.set(to: false)])
+    }
+  }
 }

--- a/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository+Sync.swift
@@ -79,9 +79,19 @@ extension GRDBTransferSuggestionRepository {
   func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
     guard !ids.isEmpty else { return 0 }
     return try database.write { database in
-      try TransferSuggestionRow
-        .filter(Set(ids).contains(TransferSuggestionRow.Columns.id))
-        .updateAll(database, [TransferSuggestionRow.Columns.needsPush.set(to: false)])
+      try clearNeedsPushBatchSync(ids, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `clearNeedsPushBatchSync(_:)` — see
+  /// `GRDBAccountRepository` for the atomic compare-and-clear rationale
+  /// (issue #1081).
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID], in database: Database) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return
+      try TransferSuggestionRow
+      .filter(Set(ids).contains(TransferSuggestionRow.Columns.id))
+      .updateAll(database, [TransferSuggestionRow.Columns.needsPush.set(to: false)])
   }
 }

--- a/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository+Sync.swift
@@ -26,6 +26,26 @@ extension GRDBTransferSuggestionRepository {
     }
   }
 
+  /// In-transaction counterpart to `setEncodedSystemFieldsBatchSync(_:)`.
+  /// Writes against the caller's active `database` (no nested write) so a
+  /// dirty echo's system-fields-only update shares the apply transaction
+  /// that read `needs_push` (issue #1081).
+  @discardableResult
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    var updatedCount = 0
+    for (id, data) in updates {
+      updatedCount +=
+        try TransferSuggestionRow
+        .filter(TransferSuggestionRow.Columns.id == id)
+        .updateAll(
+          database, [TransferSuggestionRow.Columns.encodedSystemFields.set(to: data)])
+    }
+    return updatedCount
+  }
+
   /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
   /// See `GRDBAccountRepository.markNeedsPushSync(id:in:)` (issue #1081).
   func markNeedsPushSync(id: UUID, in database: Database) throws {

--- a/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository.swift
@@ -166,10 +166,15 @@ final class GRDBTransferSuggestionRepository: TransferSuggestionRepository,
   /// the sync handler.
   func fetchRowSync(id: UUID) throws -> TransferSuggestionRow? {
     try database.read { database in
-      try TransferSuggestionRow
-        .filter(TransferSuggestionRow.Columns.id == id)
-        .fetchOne(database)
+      try fetchRowSync(id: id, in: database)
     }
+  }
+
+  /// In-transaction counterpart to `fetchRowSync(id:)` (issue #1081).
+  func fetchRowSync(id: UUID, in database: Database) throws -> TransferSuggestionRow? {
+    try TransferSuggestionRow
+      .filter(TransferSuggestionRow.Columns.id == id)
+      .fetchOne(database)
   }
 
   /// Batch lookup by ids — used by the batch-build phase of the sync

--- a/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransferSuggestionRepository.swift
@@ -65,6 +65,7 @@ final class GRDBTransferSuggestionRepository: TransferSuggestionRepository,
       // any argument order) upserts the same row rather than failing on
       // a duplicate-key constraint.
       try row.upsert(database)
+      try markNeedsPushSync(id: suggestion.id, in: database)
     }
     onRecordChanged(TransferSuggestionRow.recordType, suggestion.id)
     return row.toDomain()

--- a/MoolahTests/Backends/GRDB/NeedsPushMarkRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/NeedsPushMarkRollbackTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Rollback contract for the `needs_push` mark (issue #1081). Every
+/// mutation sets `needs_push = 1` inside the same `database.write` as the
+/// row change; a failure on the mark itself must roll the whole write
+/// back, leaving no torn "fields updated but flag not set" (or vice-versa)
+/// half-write.
+@Suite("needs_push mark is transactional")
+@MainActor
+struct NeedsPushMarkRollbackTests {
+  /// Installs a `BEFORE UPDATE OF needs_push` trigger on `account` that
+  /// aborts, then drives `update(_:)` (which renames the row and then
+  /// marks it dirty in the same transaction). The rename must be undone
+  /// and the flag must stay clear.
+  @Test
+  func accountMutationNeedsPushMarkRollsBackTransactionally() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let repo = GRDBAccountRepository(
+      database: database,
+      instrumentResolver: registry,
+      instrumentRegistrar: registry)
+
+    let id = UUID()
+    let original = Account(id: id, name: "Original", type: .bank, instrument: .AUD)
+    _ = try await repo.create(original, openingBalance: nil)
+    // Clear the create's mark so the trigger below fires only on update's mark.
+    _ = try repo.clearNeedsPushBatchSync([id])
+
+    // Abort specifically when the `needs_push` column is updated — i.e. on
+    // the mark step, after `update` has already issued the field UPDATE in
+    // the same transaction.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_account_needs_push_mark
+          BEFORE UPDATE OF needs_push ON account
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    let mutated = Account(
+      id: id, name: "Renamed", type: .bank, instrument: .AUD,
+      position: 99, isHidden: true)
+    do {
+      _ = try await repo.update(mutated)
+      Issue.record("update should have thrown but did not")
+    } catch {
+      // Expected — the needs_push mark trips the trigger.
+    }
+
+    // The whole write rolled back: field values are byte-equal to the
+    // pre-update snapshot, and the flag is still clear.
+    let surviving = try await database.read { database in
+      try AccountRow.filter(AccountRow.Columns.id == id).fetchOne(database)
+    }
+    let row = try #require(surviving)
+    #expect(row.name == "Original")
+    #expect(row.position != 99)
+    #expect(row.isHidden == false)
+    #expect(try repo.dirtyIdsSync(from: [id]).isEmpty)
+  }
+}

--- a/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+++ b/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
@@ -38,4 +38,44 @@ struct NeedsPushMutationTests {
       #expect((col["dflt_value"] as String?) == "0")
     }
   }
+
+  @Test("markNeedsPushSync sets the flag; dirtyIdsSync reports it; clear resets it")
+  func markReadClearRoundTrip() throws {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let repo = GRDBAccountRepository(
+      database: database, instrumentResolver: registry, instrumentRegistrar: registry)
+    let id = UUID()
+    try database.write { database in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "A").insert(database)
+    }
+
+    #expect(try repo.dirtyIdsSync(from: [id]).isEmpty)
+
+    try database.write { database in try repo.markNeedsPushSync(id: id, in: database) }
+    #expect(try repo.dirtyIdsSync(from: [id]) == [id])
+
+    _ = try repo.clearNeedsPushBatchSync([id])
+    #expect(try repo.dirtyIdsSync(from: [id]).isEmpty)
+  }
+
+  @Test("account create/update set needs_push")
+  func accountMutationsMarkDirty() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let repo = GRDBAccountRepository(
+      database: database, instrumentResolver: registry, instrumentRegistrar: registry)
+    let account = Account(
+      id: UUID(), name: "Checking", type: .bank,
+      instrument: .defaultTestInstrument, position: 0)
+
+    _ = try await repo.create(account)
+    #expect(try repo.dirtyIdsSync(from: [account.id]) == [account.id])
+
+    _ = try repo.clearNeedsPushBatchSync([account.id])
+    var renamed = account
+    renamed.name = "Renamed"
+    _ = try await repo.update(renamed)
+    #expect(try repo.dirtyIdsSync(from: [account.id]) == [account.id])
+  }
 }

--- a/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+++ b/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("needs_push column migration")
+struct NeedsPushMutationTests {
+  private static let tables = [
+    "account", "account_group", "category", "earmark", "earmark_budget_item",
+    "investment_value", "\"transaction\"", "transaction_leg", "transfer_suggestion",
+    "insight_dismissal", "csv_import_profile", "import_rule",
+  ]
+
+  @Test("every syncable table has needs_push INTEGER NOT NULL DEFAULT 0")
+  func needsPushColumnPresent() throws {
+    let database = try ProfileDatabase.openInMemory()
+    try database.read { db in
+      for table in Self.tables {
+        let unquoted = table.replacingOccurrences(of: "\"", with: "")
+        let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+        let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
+        let col = try #require(needsPush, "needs_push missing on \(unquoted)")
+        #expect((col["notnull"] as Int?) == 1)
+        #expect((col["dflt_value"] as String?) == "0")
+      }
+    }
+  }
+}

--- a/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+++ b/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
@@ -15,10 +15,10 @@ struct NeedsPushMutationTests {
   @Test("every syncable table has needs_push INTEGER NOT NULL DEFAULT 0")
   func needsPushColumnPresent() throws {
     let database = try ProfileDatabase.openInMemory()
-    try database.read { db in
+    try database.read { database in
       for table in Self.tables {
         let unquoted = table.replacingOccurrences(of: "\"", with: "")
-        let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+        let columns = try Row.fetchAll(database, sql: "PRAGMA table_info(\(table))")
         let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
         let col = try #require(needsPush, "needs_push missing on \(unquoted)")
         #expect((col["notnull"] as Int?) == 1)
@@ -30,8 +30,8 @@ struct NeedsPushMutationTests {
   @Test("profile table has needs_push INTEGER NOT NULL DEFAULT 0")
   func profileNeedsPushColumnPresent() throws {
     let database = try ProfileIndexDatabase.openInMemory()
-    try database.read { db in
-      let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(profile)")
+    try database.read { database in
+      let columns = try Row.fetchAll(database, sql: "PRAGMA table_info(profile)")
       let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
       let col = try #require(needsPush, "needs_push missing on profile")
       #expect((col["notnull"] as Int?) == 1)

--- a/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+++ b/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
@@ -6,23 +6,87 @@ import Testing
 
 @Suite("needs_push column migration")
 struct NeedsPushMutationTests {
-  private static let tables = [
-    "account", "account_group", "category", "earmark", "earmark_budget_item",
-    "investment_value", "\"transaction\"", "transaction_leg", "transfer_suggestion",
-    "insight_dismissal", "csv_import_profile", "import_rule",
-  ]
+  /// Asserts the `needs_push` column on the table described by `pragmaRows`
+  /// is `INTEGER NOT NULL DEFAULT 0`. The caller fetches `pragmaRows` via
+  /// an explicit per-table literal `PRAGMA table_info(...)` (no string
+  /// interpolation); `unquoted` names the table in failure messages.
+  private func expectNeedsPushColumn(
+    pragmaRows: [Row], unquoted: String
+  ) throws {
+    let needsPush = pragmaRows.first { ($0["name"] as String?) == "needs_push" }
+    let col = try #require(needsPush, "needs_push missing on \(unquoted)")
+    #expect((col["notnull"] as Int?) == 1)
+    #expect((col["dflt_value"] as String?) == "0")
+  }
 
   @Test("every syncable table has needs_push INTEGER NOT NULL DEFAULT 0")
   func needsPushColumnPresent() throws {
     let database = try ProfileDatabase.openInMemory()
+    // Explicit per-table literal PRAGMA calls (no `\(table)` interpolation)
+    // so a failure points at the exact table and the SQL is a literal.
+    try assertReferenceTablesHaveNeedsPush(database)
+    try assertDomainTablesHaveNeedsPush(database)
+  }
+
+  private func assertReferenceTablesHaveNeedsPush(_ database: DatabaseQueue) throws {
     try database.read { database in
-      for table in Self.tables {
-        let unquoted = table.replacingOccurrences(of: "\"", with: "")
-        let columns = try Row.fetchAll(database, sql: "PRAGMA table_info(\(table))")
-        let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
-        let col = try #require(needsPush, "needs_push missing on \(unquoted)")
-        #expect((col["notnull"] as Int?) == 1)
-        #expect((col["dflt_value"] as String?) == "0")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(account_group)"),
+        unquoted: "account_group")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(category)"),
+        unquoted: "category")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(transfer_suggestion)"),
+        unquoted: "transfer_suggestion")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(insight_dismissal)"),
+        unquoted: "insight_dismissal")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(csv_import_profile)"),
+        unquoted: "csv_import_profile")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(import_rule)"),
+        unquoted: "import_rule")
+    }
+  }
+
+  private func assertDomainTablesHaveNeedsPush(_ database: DatabaseQueue) throws {
+    try database.read { database in
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(account)"),
+        unquoted: "account")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(earmark)"),
+        unquoted: "earmark")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(earmark_budget_item)"),
+        unquoted: "earmark_budget_item")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(investment_value)"),
+        unquoted: "investment_value")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(\"transaction\")"),
+        unquoted: "transaction")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(transaction_leg)"),
+        unquoted: "transaction_leg")
+    }
+  }
+
+  @Test("needs_push CHECK rejects values outside 0/1 on a syncable table")
+  func needsPushCheckConstraintEnforced() throws {
+    let database = try ProfileDatabase.openInMemory()
+    let id = UUID()
+    try database.write { database in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "A").insert(database)
+    }
+    // `needs_push` is local-only (absent from AccountRow's CodingKeys), so
+    // drive the CHECK with a literal UPDATE rather than the query builder.
+    #expect(throws: DatabaseError.self) {
+      try database.write { database in
+        try database.execute(
+          sql: "UPDATE account SET needs_push = 2 WHERE id = ?", arguments: [id])
       }
     }
   }
@@ -31,11 +95,25 @@ struct NeedsPushMutationTests {
   func profileNeedsPushColumnPresent() throws {
     let database = try ProfileIndexDatabase.openInMemory()
     try database.read { database in
-      let columns = try Row.fetchAll(database, sql: "PRAGMA table_info(profile)")
-      let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
-      let col = try #require(needsPush, "needs_push missing on profile")
-      #expect((col["notnull"] as Int?) == 1)
-      #expect((col["dflt_value"] as String?) == "0")
+      try expectNeedsPushColumn(
+        pragmaRows: Row.fetchAll(database, sql: "PRAGMA table_info(profile)"),
+        unquoted: "profile")
+    }
+  }
+
+  @Test("needs_push CHECK rejects values outside 0/1 on the profile table")
+  func profileNeedsPushCheckConstraintEnforced() throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let profile = Profile(
+      id: UUID(), label: "P", currencyCode: "AUD", financialYearStartMonth: 7)
+    try database.write { database in
+      try ProfileRow(domain: profile).insert(database)
+    }
+    #expect(throws: DatabaseError.self) {
+      try database.write { database in
+        try database.execute(
+          sql: "UPDATE profile SET needs_push = -1 WHERE id = ?", arguments: [profile.id])
+      }
     }
   }
 

--- a/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+++ b/MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
@@ -26,4 +26,16 @@ struct NeedsPushMutationTests {
       }
     }
   }
+
+  @Test("profile table has needs_push INTEGER NOT NULL DEFAULT 0")
+  func profileNeedsPushColumnPresent() throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try database.read { db in
+      let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(profile)")
+      let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
+      let col = try #require(needsPush, "needs_push missing on profile")
+      #expect((col["notnull"] as Int?) == 1)
+      #expect((col["dflt_value"] as String?) == "0")
+    }
+  }
 }

--- a/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
@@ -15,9 +15,10 @@ struct ProfileIndexSchemaV3Tests {
     try ProfileIndexDatabase.openInMemory()
   }
 
-  @Test("schema version reflects the v3 migration")
-  func versionIsThree() {
-    #expect(ProfileIndexSchema.version == 3)
+  @Test("schema version reflects the latest migration")
+  func versionIsLatest() {
+    // Bumped to 4 by `v4_needs_push` (issue #1081).
+    #expect(ProfileIndexSchema.version == 4)
   }
 
   @Test("v3 creates the instrument table plus all six rate-cache tables")

--- a/MoolahTests/Backends/GRDB/ProfileSchemaV13TransferSuggestionTests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileSchemaV13TransferSuggestionTests.swift
@@ -6,16 +6,17 @@ import Testing
 
 @Suite("ProfileSchema v13 transfer suggestion")
 struct ProfileSchemaV13TransferSuggestionTests {
-  @Test("v13 creates the transfer_suggestion table with its six columns")
+  @Test("transfer_suggestion table has its six base columns plus needs_push")
   func createsTransferSuggestionTable() throws {
     let queue = try DatabaseQueue()
     try ProfileSchema.migrator.migrate(queue)
     try queue.read { database in
       let cols = try Set(database.columns(in: "transfer_suggestion").map(\.name))
+      // `needs_push` added by `v17_needs_push` (issue #1081).
       #expect(
         cols == [
           "id", "record_name", "transaction_id_a", "transaction_id_b",
-          "suggested_at", "encoded_system_fields",
+          "suggested_at", "encoded_system_fields", "needs_push",
         ])
     }
   }

--- a/MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift
+++ b/MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift
@@ -11,11 +11,14 @@ import Testing
 /// local edit that is still queued for upload, the stale echo must not
 /// clobber the in-flight local edit.
 ///
-/// The fix routes such records through a system-fields-only update — the
-/// echo updates the cached change tag but never overwrites field values
-/// for any record name that is locally pending. Records with no pending
-/// local change apply normally (genuine remote changes from another
-/// device, or harmless no-op echoes).
+/// The fix flags the locally-edited row `needs_push = 1` and reads that
+/// flag inside the apply write transaction (issue #1081): a dirty row's
+/// field values are preserved and it receives a system-fields-only update
+/// (the cached change tag advances so the queued upload lands cleanly),
+/// while clean rows apply normally (genuine remote changes from another
+/// device, or harmless no-op echoes). This suite exercises that
+/// transactional guard — the regression coverage migrated off the older
+/// main-actor pending-record snapshot.
 @Suite("Apply remote changes preserves in-flight local edits")
 struct ApplyRemoteChangesPendingGuardTests {
   private static let zoneID = CKRecordZone.ID(
@@ -30,11 +33,14 @@ struct ApplyRemoteChangesPendingGuardTests {
     }
     let id = UUID()
 
-    // Local state reflects the user's *newer* edit (edit #2), not yet uploaded.
+    // Local state reflects the user's *newer* edit (edit #2), not yet
+    // uploaded, flagged dirty as a mutation would.
     let localRow = ProfileDataSyncHandlerTestSupport.accountRow(
       id: id, name: "LOCAL EDIT 2", encodedSystemFields: nil)
     try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
       try localRow.insert(database)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
     }
 
     // Stale server echo carries edit #1's value.
@@ -43,10 +49,7 @@ struct ApplyRemoteChangesPendingGuardTests {
     ).toCKRecord(in: Self.zoneID)
     let echoSystemFields = staleEcho.encodedSystemFields
 
-    let result = harness.handler.applyRemoteChanges(
-      saved: [staleEcho],
-      deleted: [],
-      locallyPendingRecordNames: [AccountRow.recordName(for: id)])
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
 
     if case .saveFailed(let message) = result {
       Issue.record("Expected success, got .saveFailed(\(message))")
@@ -73,14 +76,14 @@ struct ApplyRemoteChangesPendingGuardTests {
       id: id, name: "OLD LOCAL", encodedSystemFields: nil)
     try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
       try localRow.insert(database)
+      // needs_push defaults to 0 (clean) — no local edit pending.
     }
 
     let remote = ProfileDataSyncHandlerTestSupport.accountRow(
       id: id, name: "GENUINE REMOTE CHANGE"
     ).toCKRecord(in: Self.zoneID)
 
-    let result = harness.handler.applyRemoteChanges(
-      saved: [remote], deleted: [], locallyPendingRecordNames: [])
+    let result = harness.handler.applyRemoteChanges(saved: [remote], deleted: [])
 
     if case .saveFailed(let message) = result {
       Issue.record("Expected success, got .saveFailed(\(message))")
@@ -107,16 +110,15 @@ struct ApplyRemoteChangesPendingGuardTests {
       id: id, date: date, payee: "LOCAL EDIT 2", encodedSystemFields: nil)
     try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
       try localRow.insert(database)
+      try TransactionRow.filter(TransactionRow.Columns.id == id)
+        .updateAll(database, [TransactionRow.Columns.needsPush.set(to: true)])
     }
 
     let staleEcho = ProfileDataSyncHandlerTestSupport.transactionRow(
       id: id, date: date, payee: "STALE SERVER EDIT 1"
     ).toCKRecord(in: Self.zoneID)
 
-    let result = harness.handler.applyRemoteChanges(
-      saved: [staleEcho],
-      deleted: [],
-      locallyPendingRecordNames: [TransactionRow.recordName(for: id)])
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
 
     if case .saveFailed(let message) = result {
       Issue.record("Expected success, got .saveFailed(\(message))")
@@ -143,6 +145,8 @@ struct ApplyRemoteChangesPendingGuardTests {
       encodedSystemFields: nil)
     try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
       try localRow.insert(database)
+      try TransactionLegRow.filter(TransactionLegRow.Columns.id == id)
+        .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
     }
 
     let staleEcho = ProfileDataSyncHandlerTestSupport.transactionLegRow(
@@ -150,10 +154,7 @@ struct ApplyRemoteChangesPendingGuardTests {
     ).toCKRecord(in: Self.zoneID)
     let echoSystemFields = staleEcho.encodedSystemFields
 
-    let result = harness.handler.applyRemoteChanges(
-      saved: [staleEcho],
-      deleted: [],
-      locallyPendingRecordNames: [TransactionLegRow.recordName(for: id)])
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
 
     if case .saveFailed(let message) = result {
       Issue.record("Expected success, got .saveFailed(\(message))")

--- a/MoolahTests/Sync/CKRecordUserFieldComparisonTests.swift
+++ b/MoolahTests/Sync/CKRecordUserFieldComparisonTests.swift
@@ -12,13 +12,13 @@ struct CKRecordUserFieldComparisonTests {
   @Test("equal user fields compare equal; a differing field compares unequal")
   func sameUserFields() {
     let id = UUID()
-    let a = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
+    let first = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
       .toCKRecord(in: Self.zoneID)
-    let b = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
+    let second = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
       .toCKRecord(in: Self.zoneID)
-    let c = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "Y")
+    let differing = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "Y")
       .toCKRecord(in: Self.zoneID)
-    #expect(a.hasSameUserFields(as: b))
-    #expect(!a.hasSameUserFields(as: c))
+    #expect(first.hasSameUserFields(as: second))
+    #expect(!first.hasSameUserFields(as: differing))
   }
 }

--- a/MoolahTests/Sync/NeedsPushAckClearTests.swift
+++ b/MoolahTests/Sync/NeedsPushAckClearTests.swift
@@ -1,0 +1,71 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("Upload ack clears needs_push only when unchanged")
+struct NeedsPushAckClearTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  /// Reads the raw `needs_push` flag for an account id. Uses raw SQL
+  /// because the flag is a local-only column absent from `AccountRow`'s
+  /// `CodingKeys`, so it is not visible on the decoded row.
+  private func needsPushFlag(
+    in database: DatabaseQueue, id: UUID
+  ) async throws -> Bool {
+    try await database.read { database -> Bool in
+      try Bool.fetchOne(
+        database, sql: "SELECT needs_push FROM account WHERE id = ?", arguments: [id]) ?? false
+    }
+  }
+
+  @Test("ack clears the flag when the row matches what was sent")
+  func clearsWhenUnchanged() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let row = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "Sent")
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try row.insert(database)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+    // Build the sent record from the SAME row state that was persisted so
+    // the user fields match exactly (no sub-ms Date round-trip drift).
+    let sent = row.toCKRecord(in: Self.zoneID)
+
+    await MainActor.run {
+      _ = harness.handler.handleSentRecordZoneChanges(
+        savedRecords: [sent], failedSaves: [], failedDeletes: [])
+    }
+
+    #expect(try await needsPushFlag(in: harness.database, id: id) == false)
+  }
+
+  @Test("ack leaves the flag set when the row changed since send")
+  func keepsWhenChanged() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "EDIT 2").insert(database)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+    // The record that was actually sent carried the OLD value "EDIT 1".
+    let sent = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "EDIT 1")
+      .toCKRecord(in: Self.zoneID)
+
+    await MainActor.run {
+      _ = harness.handler.handleSentRecordZoneChanges(
+        savedRecords: [sent], failedSaves: [], failedDeletes: [])
+    }
+
+    #expect(try await needsPushFlag(in: harness.database, id: id))  // newer edit must remain pending
+  }
+}

--- a/MoolahTests/Sync/NeedsPushApplyGuardTests.swift
+++ b/MoolahTests/Sync/NeedsPushApplyGuardTests.swift
@@ -1,0 +1,63 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("Apply guards rows flagged needs_push")
+struct NeedsPushApplyGuardTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test("a dirty row's field values survive a stale echo; system fields update")
+  func dirtyRowFieldValuesPreserved() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    // Local newer edit, flagged dirty (as a mutation would).
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "LOCAL EDIT 2")
+        .insert(database)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+    let staleEcho = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "STALE SERVER EDIT 1"
+    ).toCKRecord(in: Self.zoneID)
+    let echoSystemFields = staleEcho.encodedSystemFields
+
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
+    if case .saveFailed(let message) = result { Issue.record("save failed: \(message)") }
+
+    let row = try await harness.database.read { database in
+      try AccountRow.fetchOne(database, key: id)
+    }
+    let saved = try #require(row)
+    #expect(saved.name == "LOCAL EDIT 2")  // field values preserved
+    #expect(saved.encodedSystemFields == echoSystemFields)  // system fields updated
+  }
+
+  @Test("a clean row applies the remote change normally")
+  func cleanRowApplies() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "OLD").insert(database)
+      // needs_push defaults to 0 (clean).
+    }
+    let remote = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "REMOTE"
+    ).toCKRecord(in: Self.zoneID)
+
+    _ = harness.handler.applyRemoteChanges(saved: [remote], deleted: [])
+
+    let row = try await harness.database.read { database in
+      try AccountRow.fetchOne(database, key: id)
+    }
+    #expect(try #require(row).name == "REMOTE")
+  }
+}

--- a/MoolahTests/Sync/NeedsPushConditionalClearTests.swift
+++ b/MoolahTests/Sync/NeedsPushConditionalClearTests.swift
@@ -1,0 +1,24 @@
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CKRecord user-field comparison")
+struct CKRecordUserFieldComparisonTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test("equal user fields compare equal; a differing field compares unequal")
+  func sameUserFields() {
+    let id = UUID()
+    let a = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
+      .toCKRecord(in: Self.zoneID)
+    let b = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
+      .toCKRecord(in: Self.zoneID)
+    let c = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "Y")
+      .toCKRecord(in: Self.zoneID)
+    #expect(a.hasSameUserFields(as: b))
+    #expect(!a.hasSameUserFields(as: c))
+  }
+}

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
@@ -76,44 +76,6 @@ struct ProfileIndexSyncHandlerTests {
     #expect(row.financialYearStartMonth == 1)
   }
 
-  // MARK: - Pending-Echo Guard
-
-  @Test("Stale profile echo does not overwrite a pending local rename")
-  func pendingProfileEchoPreservesLocalRename() throws {
-    let (handler, repository) = try makeHandler()
-
-    let profileId = UUID()
-    // Local state reflects the user's newer rename (edit #2), not yet uploaded.
-    let local = Profile(
-      id: profileId,
-      label: "LOCAL RENAME",
-      currencyCode: "AUD",
-      financialYearStartMonth: 7
-    )
-    try repository.applyRemoteChangesSync(saved: [ProfileRow(domain: local)], deleted: [])
-
-    // Stale server echo carries the pre-rename label.
-    let staleEcho = CKRecord(
-      recordType: ProfileRow.recordType,
-      recordID: CKRecord.ID(
-        recordType: ProfileRow.recordType, uuid: profileId, zoneID: handler.zoneID)
-    )
-    staleEcho["label"] = "STALE OLD LABEL" as CKRecordValue
-    staleEcho["currencyCode"] = "AUD" as CKRecordValue
-    staleEcho["financialYearStartMonth"] = 7 as CKRecordValue
-    staleEcho["createdAt"] = Date() as CKRecordValue
-
-    _ = handler.applyRemoteChanges(
-      saved: [staleEcho],
-      deleted: [],
-      locallyPendingRecordNames: [staleEcho.recordID.recordName])
-
-    let row = try #require(try repository.fetchRowSync(id: profileId))
-    // The in-flight rename wins; only system fields were updated.
-    #expect(row.label == "LOCAL RENAME")
-    #expect(row.encodedSystemFields == staleEcho.encodedSystemFields)
-  }
-
   // MARK: - Remote Deletion
 
   @Test
@@ -162,7 +124,9 @@ struct ProfileIndexSyncHandlerTests {
     _ = handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
 
     let row = try #require(try repository.fetchRowSync(id: profileId))
+    // The in-flight rename wins; only system fields were updated.
     #expect(row.label == "LOCAL RENAME")
+    #expect(row.encodedSystemFields == staleEcho.encodedSystemFields)
   }
 
   // MARK: - needs_push Conditional Clear on Ack (issue #1081)

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
@@ -165,6 +165,30 @@ struct ProfileIndexSyncHandlerTests {
     #expect(row.label == "LOCAL RENAME")
   }
 
+  // MARK: - needs_push Conditional Clear on Ack (issue #1081)
+
+  @Test("profile ack clears needs_push only when unchanged since send")
+  func profileAckConditionalClear() throws {
+    let (handler, repository) = try makeHandler()
+    let profileId = UUID()
+    let row = ProfileRow(
+      domain: Profile(
+        id: profileId, label: "Sent", currencyCode: "AUD", financialYearStartMonth: 7))
+    try repository.applyRemoteChangesSync(saved: [row], deleted: [])
+    try repository.markNeedsPushSync(id: profileId)
+    // The uploaded record is built from the persisted row (production
+    // builds it via `recordToSave` → `fetchRowSync`), so it carries the
+    // same SQLite-round-tripped `createdAt` the ack path re-reads.
+    let persisted = try #require(try repository.fetchRowSync(id: profileId))
+    let sent = handler.buildCKRecord(for: persisted)
+
+    _ = handler.handleSentRecordZoneChanges(
+      savedRecords: [sent], failedSaves: [], failedDeletes: [])
+
+    let dirty = try repository.dirtyIdsSync(from: [profileId])
+    #expect(dirty.isEmpty)  // unchanged → cleared
+  }
+
   @Test
   func applyRemoteChangesSkipsNonProfileRecordTypes() throws {
     let (handler, repository) = try makeHandler()

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
@@ -138,6 +138,33 @@ struct ProfileIndexSyncHandlerTests {
     #expect(row == nil)
   }
 
+  // MARK: - needs_push Apply Guard (issue #1081)
+
+  @Test("a needs_push profile row's label survives a stale echo")
+  func dirtyProfileEchoPreservesRename() throws {
+    let (handler, repository) = try makeHandler()
+    let profileId = UUID()
+    let local = Profile(
+      id: profileId, label: "LOCAL RENAME", currencyCode: "AUD",
+      financialYearStartMonth: 7)
+    try repository.applyRemoteChangesSync(saved: [ProfileRow(domain: local)], deleted: [])
+    try repository.markNeedsPushSync(id: profileId)  // simulate a pending local edit
+
+    let staleEcho = CKRecord(
+      recordType: ProfileRow.recordType,
+      recordID: CKRecord.ID(
+        recordType: ProfileRow.recordType, uuid: profileId, zoneID: handler.zoneID))
+    staleEcho["label"] = "STALE OLD LABEL" as CKRecordValue
+    staleEcho["currencyCode"] = "AUD" as CKRecordValue
+    staleEcho["financialYearStartMonth"] = 7 as CKRecordValue
+    staleEcho["createdAt"] = Date() as CKRecordValue
+
+    _ = handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
+
+    let row = try #require(try repository.fetchRowSync(id: profileId))
+    #expect(row.label == "LOCAL RENAME")
+  }
+
   @Test
   func applyRemoteChangesSkipsNonProfileRecordTypes() throws {
     let (handler, repository) = try makeHandler()

--- a/plans/2026-06-09-needs-push-dirty-flag.md
+++ b/plans/2026-06-09-needs-push-dirty-flag.md
@@ -1,0 +1,1112 @@
+# `needs_push` Transactional Dirty-Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fully close the residual single-device echo race (issue #1081) by tracking "has un-uploaded local change" as a per-row `needs_push` column that is read **inside the apply write transaction**, so a fetched echo can never clobber an in-flight local edit — with no main-actor snapshot gap.
+
+**Architecture:** Adopt the WatermelonDB / Firestore discipline confirmed by deep research (run `wf_e84643db-263`): a per-record dirty flag set transactionally on every mutation, checked transactionally on apply (dirty rows skip the field-value upsert and take system-fields only, deferring to the next push), and cleared on successful upload **only if the row still matches what was sent** (so a newer edit made between send and ack stays dirty and re-pushes). The flag is a local-only column kept OUT of the `Codable` Row struct, managed by targeted SQL, so it never crosses the CloudKit wire and `upsert` leaves it untouched. This replaces the non-atomic `locallyPendingRecordNames` main-actor snapshot added in #1079.
+
+**Tech Stack:** Swift, GRDB (SQLite, STRICT tables), CKSyncEngine. Swift Testing (`@Suite`/`@Test`/`#expect`/`#require`). Tooling via `just`.
+
+**Scope:** 12 syncable per-profile tables (account, account_group, category, earmark, earmark_budget_item, investment_value, transaction, transaction_leg, transfer_suggestion, insight_dismissal, csv_import_profile, import_rule) + the profile-index `profile` table. Instrument rows live in the shared registry and are out of scope (no per-profile instrument table). Deletions are out of scope — `needs_push` guards SAVES (field-value upserts) only; the deletion path is unchanged.
+
+---
+
+## Key invariants (read before starting)
+
+1. **`needs_push` is local-only.** It is NOT in any Row struct's `CodingKeys`/stored properties, so `insert`/`update`/`upsert` (Codable-driven) never write it. It IS added to each Row's `Columns` enum so it can be set/read via the GRDB query builder. It is never mapped to/from a `CKRecord`.
+2. **Set transactionally on mutation.** Every repository create/update/soft-delete sets `needs_push = 1` for the affected id(s) **inside the same `database.write`** as the row change.
+3. **Checked transactionally on apply.** `applyRemoteChanges` reads `needs_push` for the incoming ids **inside its own write transaction**; dirty rows skip the field-value upsert and get a system-fields-only update; clean rows apply normally. There is no main-actor pre-snapshot.
+4. **Cleared only when unchanged since send.** On `handleSentRecordZoneChanges.savedRecords`, clear `needs_push = 0` for a record **only if** the current row's user fields equal the just-saved record's user fields. A newer edit (different fields) leaves it dirty; CKSyncEngine has already re-queued that edit, and the next ack will clear it. This ordering is race-free under GRDB's serial write queue (a wrongly-cleared flag is re-set by the newer edit's own write; a correctly-skipped clear keeps protection).
+5. **`upsert` preserves the column.** GRDB `upsert` emits `INSERT ... ON CONFLICT DO UPDATE SET <Codable columns>`; `needs_push` is not among them, so it is left unchanged on conflict-update and takes the schema `DEFAULT 0` on insert of a brand-new remote row (correct: a freshly-arrived remote row is clean).
+
+---
+
+## File Structure
+
+- **Schema:** `Backends/GRDB/ProfileSchema.swift` (register v17), a new `Backends/GRDB/ProfileSchema+NeedsPush.swift` (the migration body), `Backends/GRDB/ProfileIndexSchema.swift` (register v4) + a new `Backends/GRDB/ProfileIndexSchema+NeedsPush.swift`.
+- **Row Columns:** the 12 `Backends/GRDB/Records/*Row.swift` + `ProfileRow.swift` — one `Columns` case each.
+- **Repository mutations:** the 13 `Backends/GRDB/Repositories/GRDB*Repository.swift` — set `needs_push=1` in mutations.
+- **Repository sync helpers:** the 13 `Backends/GRDB/Repositories/GRDB*Repository+Sync.swift` (or the repo file for profile index) — add `markNeedsPushSync`, `dirtyIdsSync`, `clearNeedsPushBatchSync`.
+- **Apply path:** `Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift`, `+GRDBSaveHelpers.swift`, `+SystemFields.swift`; `ProfileIndexSyncHandler.swift`.
+- **Ack clear:** `ProfileDataSyncHandler+SystemFields.swift`, `ProfileIndexSyncHandler.swift`, + a new `CKRecord.hasSameUserFields(as:)` helper in `Backends/CloudKit/Sync/CloudKitRecordConvertible.swift`.
+- **Remove #1079 snapshot:** `Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift` (`locallyPendingRecordNames(in:)` + param threading).
+- **Tests:** `MoolahTests/Sync/NeedsPushApplyGuardTests.swift`, `MoolahTests/Sync/NeedsPushConditionalClearTests.swift`, `MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift`, and an update to `MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift`.
+
+---
+
+## Per-type repeat list (the "12 syncable tables")
+
+Where a task says "repeat for each syncable type", apply to all of:
+
+| Table | Row file | Repo file | Repo property |
+|---|---|---|---|
+| account | AccountRow | GRDBAccountRepository | accounts |
+| account_group | AccountGroupRow | GRDBAccountGroupRepository | accountGroups |
+| category | CategoryRow | GRDBCategoryRepository | categories |
+| earmark | EarmarkRow | GRDBEarmarkRepository | earmarks |
+| earmark_budget_item | EarmarkBudgetItemRow | GRDBEarmarkBudgetItemRepository | earmarkBudgetItems |
+| investment_value | InvestmentValueRow | GRDBInvestmentRepository | investmentValues |
+| transaction | TransactionRow | GRDBTransactionRepository | transactions |
+| transaction_leg | TransactionLegRow | GRDBTransactionLegRepository | transactionLegs |
+| transfer_suggestion | TransferSuggestionRow | GRDBTransferSuggestionRepository | transferSuggestions |
+| insight_dismissal | InsightDismissalRow | GRDBInsightDismissalRepository | insightDismissals |
+| csv_import_profile | CSVImportProfileRow | GRDBCSVImportProfileRepository | csvImportProfiles |
+| import_rule | ImportRuleRow | GRDBImportRuleRepository | importRules |
+
+`profile` (ProfileRow / GRDBProfileIndexRepository) is handled separately in the profile-index tasks.
+
+---
+
+## Task 1: Schema migration — add `needs_push` to every syncable per-profile table
+
+**Files:**
+- Create: `Backends/GRDB/ProfileSchema+NeedsPush.swift`
+- Modify: `Backends/GRDB/ProfileSchema.swift` (register migration; bump `version`)
+- Test: `MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift`
+
+- [ ] **Step 1: Write the failing test** (column exists, default 0, STRICT-compatible)
+
+Create `MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift`:
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("needs_push column migration")
+struct NeedsPushMutationTests {
+  private static let tables = [
+    "account", "account_group", "category", "earmark", "earmark_budget_item",
+    "investment_value", "\"transaction\"", "transaction_leg", "transfer_suggestion",
+    "insight_dismissal", "csv_import_profile", "import_rule",
+  ]
+
+  @Test("every syncable table has needs_push INTEGER NOT NULL DEFAULT 0")
+  func needsPushColumnPresent() throws {
+    let database = try ProfileDatabase.openInMemory()
+    try database.read { db in
+      for table in Self.tables {
+        let unquoted = table.replacingOccurrences(of: "\"", with: "")
+        let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+        let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
+        let col = try #require(needsPush, "needs_push missing on \(unquoted)")
+        #expect((col["notnull"] as Int?) == 1)
+        #expect((col["dflt_value"] as String?) == "0")
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac NeedsPushMutationTests`
+Expected: FAIL — `needs_push missing on account` (column not yet added).
+
+- [ ] **Step 3: Write the migration body**
+
+Create `Backends/GRDB/ProfileSchema+NeedsPush.swift`:
+
+```swift
+import Foundation
+import GRDB
+
+extension ProfileSchema {
+  /// v17 — adds the local-only `needs_push` dirty flag to every syncable
+  /// per-profile table. `needs_push = 1` means the row has a local change
+  /// not yet confirmed uploaded to CloudKit; the fetched-changes apply
+  /// path reads it inside its write transaction and refuses to overwrite
+  /// such a row's field values (issue #1081). The column never crosses
+  /// the CloudKit wire and is absent from every Row struct's CodingKeys,
+  /// so `upsert` leaves it untouched. Existing rows default to 0 (clean):
+  /// any genuinely-unpushed row already has `encoded_system_fields IS NULL`
+  /// and is re-queued by the first-start self-heal, so a 0 default cannot
+  /// lose an edit at migration time.
+  static func addNeedsPush(_ database: Database) throws {
+    let tables = [
+      "account", "account_group", "category", "earmark", "earmark_budget_item",
+      "investment_value", "\"transaction\"", "transaction_leg",
+      "transfer_suggestion", "insight_dismissal", "csv_import_profile", "import_rule",
+    ]
+    for table in tables {
+      try database.execute(
+        sql: "ALTER TABLE \(table) ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0;")
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Register the migration**
+
+In `Backends/GRDB/ProfileSchema.swift`, bump the `version` constant from `16` to `17`, and add after the `v16_insight_dismissals` line:
+
+```swift
+    migrator.registerMigration("v17_needs_push", migrate: addNeedsPush)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-mac NeedsPushMutationTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Backends/GRDB/ProfileSchema.swift Backends/GRDB/ProfileSchema+NeedsPush.swift MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+git commit -m "feat(sync): add local-only needs_push column to syncable per-profile tables (v17)"
+```
+
+---
+
+## Task 2: Schema migration — add `needs_push` to the profile-index `profile` table
+
+**Files:**
+- Create: `Backends/GRDB/ProfileIndexSchema+NeedsPush.swift`
+- Modify: `Backends/GRDB/ProfileIndexSchema.swift` (register v4; bump `version` 3 → 4)
+- Test: extend `NeedsPushMutationTests`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `NeedsPushMutationTests`:
+
+```swift
+  @Test("profile table has needs_push INTEGER NOT NULL DEFAULT 0")
+  func profileNeedsPushColumnPresent() throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try database.read { db in
+      let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(profile)")
+      let needsPush = columns.first { ($0["name"] as String?) == "needs_push" }
+      let col = try #require(needsPush, "needs_push missing on profile")
+      #expect((col["notnull"] as Int?) == 1)
+      #expect((col["dflt_value"] as String?) == "0")
+    }
+  }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac NeedsPushMutationTests/profileNeedsPushColumnPresent`
+Expected: FAIL — `needs_push missing on profile`.
+
+- [ ] **Step 3: Write the migration body**
+
+Create `Backends/GRDB/ProfileIndexSchema+NeedsPush.swift`:
+
+```swift
+import Foundation
+import GRDB
+
+extension ProfileIndexSchema {
+  /// v4 — adds the local-only `needs_push` dirty flag to the `profile`
+  /// table (mirrors the per-profile v17 migration; see
+  /// `ProfileSchema+NeedsPush.swift`). Instrument rows live in the shared
+  /// registry and are out of scope.
+  static func addNeedsPush(_ database: Database) throws {
+    try database.execute(
+      sql: "ALTER TABLE profile ADD COLUMN needs_push INTEGER NOT NULL DEFAULT 0;")
+  }
+}
+```
+
+- [ ] **Step 4: Register the migration**
+
+In `Backends/GRDB/ProfileIndexSchema.swift` bump `version` 3 → 4 and add after the `v3_shared_instrument_registry` registration:
+
+```swift
+    migrator.registerMigration("v4_needs_push", migrate: addNeedsPush)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-mac NeedsPushMutationTests`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Backends/GRDB/ProfileIndexSchema.swift Backends/GRDB/ProfileIndexSchema+NeedsPush.swift MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift
+git commit -m "feat(sync): add needs_push column to profile-index profile table (v4)"
+```
+
+---
+
+## Task 3: Add `Columns.needsPush` to every Row's `Columns` enum
+
+**Files:** the 12 `Backends/GRDB/Records/*Row.swift` + `Backends/GRDB/Records/ProfileRow.swift`
+
+> No test of its own — it is exercised by Task 4+. This is a pure additive query-builder change. Do NOT add `needsPush` to `CodingKeys` or to the struct's stored properties.
+
+- [ ] **Step 1: Add the column case (exemplar: AccountRow)**
+
+In `Backends/GRDB/Records/AccountRow.swift`, inside `enum Columns`, add (after `groupId`):
+
+```swift
+    /// Local-only dirty flag (issue #1081). Absent from `CodingKeys` so
+    /// it never crosses the wire and `upsert` leaves it untouched; set
+    /// via the query builder only.
+    case needsPush = "needs_push"
+```
+
+- [ ] **Step 2: Repeat for each syncable type + ProfileRow**
+
+Add the same `case needsPush = "needs_push"` to the `Columns` enum of every Row in the per-type list above, plus `ProfileRow.Columns`. Keep the doc comment only on AccountRow; the rest get the bare case.
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `just build-mac`
+Expected: `** BUILD SUCCEEDED **` (warnings-as-errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Backends/GRDB/Records/
+git commit -m "feat(sync): add needsPush query-builder column to syncable Row types"
+```
+
+---
+
+## Task 4: Repository sync helpers — mark / read / clear `needs_push`
+
+**Files:** the 13 `Backends/GRDB/Repositories/GRDB*Repository+Sync.swift` (Account exemplar) and `GRDBProfileIndexRepository` for `profile`.
+**Test:** `MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift`
+
+Add three helpers per repo, mirroring the existing `setEncodedSystemFieldsBatchSync` shape.
+
+- [ ] **Step 1: Write the failing test** (mark, read dirty ids, clear)
+
+Append to `NeedsPushMutationTests`:
+
+```swift
+  @Test("markNeedsPushSync sets the flag; dirtyIdsSync reports it; clear resets it")
+  func markReadClearRoundTrip() async throws {
+    let database = try ProfileIndexDatabase.openInMemory() == database  // placeholder
+    fatalError("replaced below")
+  }
+```
+
+Replace that placeholder with a real test against the account repo:
+
+```swift
+  @Test("markNeedsPushSync sets the flag; dirtyIdsSync reports it; clear resets it")
+  func markReadClearRoundTrip() throws {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let repo = GRDBAccountRepository(
+      database: database, instrumentResolver: registry, instrumentRegistrar: registry)
+    let id = UUID()
+    try database.write { db in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "A").insert(db)
+    }
+
+    #expect(try repo.dirtyIdsSync(from: [id]) == [])
+
+    try database.write { db in try repo.markNeedsPushSync(id: id, in: db) }
+    #expect(try repo.dirtyIdsSync(from: [id]) == [id])
+
+    _ = try repo.clearNeedsPushBatchSync([id])
+    #expect(try repo.dirtyIdsSync(from: [id]) == [])
+  }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac NeedsPushMutationTests/markReadClearRoundTrip`
+Expected: FAIL — `markNeedsPushSync` / `dirtyIdsSync` / `clearNeedsPushBatchSync` not found.
+
+- [ ] **Step 3: Add the helpers (exemplar: GRDBAccountRepository+Sync.swift)**
+
+```swift
+  /// Sets `needs_push = 1` for `id` inside the caller's write transaction.
+  /// Called from every mutation so the apply path (issue #1081) can detect
+  /// an in-flight local edit transactionally.
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try AccountRow
+      .filter(AccountRow.Columns.id == id)
+      .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+  }
+
+  /// Returns the subset of `ids` whose row currently has `needs_push = 1`.
+  /// Read inside the apply write transaction (pass that `database`); the
+  /// overload without `database` opens its own read for non-apply callers.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    let rows =
+      try AccountRow
+      .filter(idSet.contains(AccountRow.Columns.id))
+      .filter(AccountRow.Columns.needsPush == true)
+      .select(AccountRow.Columns.id, as: UUID.self)
+      .fetchAll(database)
+    return Set(rows)
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { db in try dirtyIdsSync(from: ids, in: db) }
+  }
+
+  /// Clears `needs_push` for the given ids in one transaction. Returns the
+  /// number of rows updated.
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { database in
+      try AccountRow
+        .filter(Set(ids).contains(AccountRow.Columns.id))
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: false)])
+    }
+  }
+```
+
+- [ ] **Step 4: Repeat for each syncable type**
+
+Add the same three helpers to every `GRDB*Repository+Sync.swift`, substituting the Row type and table. For `transaction_leg`, keys are `UUID` (`TransactionLegRow`). For `GRDBProfileIndexRepository`, add equivalents on `ProfileRow` (it lives in the main repo file, not a `+Sync.swift`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-mac NeedsPushMutationTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Backends/GRDB/Repositories/
+git commit -m "feat(sync): add markNeedsPush / dirtyIds / clearNeedsPush repo helpers"
+```
+
+---
+
+## Task 5: Set `needs_push = 1` in every repository mutation
+
+**Files:** the 13 `Backends/GRDB/Repositories/GRDB*Repository.swift` + `GRDBProfileIndexRepository`.
+**Test:** `MoolahTests/Backends/GRDB/NeedsPushMutationTests.swift`
+
+Every create/update/soft-delete that already calls `onRecordChanged` must also call `markNeedsPushSync(id:in:)` **inside its `database.write`** for the same id(s). For multi-record mutations (e.g. account create that also writes an opening-balance transaction + leg), mark each affected id.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `NeedsPushMutationTests`:
+
+```swift
+  @Test("account create/update set needs_push")
+  func accountMutationsMarkDirty() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let repo = GRDBAccountRepository(
+      database: database, instrumentResolver: registry, instrumentRegistrar: registry)
+    let account = Account(
+      id: UUID(), name: "Checking", type: .bank,
+      instrument: .defaultTestInstrument, position: 0)
+
+    _ = try await repo.create(account)
+    #expect(try repo.dirtyIdsSync(from: [account.id]) == [account.id])
+
+    _ = try repo.clearNeedsPushBatchSync([account.id])
+    var renamed = account
+    renamed.name = "Renamed"
+    _ = try await repo.update(renamed)
+    #expect(try repo.dirtyIdsSync(from: [account.id]) == [account.id])
+  }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac NeedsPushMutationTests/accountMutationsMarkDirty`
+Expected: FAIL — `needs_push` stays 0 after create (`dirtyIdsSync` returns `[]`).
+
+- [ ] **Step 3: Add the mark calls (exemplar: GRDBAccountRepository)**
+
+In `create`, inside `performAccountInsert`'s `database.write` (or the write block that inserts the rows), after each row insert, mark it. Concretely, in the `database.write { database -> OpeningBalanceInserts in ... }` block add before returning:
+
+```swift
+      try markNeedsPushSync(id: account.id, in: database)
+      if let txnId = inserts.transactionId {
+        try transactionsDelegateMarkNeedsPush(txnId, in: database)
+      }
+      if let legId = inserts.legId {
+        try legsDelegateMarkNeedsPush(legId, in: database)
+      }
+```
+
+> NOTE: account `create` also writes a `transaction` + `transaction_leg`. Those rows belong to other repos. Rather than reach across repos, mark them with inline `updateAll` on their tables within the same `database`:
+>
+> ```swift
+> try TransactionRow.filter(TransactionRow.Columns.id == txnId)
+>   .updateAll(database, [TransactionRow.Columns.needsPush.set(to: true)])
+> try TransactionLegRow.filter(TransactionLegRow.Columns.id == legId)
+>   .updateAll(database, [TransactionLegRow.Columns.needsPush.set(to: true)])
+> ```
+>
+> Use the inline form for cross-table marks; use `markNeedsPushSync(id:in:)` for the repo's own table. Delete the `transactionsDelegate*` placeholders above — they are illustrative only.
+
+In `update`, inside the `database.write` block after `try existing.update(database)`:
+
+```swift
+    try markNeedsPushSync(id: account.id, in: database)
+```
+
+In `delete` (soft-delete via `isHidden = true`), after `try existing.update(database)`:
+
+```swift
+    try markNeedsPushSync(id: id, in: database)
+```
+
+- [ ] **Step 4: Repeat for each syncable type**
+
+For every repo, add `markNeedsPushSync(id:in:)` (or the inline cross-table form) inside the `database.write` of every mutation that calls `onRecordChanged`. Audit each repo: any mutation path that queues a sync save MUST mark the same id. Mutations that write multiple record types (transaction create writes transaction + legs; earmark writes budget items) must mark every affected id. For `GRDBProfileIndexRepository`, mark `profile` on create/update.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-mac NeedsPushMutationTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Backends/GRDB/Repositories/
+git commit -m "feat(sync): mark needs_push on every repository mutation"
+```
+
+---
+
+## Task 6: Add `CKRecord.hasSameUserFields(as:)` helper
+
+**Files:** Modify `Backends/CloudKit/Sync/CloudKitRecordConvertible.swift`
+**Test:** `MoolahTests/Sync/NeedsPushConditionalClearTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Sync/NeedsPushConditionalClearTests.swift`:
+
+```swift
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CKRecord user-field comparison")
+struct CKRecordUserFieldComparisonTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test("equal user fields compare equal; a differing field compares unequal")
+  func sameUserFields() {
+    let id = UUID()
+    let a = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
+      .toCKRecord(in: Self.zoneID)
+    let b = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "X")
+      .toCKRecord(in: Self.zoneID)
+    let c = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "Y")
+      .toCKRecord(in: Self.zoneID)
+    #expect(a.hasSameUserFields(as: b))
+    #expect(!a.hasSameUserFields(as: c))
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac CKRecordUserFieldComparisonTests`
+Expected: FAIL — `hasSameUserFields` not found.
+
+- [ ] **Step 3: Add the helper**
+
+In `Backends/CloudKit/Sync/CloudKitRecordConvertible.swift`, in the `extension CKRecord` block:
+
+```swift
+  /// True when `self` and `other` carry identical user-field values
+  /// (system fields / change tag ignored). Used by the upload-ack path to
+  /// decide whether a row changed locally since the version that was
+  /// uploaded: if the current row's `toCKRecord` still matches the saved
+  /// record, the local edit has been confirmed and `needs_push` can be
+  /// cleared; if a field differs, a newer edit is pending and the flag
+  /// stays set (issue #1081). CKRecord user values are CloudKit-native
+  /// types bridged to `NSObject` (`NSString`/`NSNumber`/`NSData`/`NSDate`),
+  /// so `isEqual` compares them correctly.
+  func hasSameUserFields(as other: CKRecord) -> Bool {
+    let keys = Set(allKeys()).union(other.allKeys())
+    for key in keys {
+      let lhs = self[key] as? NSObject
+      let rhs = other[key] as? NSObject
+      if lhs != rhs { return false }
+    }
+    return true
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac CKRecordUserFieldComparisonTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/CloudKitRecordConvertible.swift MoolahTests/Sync/NeedsPushConditionalClearTests.swift
+git commit -m "feat(sync): add CKRecord.hasSameUserFields(as:) for conditional clear"
+```
+
+---
+
+## Task 7: Apply path — check `needs_push` inside the write transaction (ProfileDataSyncHandler)
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift`, `+GRDBSaveHelpers.swift`, `+GRDBDispatch.swift` as needed
+- Test: `MoolahTests/Sync/NeedsPushApplyGuardTests.swift`
+
+The apply currently partitions on the `locallyPendingRecordNames` set. Replace that with an **in-transaction** read of `needs_push`: inside the outer `database.write`, for the incoming saved records, query which ids are dirty (per type via `dirtyIdsSync(from:in:)`); dirty records skip the field-value upsert and are collected for a system-fields-only update; clean records upsert as today.
+
+- [ ] **Step 1: Write the failing test** (edit lands as dirty → echo must not clobber)
+
+Create `MoolahTests/Sync/NeedsPushApplyGuardTests.swift`:
+
+```swift
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("Apply guards rows flagged needs_push")
+struct NeedsPushApplyGuardTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test("a dirty row's field values survive a stale echo; system fields update")
+  func dirtyRowFieldValuesPreserved() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    // Local newer edit, flagged dirty (as a mutation would).
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { db in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "LOCAL EDIT 2")
+        .insert(db)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(db, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+    let staleEcho = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "STALE SERVER EDIT 1"
+    ).toCKRecord(in: Self.zoneID)
+    let echoSystemFields = staleEcho.encodedSystemFields
+
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
+    if case .saveFailed(let m) = result { Issue.record("save failed: \(m)") }
+
+    let row = try await harness.database.read { db in
+      try AccountRow.fetchOne(db, key: id)
+    }
+    let saved = try #require(row)
+    #expect(saved.name == "LOCAL EDIT 2")            // field values preserved
+    #expect(saved.encodedSystemFields == echoSystemFields)  // system fields updated
+  }
+
+  @Test("a clean row applies the remote change normally")
+  func cleanRowApplies() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { db in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "OLD").insert(db)
+      // needs_push defaults to 0 (clean).
+    }
+    let remote = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "REMOTE"
+    ).toCKRecord(in: Self.zoneID)
+
+    _ = harness.handler.applyRemoteChanges(saved: [remote], deleted: [])
+
+    let row = try await harness.database.read { db in try AccountRow.fetchOne(db, key: id) }
+    #expect(try #require(row).name == "REMOTE")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac NeedsPushApplyGuardTests`
+Expected: `dirtyRowFieldValuesPreserved` FAILS (name becomes "STALE SERVER EDIT 1" — apply still blind-upserts dirty rows); `cleanRowApplies` PASSES.
+
+- [ ] **Step 3: Add an in-transaction dirty-id lookup dispatch**
+
+In `ProfileDataSyncHandler+GRDBSaveHelpers.swift` add a helper that, given a recordType and ids, returns the dirty subset using the repo's `dirtyIdsSync(from:in:)` inside the active `database`:
+
+```swift
+  nonisolated func dirtyIds(
+    recordType: String, ids: [UUID], in database: Database
+  ) throws -> Set<UUID> {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType: return try repos.accounts.dirtyIdsSync(from: ids, in: database)
+    case AccountGroupRow.recordType:
+      return try repos.accountGroups.dirtyIdsSync(from: ids, in: database)
+    case CategoryRow.recordType: return try repos.categories.dirtyIdsSync(from: ids, in: database)
+    case EarmarkRow.recordType: return try repos.earmarks.dirtyIdsSync(from: ids, in: database)
+    case EarmarkBudgetItemRow.recordType:
+      return try repos.earmarkBudgetItems.dirtyIdsSync(from: ids, in: database)
+    case InvestmentValueRow.recordType:
+      return try repos.investmentValues.dirtyIdsSync(from: ids, in: database)
+    case TransactionRow.recordType:
+      return try repos.transactions.dirtyIdsSync(from: ids, in: database)
+    case TransactionLegRow.recordType:
+      return try repos.transactionLegs.dirtyIdsSync(from: ids, in: database)
+    case TransferSuggestionRow.recordType:
+      return try repos.transferSuggestions.dirtyIdsSync(from: ids, in: database)
+    case InsightDismissalRow.recordType:
+      return try repos.insightDismissals.dirtyIdsSync(from: ids, in: database)
+    case CSVImportProfileRow.recordType:
+      return try repos.csvImportProfiles.dirtyIdsSync(from: ids, in: database)
+    case ImportRuleRow.recordType: return try repos.importRules.dirtyIdsSync(from: ids, in: database)
+    default: return []
+    }
+  }
+```
+
+- [ ] **Step 4: Partition each per-type group by dirtiness in `applyBatchSaves`**
+
+In `ProfileDataSyncHandler+ApplyRemoteChanges.swift`, change `applyBatchSaves` so that, for each `(recordType, ckRecords)` group, it computes the dirty ids inside `database`, splits the group, applies the clean records via the existing `applyGRDBBatchSave`, and writes system-fields-only for the dirty records **in the same transaction** via a new `applySystemFieldsInTransaction(recordType:ckRecords:in:)` (a sibling of the existing `setEncodedSystemFieldsBatchSync` that takes the active `database` and does `updateAll([encodedSystemFields.set(to:)])` per row):
+
+```swift
+  nonisolated func applyBatchSaves(
+    _ records: [CKRecord], systemFields: [String: Data], in database: Database
+  ) throws {
+    let grouped = Dictionary(grouping: records, by: \.recordType)
+    for (recordType, ckRecords) in grouped {
+      let ids = ckRecords.compactMap { $0.recordID.uuid }
+      let dirty = try dirtyIds(recordType: recordType, ids: ids, in: database)
+      let clean = dirty.isEmpty ? ckRecords
+        : ckRecords.filter { $0.recordID.uuid.map { !dirty.contains($0) } ?? true }
+      let echoed = dirty.isEmpty ? []
+        : ckRecords.filter { $0.recordID.uuid.map { dirty.contains($0) } ?? false }
+
+      if !echoed.isEmpty {
+        try applySystemFieldsInTransaction(
+          recordType: recordType, ckRecords: echoed, in: database)
+      }
+      if try applyGRDBBatchSave(
+        recordType: recordType, ckRecords: clean, systemFields: systemFields, in: database)
+      {
+        continue
+      }
+      if recordType != ProfileRow.recordType && !clean.isEmpty {
+        Self.batchLogger.warning(
+          "applyBatchSaves: unknown record type '\(recordType)' — skipping")
+      }
+    }
+  }
+```
+
+Add `applySystemFieldsInTransaction` in `+GRDBSaveHelpers.swift` dispatching per type to a new in-transaction `setEncodedSystemFieldsBatchSync(_:in:)` repo helper (add that overload alongside the existing one in each `+Sync.swift`, taking `in database: Database` and skipping its own `database.write`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-mac NeedsPushApplyGuardTests ApplyRemoteChangesPendingGuardTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/ Backends/GRDB/Repositories/ MoolahTests/Sync/NeedsPushApplyGuardTests.swift
+git commit -m "feat(sync): guard apply with transactional needs_push check (ProfileDataSyncHandler)"
+```
+
+---
+
+## Task 8: Apply path — same guard for ProfileIndexSyncHandler (`profile`)
+
+**Files:** Modify `Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift` and `Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift` (add in-transaction variants + dirty helpers).
+**Test:** add a case to `MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift`.
+
+> **This path MUST be fully transactional — no accepted residual.** Data loss is non-negotiable; a "narrow window bounded to the index zone" is still a defect. The dirty check, the clean-row upsert, and the dirty-row system-fields write all happen inside ONE `repository.database.write` so an in-flight profile rename can never be clobbered by an echo, identically to the per-profile path. (Instrument rows live in the separate shared-registry database and are out of scope here.)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ProfileIndexSyncHandlerTests`:
+
+```swift
+  @Test("a needs_push profile row's label survives a stale echo")
+  func dirtyProfileEchoPreservesRename() throws {
+    let (handler, repository) = try makeHandler()
+    let profileId = UUID()
+    let local = Profile(
+      id: profileId, label: "LOCAL RENAME", currencyCode: "AUD",
+      financialYearStartMonth: 7)
+    try repository.applyRemoteChangesSync(saved: [ProfileRow(domain: local)], deleted: [])
+    try repository.markNeedsPushSync(id: profileId)  // simulate a pending local edit
+
+    let staleEcho = CKRecord(
+      recordType: ProfileRow.recordType,
+      recordID: CKRecord.ID(
+        recordType: ProfileRow.recordType, uuid: profileId, zoneID: handler.zoneID))
+    staleEcho["label"] = "STALE OLD LABEL" as CKRecordValue
+    staleEcho["currencyCode"] = "AUD" as CKRecordValue
+    staleEcho["financialYearStartMonth"] = 7 as CKRecordValue
+    staleEcho["createdAt"] = Date() as CKRecordValue
+
+    _ = handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
+
+    let row = try #require(try repository.fetchRowSync(id: profileId))
+    #expect(row.label == "LOCAL RENAME")
+  }
+```
+
+(Add the repo helpers below; a non-`in:` `markNeedsPushSync(id:)` convenience that opens its own write is used by this test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac ProfileIndexSyncHandlerTests/dirtyProfileEchoPreservesRename`
+Expected: FAIL — label becomes "STALE OLD LABEL".
+
+- [ ] **Step 3: Add in-transaction repo variants to `GRDBProfileIndexRepository`**
+
+The handler needs to do the dirty check, the clean-row upsert, and the dirty-row system-fields write in ONE transaction. Add these to `GRDBProfileIndexRepository` (alongside the existing self-write `applyRemoteChangesSync(saved:deleted:)`). The repo already holds `let database: any DatabaseWriter` — expose it to the handler if not already accessible.
+
+```swift
+  /// In-transaction profile upsert/delete (mirrors the self-write
+  /// overload). Runs against the caller's `database` so the dirty check
+  /// and the upsert share one transaction (issue #1081 — no echo race).
+  func applyRemoteChangesSync(
+    saved rows: [ProfileRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows { try row.upsert(database) }
+    for id in ids { _ = try ProfileRow.deleteOne(database, id: id) }
+  }
+
+  /// Subset of `ids` whose profile row currently has `needs_push = 1`,
+  /// read inside the caller's transaction.
+  func dirtyIdsSync(from ids: [UUID], in database: Database) throws -> Set<UUID> {
+    guard !ids.isEmpty else { return [] }
+    let idSet = Set(ids)
+    return Set(
+      try ProfileRow
+        .filter(idSet.contains(ProfileRow.Columns.id))
+        .filter(ProfileRow.Columns.needsPush == true)
+        .select(ProfileRow.Columns.id, as: UUID.self)
+        .fetchAll(database))
+  }
+
+  func dirtyIdsSync(from ids: [UUID]) throws -> Set<UUID> {
+    try database.read { db in try dirtyIdsSync(from: ids, in: db) }
+  }
+
+  /// In-transaction system-fields-only write (change tag), for dirty
+  /// profile echoes that must NOT have their field values overwritten.
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)], in database: Database
+  ) throws {
+    for (id, data) in updates {
+      _ =
+        try ProfileRow
+        .filter(ProfileRow.Columns.id == id)
+        .updateAll(database, [ProfileRow.Columns.encodedSystemFields.set(to: data)])
+    }
+  }
+
+  func markNeedsPushSync(id: UUID, in database: Database) throws {
+    _ =
+      try ProfileRow
+      .filter(ProfileRow.Columns.id == id)
+      .updateAll(database, [ProfileRow.Columns.needsPush.set(to: true)])
+  }
+
+  func markNeedsPushSync(id: UUID) throws {
+    try database.write { db in try markNeedsPushSync(id: id, in: db) }
+  }
+
+  @discardableResult
+  func clearNeedsPushBatchSync(_ ids: [UUID]) throws -> Int {
+    guard !ids.isEmpty else { return 0 }
+    return try database.write { db in
+      try ProfileRow
+        .filter(Set(ids).contains(ProfileRow.Columns.id))
+        .updateAll(db, [ProfileRow.Columns.needsPush.set(to: false)])
+    }
+  }
+```
+
+- [ ] **Step 4: Make `ProfileIndexSyncHandler.applyRemoteChanges` apply profiles in ONE transaction**
+
+Replace the current profile leg (the `do { try repository.applyRemoteChangesSync(saved: savedSplit.profileRows, deleted: deletedSplit.profileIds) } catch { ... }` block) with a single `database.write` that splits dirty vs clean inside the transaction. The instrument leg is unchanged (separate registry DB). The `saved` parameter is the original `[CKRecord]` available in `applyRemoteChanges`.
+
+```swift
+    do {
+      try repository.database.write { database in
+        let profileIds = savedSplit.profileRows.map(\.id)
+        let dirty = try repository.dirtyIdsSync(from: profileIds, in: database)
+        let clean = savedSplit.profileRows.filter { !dirty.contains($0.id) }
+        try repository.applyRemoteChangesSync(
+          saved: clean, deleted: deletedSplit.profileIds, in: database)
+        // Dirty profile echoes: advance the change tag only, never field values.
+        let echoes = saved.compactMap { record -> (id: UUID, data: Data?)? in
+          guard let uuid = record.recordID.uuid, dirty.contains(uuid),
+            record.recordType == ProfileRow.recordType
+          else { return nil }
+          return (uuid, record.encodedSystemFields)
+        }
+        if !echoes.isEmpty {
+          try repository.setEncodedSystemFieldsBatchSync(echoes, in: database)
+        }
+      }
+    } catch {
+      logger.error("Failed to save remote profile changes: \(error, privacy: .public)")
+      return .saveFailed(error.localizedDescription)
+    }
+```
+
+> Keep the existing `changedTypes` computation (profiles changed iff `savedSplit.profileRows` or `deletedSplit.profileIds` is non-empty — the dirty split doesn't change that a profile fetch arrived). The instrument leg and its `onInstrumentRemoteChange()` fan-out remain exactly as-is below this block.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-mac ProfileIndexSyncHandlerTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+git commit -m "feat(sync): guard profile-index apply with needs_push check (single transaction)"
+```
+
+---
+
+## Task 9: Conditional clear on successful upload (ProfileDataSyncHandler)
+
+**Files:** Modify `Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift`.
+**Test:** `MoolahTests/Sync/NeedsPushConditionalClearTests.swift`
+
+`handleSentRecordZoneChanges` already writes system fields for `savedRecords`. Add: for each saved record, fetch the current row, build its `toCKRecord`, and if it `hasSameUserFields(as: savedRecord)` clear `needs_push`; otherwise leave it (a newer edit is pending and is already re-queued).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `NeedsPushConditionalClearTests` (the suite created in Task 6 — add a second `@Suite` or extend; here a new suite):
+
+```swift
+@Suite("Upload ack clears needs_push only when unchanged")
+struct NeedsPushAckClearTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test("ack clears the flag when the row matches what was sent")
+  func clearsWhenUnchanged() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let row = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "Sent")
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { db in
+      try row.insert(db)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(db, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+    let sent = row.toCKRecord(in: Self.zoneID)  // matches current row
+
+    _ = harness.handler.handleSentRecordZoneChanges(
+      savedRecords: [sent], failedSaves: [], failedDeletes: [])
+
+    #expect(try await harness.database.read { db in
+      try AccountRow.fetchOne(db, key: id)?.needsPushFlag(db, id: id)
+    } == false)
+  }
+
+  @Test("ack leaves the flag set when the row changed since send") 
+  func keepsWhenChanged() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { db in
+      try ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "EDIT 2").insert(db)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(db, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+    // The record that was actually sent carried the OLD value "EDIT 1".
+    let sent = ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "EDIT 1")
+      .toCKRecord(in: Self.zoneID)
+
+    _ = harness.handler.handleSentRecordZoneChanges(
+      savedRecords: [sent], failedSaves: [], failedDeletes: [])
+
+    let stillDirty = try await harness.database.read { db -> Bool in
+      (try Bool.fetchOne(
+        db, sql: "SELECT needs_push FROM account WHERE id = ?", arguments: [id])) ?? false
+    }
+    #expect(stillDirty)  // newer edit must remain pending
+  }
+}
+```
+
+> Use the raw-SQL `needs_push` read shown in `keepsWhenChanged` for both tests; delete the `needsPushFlag(...)` placeholder in `clearsWhenUnchanged` and replace with the same raw-SQL read.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac NeedsPushAckClearTests`
+Expected: both FAIL (flag never cleared / clear logic absent).
+
+- [ ] **Step 3: Implement conditional clear**
+
+In `ProfileDataSyncHandler+SystemFields.swift`, after `updateSystemFieldsForSaved(savedRecords)` in `handleSentRecordZoneChanges`, add `clearNeedsPushForConfirmed(savedRecords)`:
+
+```swift
+  /// Clears `needs_push` for each saved record whose current local row
+  /// still matches the uploaded version. If the row changed since the
+  /// send (a newer edit), the flag stays set — CKSyncEngine has already
+  /// re-queued that edit, and its own later ack clears the flag. Race-free
+  /// under the serial write queue: a wrongly-cleared flag is re-set by the
+  /// newer edit's own write (issue #1081).
+  private func clearNeedsPushForConfirmed(_ savedRecords: [CKRecord]) {
+    var clearByType: [String: [UUID]] = [:]
+    for saved in savedRecords {
+      guard let uuid = saved.recordID.uuid else { continue }
+      guard let current = currentCKRecord(recordType: saved.recordType, id: uuid)
+      else { continue }
+      if current.hasSameUserFields(as: saved) {
+        clearByType[saved.recordType, default: []].append(uuid)
+      }
+    }
+    for (recordType, ids) in clearByType {
+      do { try clearNeedsPush(recordType: recordType, ids: ids) } catch {
+        logger.error(
+          "clearNeedsPush failed for \(recordType, privacy: .public): \(error, privacy: .public)")
+      }
+    }
+  }
+```
+
+Add `currentCKRecord(recordType:id:)` (reuse the existing `fetchAndBuild`/record-lookup helpers from `+RecordLookup.swift`) and `clearNeedsPush(recordType:ids:)` (dispatch to each repo's `clearNeedsPushBatchSync`). Call `clearNeedsPushForConfirmed(savedRecords)` from `handleSentRecordZoneChanges` when `savedRecords` is non-empty.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac NeedsPushAckClearTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift MoolahTests/Sync/NeedsPushConditionalClearTests.swift
+git commit -m "feat(sync): clear needs_push on upload ack only when row unchanged since send"
+```
+
+---
+
+## Task 10: Conditional clear for ProfileIndexSyncHandler
+
+**Files:** Modify `Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift`.
+**Test:** add a case to `ProfileIndexSyncHandlerTests`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ProfileIndexSyncHandlerTests`:
+
+```swift
+  @Test("profile ack clears needs_push only when unchanged since send")
+  func profileAckConditionalClear() throws {
+    let (handler, repository) = try makeHandler()
+    let profileId = UUID()
+    let row = ProfileRow(domain: Profile(
+      id: profileId, label: "Sent", currencyCode: "AUD", financialYearStartMonth: 7))
+    try repository.applyRemoteChangesSync(saved: [row], deleted: [])
+    try repository.markNeedsPushSync(id: profileId)
+    let sent = handler.buildCKRecord(for: row)
+
+    _ = handler.handleSentRecordZoneChanges(
+      savedRecords: [sent], failedSaves: [], failedDeletes: [])
+
+    let dirty = try repository.dirtyIdsSync(from: [profileId])
+    #expect(dirty.isEmpty)  // unchanged → cleared
+  }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac ProfileIndexSyncHandlerTests/profileAckConditionalClear`
+Expected: FAIL — flag not cleared.
+
+- [ ] **Step 3: Implement**
+
+In `ProfileIndexSyncHandler.persistSystemFields(for:)` (or alongside it in `handleSentRecordZoneChanges`), after persisting system fields, for each saved `ProfileRow`-typed record compare `buildCKRecord(for: currentRow).hasSameUserFields(as: saved)` and clear via `repository.clearNeedsPushBatchSync([id])` when equal. Ignore instrument-typed saved records (shared registry).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac ProfileIndexSyncHandlerTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+git commit -m "feat(sync): clear profile needs_push on ack only when unchanged"
+```
+
+---
+
+## Task 11: Remove the #1079 main-actor snapshot guard
+
+**Files:** Modify `Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift`, `ProfileDataSyncHandler+ApplyRemoteChanges.swift`, `ProfileIndexSyncHandler.swift`; update `MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift`.
+
+The transactional `needs_push` check (Tasks 7–8) strictly supersedes the `locallyPendingRecordNames` snapshot. Remove the snapshot to avoid two overlapping mechanisms.
+
+- [ ] **Step 1: Update the existing guard tests to the new mechanism**
+
+In `ApplyRemoteChangesPendingGuardTests.swift`, the three tests pass `locallyPendingRecordNames:`. Change each to instead flag the seeded row dirty via `needs_push` (as in Task 7's test) and call `applyRemoteChanges(saved:deleted:)` without the param. Keep the assertions identical (field values preserved, system fields updated). This keeps the regression coverage while moving it to the new mechanism.
+
+- [ ] **Step 2: Remove the parameter and snapshot**
+
+- In `ProfileDataSyncHandler+ApplyRemoteChanges.swift`: delete the `locallyPendingRecordNames` parameter, `partitionPendingEchoes`, and the post-write `applySystemFieldsBatched(pendingEchoes)` block (the in-transaction split from Task 7 replaces it). `applyRemoteChanges(saved:deleted:preExtractedSystemFields:)` returns to a 3-arg signature.
+- In `ProfileIndexSyncHandler.swift`: delete the `locallyPendingRecordNames` parameter and `partitionPendingEchoes` (Task 8's dirty split replaces it).
+- In `SyncCoordinator+RecordChanges.swift`: delete `locallyPendingRecordNames(in:)` and the `MainActor.run` snapshot in both `applyFetchedProfileDataChanges` and `applyFetchedIndexChanges`; restore the plain `handler.applyRemoteChanges(saved:deleted:preExtractedSystemFields:)` / `profileIndexHandler.applyRemoteChanges(saved:deleted:)` calls.
+
+- [ ] **Step 3: Run the full sync suites**
+
+Run: `just test-mac NeedsPushApplyGuardTests NeedsPushConditionalClearTests NeedsPushAckClearTests ApplyRemoteChangesPendingGuardTests ProfileIndexSyncHandlerTests CoreFinancialGraphSyncRoundTripTests SyncRoundTripTransactionTests ApplyRemoteChangesOutOfOrderTests ApplyRemoteChangesAtomicityTests`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/ MoolahTests/Sync/ApplyRemoteChangesPendingGuardTests.swift
+git commit -m "refactor(sync): replace #1079 main-actor pending snapshot with transactional needs_push"
+```
+
+---
+
+## Task 12: Full verification + reviews
+
+- [ ] **Step 1: Format + lint**
+
+Run: `just format && just format-check`
+Expected: "All Swift files are correctly formatted." If a touched file now exceeds the 400-line limit, split it into a focused extension file (do NOT collapse lines or re-baseline).
+
+- [ ] **Step 2: Full macOS suite**
+
+Run: `pkill -f "Moolah.*xctest" 2>/dev/null; just test-mac 2>&1 | tee .agent-tmp/test-full-mac.txt | tail -3`
+Expected: "All tests passed."
+
+- [ ] **Step 3: Specialist reviews**
+
+Run the `database-schema-review` (migrations v17/v4, STRICT, default, additive), `database-code-review` (the new repo helpers, `updateAll`/`dirtyIdsSync`, transaction discipline), `sync-review` (apply/ack changes both handlers, cross-handler rule), and `concurrency-review` (in-transaction reads, nonisolated dispatch) agents on the working tree. Apply all Critical/Important/Minor findings (separate PR only if genuinely out of scope, and ask first).
+
+- [ ] **Step 4: Update issue + memory**
+
+In the PR body, `Fixes #1081`. Update memory `reference_sync_pending_echo_guard.md` to note the residual window is now closed transactionally via `needs_push`.
+
+- [ ] **Step 5: Open PR + auto-merge**
+
+```bash
+git -C "$PWD" push origin worktree-needs-push-dirty-flag:needs-push-dirty-flag
+gh pr create --base main --head needs-push-dirty-flag --title "fix(sync): close the #1081 echo race with a transactional needs_push dirty flag" --body "<summary + Fixes #1081>"
+gh pr merge <N> --auto
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** migration (T1–2), Row columns (T3), helpers (T4), mutation marking (T5), comparison helper (T6), apply guard both handlers (T7–8), conditional clear both handlers (T9–10), remove old guard (T11), verify+review (T12). All research-recommended elements (transactional dirty check + value-comparison clear + defer-not-clobber) are present.
+- **Type consistency:** helper names used uniformly — `markNeedsPushSync(id:in:)`, `dirtyIdsSync(from:in:)` + `dirtyIdsSync(from:)`, `clearNeedsPushBatchSync(_:)`, `setEncodedSystemFieldsBatchSync(_:in:)`, `CKRecord.hasSameUserFields(as:)`, `Columns.needsPush`.
+- **No accepted residual.** Both handlers do the dirty check, clean-row upsert, and dirty-row system-fields write inside ONE transaction (per-profile: the existing outer `database.write` in T7; profile-index: a new `repository.database.write` in T8). Data loss is non-negotiable, so there is no "narrow window remains" caveat — the design is uniformly transactional across every syncable path. The conditional clear (T9/T10) is race-free under GRDB's serial write queue (a wrongly-cleared flag is re-set by the newer edit's own write).


### PR DESCRIPTION
## Problem

#1079 fixed the dominant single-device data-loss race (a fetched iCloud echo clobbering an in-flight local edit) with a main-actor snapshot of `state.pendingRecordZoneChanges`. That snapshot is **not atomic** with the off-main apply write, leaving a narrow residual window (issue #1081): a local edit committed between the snapshot and the GRDB commit could still be clobbered.

Losing user data is non-negotiable, and a rare race is a design defect — so this replaces the snapshot with a **uniformly transactional** guard. No residual window.

## Approach (research-backed)

A deep-research pass (NSPersistentCloudKitContainer, Firestore `hasPendingWrites`, WatermelonDB `_status`/`_changed`, PouchDB MVCC, Dotted Version Vectors, `pointfreeco/sqlite-data`) converged on the WatermelonDB/Firestore discipline: **a per-record dirty flag, checked transactionally on apply, and the in-flight edit deferred rather than clobbered.**

### `needs_push` — a local-only dirty column
- New `needs_push INTEGER NOT NULL DEFAULT 0 CHECK (needs_push IN (0,1))` on all 12 syncable per-profile tables (v17) + the profile-index `profile` table (v4).
- Local-only: present in each Row's `Columns` enum **only** — never in `CodingKeys` (so it never crosses the CloudKit wire and `upsert` leaves it untouched), and excluded from `observableRegion` (so dirty-flag writes don't re-fire UI observers, preserving #865).

### Set / check / clear — every step transactional
- **Set:** every repository mutation sets `needs_push = 1` in the **same `database.write`** as the row change (audited: every `onRecordChanged` save site, including multi-record mutations — account create → account+txn+leg, transaction create/update → txn+legs, category delete cascade, earmark `setBudget`, etc.).
- **Check (apply):** the fetched-changes apply reads `needs_push` **inside its write transaction**; a dirty row skips the field-value upsert and gets a system-fields-only update (advancing the change tag); a clean row applies normally. No main-actor snapshot — the gap is gone.
- **Clear (ack):** on successful upload, `needs_push` is cleared **only if** the current row's user fields still match the just-saved record (`CKRecord.hasSameUserFields`). A newer edit stays dirty and re-pushes. Crucially, the **compare and clear happen in one `database.write`** so no concurrent edit can interleave between them (a TOCTOU between a separate read and clear — caught in review — would itself have been a data-loss bug).

Applied to **both** `ProfileDataSyncHandler` and `ProfileIndexSyncHandler` (SYNC_GUIDE §2 cross-handler rule) — profile rename had the identical race. The superseded #1079 `locallyPendingRecordNames` snapshot is removed (one guard, not two).

## Tests
- `NeedsPushApplyGuardTests` (dirty row preserved across a stale echo; clean row applies), `NeedsPushAckClearTests` (clears on match, stays dirty when changed), `NeedsPushMutationTests` (column + CHECK + mark/dirty/clear round-trip), `NeedsPushMarkRollbackTests` (mark is transactional), profile-index equivalents, plus the migrated #1079 guard tests now exercising `needs_push`.
- **Full `just test-mac`: 3936 tests / 682 suites, 0 failures.** `just format-check` clean. Build warning-free.
- Reviewed by `database-schema-review`, `database-code-review`, `sync-review`, `concurrency-review`; all Critical/Important findings addressed (incl. the ack-clear atomicity fix and migration string-literal + CHECK).

## Deliberately out of scope (raised for a separate decision)
- **`backfillValuationModeForUnsnapshotInvestmentAccounts` does not mark `needs_push`** — intentional: that backfill is a local-only derived correction that does not upload, so marking it would create a permanently-dirty row that blocks legitimate remote updates. Pre-existing behavior, not a #1081 regression.
- **`account_group_ui.is_expanded` missing `CHECK (0,1)`** — pre-existing, orthogonal local-only UI flag; needs a separate v18 table-rebuild migration.

Plan: `plans/2026-06-09-needs-push-dirty-flag.md`.

Fixes #1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)