### PR TITLE
fix(sync): close superseded-echo data-loss window after upload ack (#1081 follow-up)

### DIFF
--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
@@ -72,6 +72,43 @@ extension ProfileDataSyncHandler {
     }
   }
 
+  // MARK: - needs_push confirming-echo clear (issue #1081 follow-up)
+
+  /// Clears `needs_push` for dirty rows whose fetched echo carries the
+  /// SAME user fields as the current local row — the round-trip is
+  /// complete (the version the device last uploaded has now come back via
+  /// fetch). Runs **inside** the active apply `database`, after the
+  /// echoes' system-fields-only update, so the compare and clear share one
+  /// transaction.
+  ///
+  /// **Why this is the safe place to clear (not the upload ack).** The
+  /// upload-ack path deliberately leaves `needs_push` set for any row that
+  /// has round-tripped before (issue #1081 follow-up), because a stale
+  /// echo of a *superseded* earlier version may still be queued in the
+  /// fetch backlog and would clobber the newer edit on the clean path. By
+  /// the time the *confirming* echo of the current version is fetched,
+  /// every earlier-token stale echo has already been delivered — CKSyncEngine
+  /// streams fetched changes in monotonic server-token order — so clearing
+  /// here cannot reopen the window. A genuine remote change carries
+  /// *different* user fields, so it never matches and never clears the
+  /// flag; it is handled by the normal pending-guard / conflict path.
+  nonisolated func clearNeedsPushForConfirmingEchoes(
+    recordType: String, ckRecords: [CKRecord], in database: Database
+  ) throws {
+    var confirmedIds: [UUID] = []
+    for echo in ckRecords {
+      guard let uuid = echo.recordID.uuid else { continue }
+      guard
+        let current = try currentCKRecord(recordType: recordType, id: uuid, in: database)
+      else { continue }
+      if current.hasSameUserFields(as: echo) {
+        confirmedIds.append(uuid)
+      }
+    }
+    guard !confirmedIds.isEmpty else { return }
+    try clearNeedsPush(recordType: recordType, ids: confirmedIds, in: database)
+  }
+
   // MARK: - needs_push conditional clear (issue #1081)
 
   /// Clears `needs_push` for `ids` of `recordType` (each repo's

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -191,6 +191,8 @@ extension ProfileDataSyncHandler {
       if !echoed.isEmpty {
         try applySystemFieldsInTransaction(
           recordType: recordType, ckRecords: echoed, in: database)
+        try clearNeedsPushForConfirmingEchoes(
+          recordType: recordType, ckRecords: echoed, in: database)
       }
       if try applyGRDBBatchSave(
         recordType: recordType,

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
@@ -87,4 +87,102 @@ extension ProfileDataSyncHandler {
   where T: CloudKitRecordConvertible & ValueTypeSystemFieldsReadable {
     buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
   }
+
+  /// Reads the row's currently-cached `encodedSystemFields` blob **inside**
+  /// the caller's active `database`. The outer `Optional` is whether a row
+  /// exists (and the type is known); the inner is the nullable blob. Used
+  /// by the upload-ack path to learn whether the row has ever round-tripped
+  /// (non-`nil` blob) before deciding whether clearing `needs_push` is safe
+  /// (issue #1081 follow-up). Returns `nil` for a missing row or an unknown
+  /// record type; the caller treats that conservatively (no clear).
+  /// Reads each saved record's CURRENTLY-cached `encodedSystemFields`
+  /// keyed by `<recordType>|<uuid>`, so `handleSentRecordZoneChanges` can
+  /// snapshot the pre-ack cache before `updateSystemFieldsForSaved`
+  /// overwrites it. Only rows that exist are recorded (storing their
+  /// nullable cached blob); a missing row is left absent so the ack-clear
+  /// treats it conservatively (no clear). Errors are logged and the record
+  /// is omitted (issue #1081 follow-up).
+  nonisolated func preAckCachedSystemFields(
+    _ savedRecords: [CKRecord]
+  ) -> [String: Data?] {
+    var result: [String: Data?] = [:]
+    do {
+      try grdbRepositories.database.read { database in
+        for saved in savedRecords {
+          guard let uuid = saved.recordID.uuid else { continue }
+          if let blob = try self.cachedSystemFields(
+            recordType: saved.recordType, id: uuid, in: database)
+          {
+            result[saved.recordID.systemFieldsKey] = blob
+          }
+        }
+      }
+    } catch {
+      logger.error(
+        """
+        preAckCachedSystemFields read failed: \
+        \(error.localizedDescription, privacy: .public)
+        """)
+    }
+    return result
+  }
+
+  nonisolated func cachedSystemFields(
+    recordType: String, id: UUID, in database: Database
+  ) throws -> Data?? {
+    if let reference = try cachedSystemFieldsReference(
+      recordType: recordType, id: id, in: database)
+    {
+      return reference
+    }
+    return try cachedSystemFieldsDomain(recordType: recordType, id: id, in: database)
+  }
+
+  /// Reference-data side of the `cachedSystemFields` dispatch. Outer
+  /// `.none` = "not this half's record type"; the inner double-optional is
+  /// the row-exists / nullable-blob result.
+  nonisolated private func cachedSystemFieldsReference(
+    recordType: String, id: UUID, in database: Database
+  ) throws -> (Data??)? {
+    let repos = grdbRepositories
+    switch recordType {
+    case CategoryRow.recordType:
+      return try repos.categories.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case TransferSuggestionRow.recordType:
+      return try repos.transferSuggestions.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case AccountGroupRow.recordType:
+      return try repos.accountGroups.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case InsightDismissalRow.recordType:
+      return try repos.insightDismissals.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case CSVImportProfileRow.recordType:
+      return try repos.csvImportProfiles.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case ImportRuleRow.recordType:
+      return try repos.importRules.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    default:
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the `cachedSystemFields` dispatch.
+  nonisolated private func cachedSystemFieldsDomain(
+    recordType: String, id: UUID, in database: Database
+  ) throws -> Data?? {
+    let repos = grdbRepositories
+    switch recordType {
+    case AccountRow.recordType:
+      return try repos.accounts.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case TransactionRow.recordType:
+      return try repos.transactions.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case TransactionLegRow.recordType:
+      return try repos.transactionLegs.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case EarmarkRow.recordType:
+      return try repos.earmarks.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case EarmarkBudgetItemRow.recordType:
+      return try repos.earmarkBudgetItems.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    case InvestmentValueRow.recordType:
+      return try repos.investmentValues.fetchRowSync(id: id, in: database)?.encodedSystemFields
+    default:
+      return nil
+    }
+  }
 }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -83,8 +83,20 @@ extension ProfileDataSyncHandler {
     failedDeletes: [(CKRecord.ID, CKError)]
   ) -> SyncErrorRecovery.ClassifiedFailures {
     if !savedRecords.isEmpty {
+      // Capture each row's CURRENTLY-cached system fields *before*
+      // `updateSystemFieldsForSaved` overwrites them with this ack's
+      // newer blob. A `nil` pre-ack blob means the row has never
+      // round-tripped — this is its first confirmed upload, so no echo
+      // of an earlier server version can still be queued, and the flag
+      // is safe to clear. A non-`nil` pre-ack blob means the row was
+      // uploaded before at an earlier server version; a stale echo of
+      // that superseded version may still be in the fetch backlog, so
+      // the flag must NOT be cleared here (issue #1081 follow-up — the
+      // step-5→6 single-device loss window). The fetch/apply path clears
+      // it later when the confirming echo of the current version arrives.
+      let preAckCached = preAckCachedSystemFields(savedRecords)
       updateSystemFieldsForSaved(savedRecords)
-      clearNeedsPushForConfirmed(savedRecords)
+      clearNeedsPushForConfirmed(savedRecords, preAckCached: preAckCached)
     }
 
     let failures = SyncErrorRecovery.classify(
@@ -111,12 +123,20 @@ extension ProfileDataSyncHandler {
   }
 
   /// Clears `needs_push` for each saved record whose current local row
-  /// still matches the uploaded version. If the row changed since the
-  /// send (a newer edit), the flag stays set — CKSyncEngine has already
-  /// re-queued that edit, and its own later ack clears the flag. Clearing
-  /// only on an exact user-field match is the safe direction — an
-  /// under-clear is a harmless extra deferral, while an over-clear could
-  /// let a later echo clobber a pending newer edit (data loss).
+  /// still matches the uploaded version AND that has never round-tripped
+  /// before (its pre-ack cached system fields were `nil`). A row with a
+  /// non-`nil` pre-ack blob was uploaded at an earlier server version; a
+  /// stale echo of that superseded version may still be queued in the
+  /// fetch backlog, and clearing the flag here would let that echo clobber
+  /// this newer edit on the clean apply path (the step-5→6 single-device
+  /// loss window). For those rows the flag stays set and is cleared later
+  /// by the fetch/apply path when the *confirming* echo of the current
+  /// version arrives — safe because CKSyncEngine delivers fetched changes
+  /// in server-token order, so every earlier-token stale echo has already
+  /// been processed by then. Clearing only on an exact user-field match is
+  /// the safe direction — an under-clear is a harmless extra deferral,
+  /// while an over-clear could let a later echo clobber a pending newer
+  /// edit (data loss).
   ///
   /// **Atomicity (issue #1081).** The current-row read, the user-field
   /// compare, and the conditional clear all run inside ONE
@@ -130,12 +150,19 @@ extension ProfileDataSyncHandler {
   /// - Precondition: call on `@MainActor` (matches `updateSystemFieldsForSaved`).
   ///   The single `database.write` is the only transaction opened, so this
   ///   must not be nested inside another write on the same queue.
-  private func clearNeedsPushForConfirmed(_ savedRecords: [CKRecord]) {
+  private func clearNeedsPushForConfirmed(
+    _ savedRecords: [CKRecord], preAckCached: [String: Data?]
+  ) {
     do {
       try grdbRepositories.database.write { database in
         var clearByType: [String: [UUID]] = [:]
         for saved in savedRecords {
           guard let uuid = saved.recordID.uuid else { continue }
+          // Only the first confirmed round-trip (pre-ack cache was nil)
+          // is safe to clear on the ack; a re-confirmation at a newer
+          // version leaves the flag for the fetch path (see doc above).
+          guard case .some(.none) = preAckCached[saved.recordID.systemFieldsKey]
+          else { continue }
           // Re-fetch the CURRENT row inside this transaction and compare.
           guard
             let current = try self.currentCKRecord(

--- a/MoolahTests/Sync/NeedsPushSupersededEchoLossTests.swift
+++ b/MoolahTests/Sync/NeedsPushSupersededEchoLossTests.swift
@@ -1,0 +1,151 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Reproduces the single-device data-loss race that survives the #1081
+/// apply guard: the upload-ack clears `needs_push` on plain user-field
+/// equality, with no awareness that a *stale echo of a superseded
+/// version* may still be queued in the fetch stream.
+///
+/// Losing interleaving (single device, no peers):
+///   1. create V_create, `needs_push = 1`, uploaded.
+///   2. ack of V_create caches its server system fields (non-nil blob).
+///   3. update → V_update, `needs_push = 1` re-raised.
+///   4. V_update uploaded.
+///   5. ack of V_update: current(V_update) == saved(V_update) →
+///      the over-eager clear sets `needs_push = 0` (row "confirmed").
+///   6. a stale fetched echo of V_create — queued back at step 1,
+///      delivered late under upload/echo backlog — is applied. The row
+///      is now clean, so the clean-path upsert clobbers V_update. LOST.
+///
+/// The fix must keep `needs_push` set through the step-5→6 window: a row
+/// that has already round-tripped at least once (non-nil cached system
+/// fields) and is being re-confirmed at a *newer* version must NOT have
+/// its flag cleared by the ack, because an earlier version's echo can
+/// still arrive. The flag is instead cleared by the fetch/apply path
+/// when the *confirming* echo of the current version arrives — safe
+/// because CKSyncEngine delivers fetched changes in server-token order,
+/// so every earlier-token stale echo has already been processed by then.
+@Suite("needs_push survives a superseded-version echo (single-device loss)")
+struct NeedsPushSupersededEchoLossTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  /// Encodes a non-nil cached system-fields blob for `id` of an account,
+  /// standing in for the server system fields cached after the V_create
+  /// round-trip (step 2). Locally-built records carry no server change
+  /// tag, but the encoded blob is still non-nil Data — which is the
+  /// signal "this row has round-tripped before".
+  private static func cachedSystemFields(forAccount id: UUID) -> Data {
+    ProfileDataSyncHandlerTestSupport.accountRow(id: id, name: "V_create")
+      .toCKRecord(in: zoneID)
+      .encodedSystemFields
+  }
+
+  private static func cachedSystemFields(
+    forLeg id: UUID, transactionId: UUID
+  ) -> Data {
+    ProfileDataSyncHandlerTestSupport.transactionLegRow(
+      id: id, transactionId: transactionId, accountId: nil, quantity: 100
+    )
+    .toCKRecord(in: zoneID)
+    .encodedSystemFields
+  }
+
+  @Test("AccountRow: V_update survives a stale V_create echo after the ack")
+  func accountUpdateSurvivesSupersededEcho() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+
+    // Row is at V_update, dirty, and has already round-tripped once
+    // (non-nil cached system fields from the V_create ack at step 2).
+    let vUpdateRow = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "V_update",
+      encodedSystemFields: Self.cachedSystemFields(forAccount: id))
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try vUpdateRow.insert(database)
+      try AccountRow.filter(AccountRow.Columns.id == id)
+        .updateAll(database, [AccountRow.Columns.needsPush.set(to: true)])
+    }
+
+    // Step 5: ack of the V_update upload — current row matches the sent
+    // V_update record, so the over-eager clear fires here.
+    let sentVUpdate = vUpdateRow.toCKRecord(in: Self.zoneID)
+    await MainActor.run {
+      _ = harness.handler.handleSentRecordZoneChanges(
+        savedRecords: [sentVUpdate], failedSaves: [], failedDeletes: [])
+    }
+
+    // Step 6: a stale fetched echo of V_create arrives late.
+    let staleEcho = ProfileDataSyncHandlerTestSupport.accountRow(
+      id: id, name: "V_create"
+    ).toCKRecord(in: Self.zoneID)
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
+    if case .saveFailed(let message) = result { Issue.record("save failed: \(message)") }
+
+    let row = try await harness.database.read { database in
+      try AccountRow.fetchOne(database, key: id)
+    }
+    // The newer local edit must win — the stale echo must not clobber it.
+    #expect(try #require(row).name == "V_update")
+  }
+
+  @Test("TransactionLegRow: V_update survives a stale V_create echo after the ack")
+  func transactionLegUpdateSurvivesSupersededEcho() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let transactionId = UUID()
+
+    // Higher-fidelity variant: drive the leg through the real
+    // create-then-update repository flow so `needs_push` and the cached
+    // system fields are set exactly as production leaves them, rather
+    // than stamped directly.
+    let repo = harness.handler.grdbRepositories.transactionLegs
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      // create (V_create) — quantity 100, dirty.
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: transactionId, accountId: nil, quantity: 100
+      ).insert(database)
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+    // ack of V_create caches its (non-nil) server system fields.
+    _ = try repo.setEncodedSystemFieldsSync(
+      id: id, data: Self.cachedSystemFields(forLeg: id, transactionId: transactionId))
+    // update → V_update (quantity 200), dirty again.
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == id)
+        .updateAll(database, [TransactionLegRow.Columns.quantity.set(to: 200)])
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+
+    let vUpdateRow = try #require(try repo.fetchRowSync(id: id))
+
+    // Step 5: ack of the V_update upload.
+    let sentVUpdate = vUpdateRow.toCKRecord(in: Self.zoneID)
+    await MainActor.run {
+      _ = harness.handler.handleSentRecordZoneChanges(
+        savedRecords: [sentVUpdate], failedSaves: [], failedDeletes: [])
+    }
+
+    // Step 6: stale V_create echo (quantity 100) arrives late.
+    let staleEcho = ProfileDataSyncHandlerTestSupport.transactionLegRow(
+      id: id, transactionId: transactionId, accountId: nil, quantity: 100
+    ).toCKRecord(in: Self.zoneID)
+    let result = harness.handler.applyRemoteChanges(saved: [staleEcho], deleted: [])
+    if case .saveFailed(let message) = result { Issue.record("save failed: \(message)") }
+
+    let row = try await harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: id)
+    }
+    #expect(try #require(row).quantity == 200)
+  }
+}


### PR DESCRIPTION
## The bug
A single-device data-loss window remained after #1079/#1081. The `needs_push` apply-guard is cleared on the upload ack via user-field equality, which **over-clears for a row's second-or-later round-trip**:

1. create row `V_create`, upload it
2. `update` row → `V_update` (re-raises `needs_push`)
3. ack of `V_create` upload: content differs → flag kept ✓
4. upload `V_update`; ack matches content → **`needs_push` cleared**
5. a **stale fetched echo of the superseded `V_create`** (still queued in the fetch backlog) lands → flag is 0 → clean apply path upserts `V_create` → **clobbers `V_update`**

Reproduced in the running app: 15/15 rapid create+update legs survive with **no** sync, only ~4–14/15 under concurrent sync, and **heavy loss** when reconstruction runs right after a 514-record import (heavy echo backlog) — legs revert to placeholders, trade legs half-revert to negative balances.

## The fix
Clear `needs_push` on the ack **only for a row's first confirmed round-trip** (pre-ack cached system fields were `nil` — no earlier-version echo can exist). A row that already round-tripped keeps the flag set on the ack and is cleared instead by the **fetch/apply path when the confirming echo of the current version arrives**.

Safe because CKSyncEngine delivers fetched changes in **server-token order**: every earlier-token stale echo is processed (harmlessly system-fields-only under the still-set guard) **before** the confirming echo clears the flag. No CloudKit change-tag ordering is used (tags are opaque). Genuine multi-device remote changes carry different user fields, never match a confirming echo, and are unaffected.

## Tests
- New `NeedsPushSupersededEchoLossTests` (minimal `AccountRow` + higher-fidelity create-then-update `TransactionLeg` variant) reproduces the loss — **fails on prior code, passes now**.
- Full Sync suite stays green (58 tests / 13 suites, incl. `ApplyRemoteChangesOutOfOrderTests`, round-trip suites). `just format-check` clean; warnings-as-errors build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)