### PR TITLE
fix(sync): close out-of-order self-echo data-loss window via modificationDate gate (#1085)

### DIFF
--- a/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
+++ b/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
@@ -92,6 +92,19 @@ extension CKRecord {
     return CKRecord(coder: coder)
   }
 
+  /// Decodes the server-assigned `modificationDate` carried in a cached
+  /// `encoded_system_fields` blob, or `nil` when the blob is absent /
+  /// undecodable / carries no date. The modification-date gate (issue
+  /// #1085) uses this to learn the server version a clean row currently
+  /// holds: an incoming echo is applied only when its own
+  /// `modificationDate` is strictly newer. A `nil` here means fail-open
+  /// (apply), so a genuine first sync or a dateless blob is never
+  /// rejected.
+  static func modificationDate(fromEncodedSystemFields data: Data?) -> Date? {
+    guard let data, let record = fromEncodedSystemFields(data) else { return nil }
+    return record.modificationDate
+  }
+
   /// True when `self` and `other` carry identical user-field values
   /// (system fields / change tag ignored). Used by the upload-ack path to
   /// decide whether a row changed locally since the version that was

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyGuard.swift
@@ -81,17 +81,20 @@ extension ProfileDataSyncHandler {
   /// echoes' system-fields-only update, so the compare and clear share one
   /// transaction.
   ///
-  /// **Why this is the safe place to clear (not the upload ack).** The
-  /// upload-ack path deliberately leaves `needs_push` set for any row that
-  /// has round-tripped before (issue #1081 follow-up), because a stale
-  /// echo of a *superseded* earlier version may still be queued in the
-  /// fetch backlog and would clobber the newer edit on the clean path. By
-  /// the time the *confirming* echo of the current version is fetched,
-  /// every earlier-token stale echo has already been delivered — CKSyncEngine
-  /// streams fetched changes in monotonic server-token order — so clearing
-  /// here cannot reopen the window. A genuine remote change carries
-  /// *different* user fields, so it never matches and never clears the
-  /// flag; it is handled by the normal pending-guard / conflict path.
+  /// **Why clearing here is safe.** Clearing `needs_push` exposes the row
+  /// to the clean apply path, where an out-of-order stale echo of a
+  /// superseded version could otherwise clobber the newer edit. That window
+  /// is closed not by fetch ordering — CloudKit does **not** guarantee
+  /// fetched changes arrive in server-token order (issue #1085; an earlier
+  /// version of this doc wrongly assumed it did) — but by the
+  /// modification-date gate on the clean path (`applyBatchSaves` →
+  /// `applicableCleanSaves`): a clean echo is applied only when its server
+  /// `modificationDate` is strictly newer than the date the row caches, so a
+  /// superseded echo is rejected regardless of when it is delivered. The
+  /// gate is the load-bearing guarantee; this clear is correct independent
+  /// of it. A genuine remote change carries *different* user fields, so it
+  /// never matches and never clears the flag; it is handled by the normal
+  /// pending-guard / conflict path.
   nonisolated func clearNeedsPushForConfirmingEchoes(
     recordType: String, ckRecords: [CKRecord], in database: Database
   ) throws {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -194,9 +194,20 @@ extension ProfileDataSyncHandler {
         try clearNeedsPushForConfirmingEchoes(
           recordType: recordType, ckRecords: echoed, in: database)
       }
+
+      // Modification-date gate on the clean path (issue #1085). A clean
+      // row is fully round-tripped, so `needs_push` no longer protects it;
+      // an out-of-order stale echo of a superseded version would clobber
+      // the newer cached version on the upsert below. The gate rejects any
+      // clean echo whose server `modificationDate` is older-or-equal to the
+      // date the row currently caches, and collapses any same-batch
+      // duplicates of one id to the newest version first.
+      let applicable = try applicableCleanSaves(
+        recordType: recordType, clean: clean, in: database)
+
       if try applyGRDBBatchSave(
         recordType: recordType,
-        ckRecords: clean,
+        ckRecords: applicable,
         systemFields: systemFields,
         in: database)
       {
@@ -282,17 +293,33 @@ extension ProfileDataSyncHandler {
   nonisolated private static func systemFieldsLookup(
     saved: [CKRecord], preExtracted: [(String, Data)]
   ) -> [String: Data] {
+    // A single fetched batch is expected to coalesce to one version per
+    // record, but is not guaranteed to (issue #1085). On a duplicate
+    // recordID keep the NEWEST-dated blob so the stamped cached date stays
+    // consistent with the clean-path dedup-to-max winner (which upserts the
+    // newest version) — otherwise the row would hold the newest field values
+    // but an older blob, understating the cached date and re-admitting a
+    // stale echo the gate should reject. `uniquingKeysWith` also avoids the
+    // `uniqueKeysWithValues` trap on a duplicate key.
     let keyFor = CKRecordIDRecordName.systemFieldsKey(for:)
     if !preExtracted.isEmpty {
       return Dictionary(
         preExtracted.map { (keyFor($0.0), $0.1) },
-        uniquingKeysWith: { _, last in last })
+        uniquingKeysWith: newerSystemFieldsBlob)
     }
     return Dictionary(
-      uniqueKeysWithValues: saved.map {
-        ($0.recordID.systemFieldsKey, $0.encodedSystemFields)
-      }
-    )
+      saved.map { ($0.recordID.systemFieldsKey, $0.encodedSystemFields) },
+      uniquingKeysWith: newerSystemFieldsBlob)
+  }
+
+  /// On a duplicate recordID in one fetched batch, keeps the blob carrying
+  /// the newer server `modificationDate` (a `nil` date sorts as oldest), so
+  /// the stamped cached date matches the clean-path dedup-to-max winner
+  /// (issue #1085).
+  nonisolated private static func newerSystemFieldsBlob(_ lhs: Data, _ rhs: Data) -> Data {
+    (CKRecord.modificationDate(fromEncodedSystemFields: rhs) ?? .distantPast)
+      > (CKRecord.modificationDate(fromEncodedSystemFields: lhs) ?? .distantPast)
+      ? rhs : lhs
   }
 
   nonisolated private func logIncomingBatch(

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
@@ -127,6 +127,32 @@ extension ProfileDataSyncHandler {
     return result
   }
 
+  /// Reads the cached server `modificationDate` for each of `ids` of
+  /// `recordType`, decoded from the row's stored `encoded_system_fields`
+  /// blob **inside** the active apply write `database` (issue #1085). The
+  /// clean-path date gate compares these against each incoming echo's date.
+  /// Only ids whose row exists AND carries a decodable date appear in the
+  /// result; an absent id means "no cached date" → fail-open at the gate.
+  ///
+  /// Implemented as a point read + decode per id, reusing the existing
+  /// `cachedSystemFields` dispatch. The dominant cost is the
+  /// `NSKeyedUnarchiver` decode, not the indexed-PK lookups (design §M-1);
+  /// a stored, indexed `server_modification_date` column is deliberately
+  /// not added unless a benchmark shows the decode is a regression.
+  nonisolated func cachedModificationDates(
+    recordType: String, ids: [UUID], in database: Database
+  ) throws -> [UUID: Date] {
+    var result: [UUID: Date] = [:]
+    for id in ids {
+      guard
+        let blob = try cachedSystemFields(recordType: recordType, id: id, in: database),
+        let date = CKRecord.modificationDate(fromEncodedSystemFields: blob)
+      else { continue }
+      result[id] = date
+    }
+    return result
+  }
+
   nonisolated func cachedSystemFields(
     recordType: String, id: UUID, in database: Database
   ) throws -> Data?? {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ModificationDateGate.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ModificationDateGate.swift
@@ -1,0 +1,92 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+
+// Clean-path modification-date gate (issue #1085). A clean row is fully
+// round-tripped, so `needs_push` no longer protects it; the gate rejects any
+// out-of-order echo whose server `modificationDate` is older-or-equal to the
+// date the row already caches, closing the single-device revert window the
+// dirty-path guard cannot reach.
+
+/// Collapses same-id duplicates within one fetched batch to the
+/// highest-`modificationDate` version (issue #1085). Cheap insurance for the
+/// whole-row server-wins upsert sites, where keeping the newest version is
+/// correct and a stray duplicate would otherwise land by array order. `id`
+/// and `date` are closures because the batch element may be a `CKRecord`
+/// (whose uuid is optional and not expressible as `Identifiable`) or a typed
+/// row. Elements with no id and the common no-duplicate batch pass through
+/// untouched. A nil date sorts as oldest, so a dated version always beats a
+/// dateless one.
+///
+/// Assumption: one fetch event coalesces to at most one version per record,
+/// so this only ever guards against a defensive edge case.
+func dedupToMaxModificationDate<Element>(
+  _ items: [Element], id: (Element) -> UUID?, date: (Element) -> Date?
+) -> [Element] {
+  var newestByID: [UUID: Element] = [:]
+  var hasDuplicate = false
+  for item in items {
+    guard let key = id(item) else { continue }
+    if let existing = newestByID[key] {
+      hasDuplicate = true
+      if (date(item) ?? .distantPast) > (date(existing) ?? .distantPast) {
+        newestByID[key] = item
+      }
+    } else {
+      newestByID[key] = item
+    }
+  }
+  guard hasDuplicate else { return items }
+  // Rebuild preserving first-seen order, substituting the chosen version.
+  var seen: Set<UUID> = []
+  var result: [Element] = []
+  for item in items {
+    guard let key = id(item) else {
+      result.append(item)
+      continue
+    }
+    guard seen.insert(key).inserted else { continue }
+    result.append(newestByID[key] ?? item)
+  }
+  return result
+}
+
+extension ProfileDataSyncHandler {
+  /// Applies the modification-date gate to the clean subset of one
+  /// record-type group: dedups same-id duplicates to the newest version then
+  /// drops any echo not strictly newer than the version the local row already
+  /// caches. Reads each clean row's cached `modificationDate` inside the
+  /// active write `database`, so the gate decision and the upsert share one
+  /// transaction. Fail-open: a row with no cached date (first sync) or an
+  /// echo with no date applies.
+  nonisolated func applicableCleanSaves(
+    recordType: String, clean: [CKRecord], in database: Database
+  ) throws -> [CKRecord] {
+    guard !clean.isEmpty else { return clean }
+    let deduped = dedupToMaxModificationDate(
+      clean, id: { $0.recordID.uuid }, date: { $0.modificationDate })
+    let cleanIds = deduped.compactMap { $0.recordID.uuid }
+    let cachedDates = try cachedModificationDates(
+      recordType: recordType, ids: cleanIds, in: database)
+    return Self.applicableAfterDateGate(deduped, cachedDates: cachedDates)
+  }
+
+  /// Filters the clean records by the modification-date gate, returning only
+  /// the applicable ones. A record is applied when the row has no cached
+  /// date (`nil` → fail-open, first sync), the incoming record has no date
+  /// (`nil` → fail-open, unreachable in production), or the incoming date is
+  /// strictly newer than the cached date. An older-or-equal date is a
+  /// superseded stale echo and is rejected (reject-on-tie).
+  nonisolated static func applicableAfterDateGate(
+    _ clean: [CKRecord], cachedDates: [UUID: Date]
+  ) -> [CKRecord] {
+    clean.filter { record in
+      guard
+        let uuid = record.recordID.uuid,
+        let cached = cachedDates[uuid],
+        let incoming = record.modificationDate
+      else { return true }
+      return incoming > cached
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -131,12 +131,16 @@ extension ProfileDataSyncHandler {
   /// this newer edit on the clean apply path (the step-5→6 single-device
   /// loss window). For those rows the flag stays set and is cleared later
   /// by the fetch/apply path when the *confirming* echo of the current
-  /// version arrives — safe because CKSyncEngine delivers fetched changes
-  /// in server-token order, so every earlier-token stale echo has already
-  /// been processed by then. Clearing only on an exact user-field match is
-  /// the safe direction — an under-clear is a harmless extra deferral,
-  /// while an over-clear could let a later echo clobber a pending newer
-  /// edit (data loss).
+  /// version arrives. Even once cleared, a superseded stale echo that
+  /// arrives afterwards cannot clobber the row: the modification-date gate
+  /// on the clean apply path (`applyBatchSaves`, issue #1085) rejects any
+  /// echo whose server `modificationDate` is not strictly newer than the
+  /// date the row caches. (CloudKit does **not** guarantee fetched changes
+  /// arrive in server-token order — an earlier version of this doc wrongly
+  /// relied on that; the date gate is the actual guarantee.) Clearing only
+  /// on an exact user-field match remains the safe direction — an
+  /// under-clear is a harmless extra deferral, while an over-clear could let
+  /// a later echo clobber a pending newer edit (data loss).
   ///
   /// **Atomicity (issue #1081).** The current-row read, the user-field
   /// compare, and the conditional clear all run inside ONE

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+NeedsPush.swift
@@ -1,5 +1,6 @@
 @preconcurrency import CloudKit
 import Foundation
+import GRDB
 
 // MARK: - needs_push conditional clear (issue #1081)
 //
@@ -30,8 +31,17 @@ extension ProfileIndexSyncHandler {
       let profileIds = profileRows.map(\.id)
       let dirty = try repository.dirtyIdsSync(from: profileIds, in: database)
       let clean = profileRows.filter { !dirty.contains($0.id) }
+      // Modification-date gate on the clean path (issue #1085), mirroring
+      // the per-profile-data handler. A clean profile row is fully
+      // round-tripped, so `needs_push` no longer protects it; an
+      // out-of-order stale echo of a superseded version (e.g. a profile
+      // created then renamed under backlog) would clobber the newer cached
+      // name on the upsert. Reject any clean echo whose server
+      // `modificationDate` is older-or-equal to the row's cached date, and
+      // collapse same-batch duplicates to the newest version first.
+      let applicable = try applicableCleanSaves(clean, in: database)
       try repository.applyRemoteChangesSync(
-        saved: clean, deleted: deletedProfileIds, in: database)
+        saved: applicable, deleted: deletedProfileIds, in: database)
       let echoes = saved.compactMap { record -> (id: UUID, data: Data?)? in
         guard let uuid = record.recordID.uuid, dirty.contains(uuid),
           record.recordType == ProfileRow.recordType
@@ -44,11 +54,46 @@ extension ProfileIndexSyncHandler {
     }
   }
 
+  /// Applies the modification-date gate to the clean profile subset (issue
+  /// #1085): dedups same-id duplicates to the newest version then drops any
+  /// echo not strictly newer than the version the local row already caches.
+  /// Each profile row carries its incoming server date in its own
+  /// `encodedSystemFields` blob (copied from the fetched record in
+  /// `partitionSaved`); the cached date is read from the stored row's blob
+  /// inside the active write `database`. Fail-open: a row with no cached date
+  /// (first sync) or an echo with no date applies.
+  private func applicableCleanSaves(
+    _ clean: [ProfileRow], in database: Database
+  ) throws -> [ProfileRow] {
+    guard !clean.isEmpty else { return clean }
+    let deduped = dedupToMaxModificationDate(
+      clean, id: { $0.id }, date: { $0.serverModificationDate })
+    var applicable: [ProfileRow] = []
+    for row in deduped {
+      let cached = try repository.fetchRowSync(id: row.id, in: database)?
+        .serverModificationDate
+      guard let cached, let incoming = row.serverModificationDate else {
+        applicable.append(row)  // fail-open
+        continue
+      }
+      if incoming > cached { applicable.append(row) }
+    }
+    return applicable
+  }
+
   /// Clears `needs_push` for each saved profile record whose current
   /// local row still matches the uploaded version. If the row changed
   /// since the send (a newer edit), the flag stays set — CKSyncEngine
   /// has already re-queued that edit, and its own later ack clears the
   /// flag. Instrument-typed saved records are ignored (shared registry).
+  ///
+  /// This clear is eager (unlike the per-profile-data ack-clear it does not
+  /// gate on a `nil` pre-ack cache), exposing the row to the clean apply
+  /// path sooner. That is safe because the clean-path modification-date gate
+  /// in `applyProfilesGuarded` (issue #1085) rejects any superseded stale
+  /// echo regardless of fetch order — CloudKit does **not** guarantee
+  /// server-token fetch ordering, so the date gate, not delivery order, is
+  /// the load-bearing guarantee.
   ///
   /// **Atomicity (issue #1081).** The current-row read, the user-field
   /// compare, and the conditional clear all share ONE

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -256,6 +256,11 @@ final class GRDBInstrumentRegistryRepository:
   func applyRemoteChangesSync(saved rows: [InstrumentRow], deleted ids: [String]) throws {
     try database.write { database in
       for var row in rows {
+        let existing =
+          try InstrumentRow
+          .filter(InstrumentRow.Columns.id == row.id)
+          .fetchOne(database)
+
         // Apply the field-level merge rule for `pricingStatus` before
         // upserting. CKSyncEngine's default "server wins" would let
         // the daily auto-resolver on one device clobber a `.spam`
@@ -269,18 +274,31 @@ final class GRDBInstrumentRegistryRepository:
         // in `InstrumentRow+CloudKit.swift`) decode as `.priced`. That
         // matches the legacy fallback and keeps the merge defensive
         // rather than throwing.
-        if let existing =
-          try InstrumentRow
-          .filter(InstrumentRow.Columns.id == row.id)
-          .fetchOne(database)
-        {
-          let local = TokenPricingStatus(rawValue: existing.pricingStatus) ?? .priced
-          let incoming = TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
-          row.pricingStatus =
-            PricingStatusMerge.merge(
-              local: local, incoming: incoming
-            ).rawValue
+        let mergedStatus = Self.mergedPricingStatus(local: existing, incoming: row)
+
+        // Modification-date gate on identity / provider-mapping fields and
+        // the cached system-fields blob (issue #1085). Instruments have no
+        // `needs_push`; the date gate piggybacks on the `fetchOne` above.
+        // A stale echo (incoming date older-or-equal to the existing row's
+        // cached date) must NOT revert the identity/mapping fields — but
+        // `pricingStatus` is EXEMPT: it always flows through
+        // `PricingStatusMerge` regardless of date, because that merge is a
+        // deliberately recency-independent CRDT (sticky `.spam`) and gating
+        // it wholesale could leave two devices divergent. So a stale echo
+        // writes only the merged `pricingStatus` (and only when it changed,
+        // to skip a no-op write), leaving identity / mapping / blob put.
+        if let existing, Self.isStaleInstrumentEcho(existing: existing, incoming: row) {
+          if mergedStatus != existing.pricingStatus {
+            _ =
+              try InstrumentRow
+              .filter(InstrumentRow.Columns.id == row.id)
+              .updateAll(
+                database, [InstrumentRow.Columns.pricingStatus.set(to: mergedStatus)])
+          }
+          continue
         }
+
+        row.pricingStatus = mergedStatus
         try row.upsert(database)
       }
       for id in ids {
@@ -291,6 +309,36 @@ final class GRDBInstrumentRegistryRepository:
     // map must be rebuilt before the next reader (e.g. a price-cache
     // resolution) observes it.
     invalidateInstrumentMapCache()
+  }
+
+  /// Resolves the `pricingStatus` raw value to persist for an incoming
+  /// instrument row, applying `PricingStatusMerge` against the existing
+  /// local row's status (issue #1085 keeps this recency-independent, so it
+  /// runs whether or not the date gate rejects the rest of the record).
+  /// With no existing row the incoming status is taken as-is.
+  private static func mergedPricingStatus(
+    local existing: InstrumentRow?, incoming row: InstrumentRow
+  ) -> String {
+    guard let existing else { return row.pricingStatus }
+    let local = TokenPricingStatus(rawValue: existing.pricingStatus) ?? .priced
+    let incoming = TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
+    return PricingStatusMerge.merge(local: local, incoming: incoming).rawValue
+  }
+
+  /// True when `row` is a superseded stale echo relative to `existing` —
+  /// its server `modificationDate` is older-or-equal to the date the local
+  /// row caches (reject-on-tie, design §4). Fail-open: if either date is
+  /// absent (no cached blob, or a dateless incoming record) returns `false`
+  /// so the incoming record applies, matching the gate's behaviour at the
+  /// UUID-keyed sites.
+  private static func isStaleInstrumentEcho(
+    existing: InstrumentRow, incoming row: InstrumentRow
+  ) -> Bool {
+    guard
+      let cached = existing.serverModificationDate,
+      let incoming = row.serverModificationDate
+    else { return false }
+    return incoming <= cached
   }
 
   /// Persists a new `pricingStatus` for the row identified by

--- a/Backends/GRDB/Sync/InstrumentRow+CloudKit.swift
+++ b/Backends/GRDB/Sync/InstrumentRow+CloudKit.swift
@@ -29,6 +29,16 @@ extension InstrumentRow: CloudKitRecordConvertible {
     return record
   }
 
+  /// The server-assigned `modificationDate` decoded from the row's cached
+  /// `encoded_system_fields` blob, or `nil` when the blob is absent or
+  /// carries no date. The instrument modification-date gate (issue #1085)
+  /// reads this to order two versions of the same instrument. Defined here,
+  /// in the CloudKit mapping file, so the storage-only
+  /// `GRDBInstrumentRegistryRepository` need not import CloudKit.
+  var serverModificationDate: Date? {
+    CKRecord.modificationDate(fromEncodedSystemFields: encodedSystemFields)
+  }
+
   /// `InstrumentRow` is keyed by `recordName` (e.g. `"AUD"`,
   /// `"ASX:BHP"`) rather than a UUID. `recordName` is always non-nil on
   /// a valid `CKRecord.ID`, so this never returns `nil`; the Optional

--- a/Backends/GRDB/Sync/ProfileRow+CloudKit.swift
+++ b/Backends/GRDB/Sync/ProfileRow+CloudKit.swift
@@ -50,4 +50,13 @@ extension ProfileRow: CloudKitRecordConvertible {
       dataFormatVersion: fields.dataFormatVersion.map(Int.init) ?? 0
     )
   }
+
+  /// The server-assigned `modificationDate` decoded from the row's cached
+  /// `encoded_system_fields` blob, or `nil` when the blob is absent or
+  /// carries no date. The clean-path modification-date gate (issue #1085)
+  /// reads this to order two versions of the same profile. Defined here, in
+  /// the CloudKit mapping file, mirroring `InstrumentRow.serverModificationDate`.
+  var serverModificationDate: Date? {
+    CKRecord.modificationDate(fromEncodedSystemFields: encodedSystemFields)
+  }
 }

--- a/MoolahTests/Backends/CloudKit/Sync/InstrumentOutOfOrderEchoTests.swift
+++ b/MoolahTests/Backends/CloudKit/Sync/InstrumentOutOfOrderEchoTests.swift
@@ -1,0 +1,150 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Reproductions for the #1085 out-of-order self-echo loss on the
+/// instrument apply path (`GRDBInstrumentRegistryRepository.applyRemoteChangesSync`)
+/// — the shared-registry path the crypto migration's `register-instrument`
+/// and pricing mutations flow through. The modification-date gate protects
+/// identity / provider-mapping fields and the cached system-fields blob;
+/// `pricingStatus` is EXEMPT and always flows through `PricingStatusMerge`.
+@Suite("instrument out-of-order echo gate (issue #1085)")
+struct InstrumentOutOfOrderEchoTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+  private static let tOlder = Date(timeIntervalSince1970: 1_700_000_000)
+  private static let tNewer = Date(timeIntervalSince1970: 1_700_000_060)
+  private static let tokenId = "1:0x0000000000000000000000000000000000000abc"
+
+  private func makeRegistry() throws -> (any DatabaseWriter, GRDBInstrumentRegistryRepository) {
+    let database = try ProfileIndexDatabase.openInMemory()
+    return (database, GRDBInstrumentRegistryRepository(database: database))
+  }
+
+  /// Builds a crypto `InstrumentRow` for the shared token id, stamped with a
+  /// server modification date so the gate can order it.
+  private func row(
+    name: String,
+    decimals: Int = 18,
+    ticker: String? = nil,
+    coingeckoId: String? = nil,
+    status: TokenPricingStatus = .priced,
+    date: Date
+  ) -> InstrumentRow {
+    var row = InstrumentRow(
+      id: Self.tokenId,
+      recordName: InstrumentRow.recordName(for: Self.tokenId),
+      kind: "cryptoToken",
+      name: name,
+      decimals: decimals,
+      ticker: ticker,
+      exchange: nil,
+      chainId: 1,
+      contractAddress: "0x0000000000000000000000000000000000000abc",
+      coingeckoId: coingeckoId,
+      cryptocompareSymbol: nil,
+      binanceSymbol: nil,
+      encodedSystemFields: nil,
+      pricingStatus: status.rawValue)
+    row.encodedSystemFields =
+      row.toCKRecord(in: Self.zoneID).withModificationDate(date).encodedSystemFields
+    return row
+  }
+
+  private func stored(
+    _ database: any DatabaseWriter
+  ) async throws -> InstrumentRow? {
+    try await database.read {
+      try InstrumentRow.filter(InstrumentRow.Columns.id == Self.tokenId).fetchOne($0)
+    }
+  }
+
+  @Test("identity/mapping fields survive an out-of-order stale instrument echo")
+  func identitySurvivesStaleEcho() async throws {
+    let (database, registry) = try makeRegistry()
+
+    let vCreate = row(name: "Placeholder", decimals: 18, status: .priced, date: Self.tOlder)
+    try registry.applyRemoteChangesSync(saved: [vCreate], deleted: [])
+
+    let vUpdate = row(
+      name: "RealToken", decimals: 8, ticker: "RT", coingeckoId: "real-token",
+      status: .priced, date: Self.tNewer)
+    try registry.applyRemoteChangesSync(saved: [vUpdate], deleted: [])
+
+    // Stale echo of V_create arrives last on a clean row.
+    try registry.applyRemoteChangesSync(saved: [vCreate], deleted: [])
+
+    let result = try #require(try await stored(database))
+    #expect(result.name == "RealToken")
+    #expect(result.decimals == 8)
+    #expect(result.ticker == "RT")
+    #expect(result.coingeckoId == "real-token")
+  }
+
+  @Test("a sticky .spam classification survives a stale echo carrying .priced")
+  func stickySpamSurvivesStaleEcho() async throws {
+    let (database, registry) = try makeRegistry()
+
+    // Current version is .spam at the newer date.
+    try registry.applyRemoteChangesSync(
+      saved: [row(name: "Token", status: .spam, date: Self.tNewer)], deleted: [])
+
+    // Stale echo (older date) carrying .priced — identity gated, and
+    // pricingStatus merge keeps the sticky .spam.
+    try registry.applyRemoteChangesSync(
+      saved: [row(name: "Token", status: .priced, date: Self.tOlder)], deleted: [])
+
+    #expect(
+      try #require(try await stored(database)).pricingStatus
+        == TokenPricingStatus.spam.rawValue)
+  }
+
+  @Test("pricingStatus is exempt: a stale echo's .spam still wins over local .priced")
+  func pricingStatusExemptFromGate() async throws {
+    let (database, registry) = try makeRegistry()
+
+    // Current version is .priced at the newer date.
+    try registry.applyRemoteChangesSync(
+      saved: [row(name: "Token", status: .priced, date: Self.tNewer)], deleted: [])
+
+    // Stale echo (older date) carrying .spam: identity is date-rejected, but
+    // pricingStatus is NOT gated — spam wins through the merge.
+    try registry.applyRemoteChangesSync(
+      saved: [row(name: "Token", status: .spam, date: Self.tOlder)], deleted: [])
+
+    #expect(
+      try #require(try await stored(database)).pricingStatus
+        == TokenPricingStatus.spam.rawValue)
+  }
+
+  @Test("within one batch: identity ends newest and pricingStatus stays sticky (order A)")
+  func withinBatchNewestIdentityAndStickySpamOrderA() async throws {
+    try await assertWithinBatch(reversed: false)
+  }
+
+  @Test("within one batch: identity ends newest and pricingStatus stays sticky (order B)")
+  func withinBatchNewestIdentityAndStickySpamOrderB() async throws {
+    try await assertWithinBatch(reversed: true)
+  }
+
+  /// Delivers a same-batch `[older .spam, newer .priced]` pair (in either
+  /// array order) and asserts the identity fields converge to the newer
+  /// version while `pricingStatus` stays sticky `.spam` — the instrument
+  /// site is within-batch-correct WITHOUT dedup because the per-row
+  /// fetchOne + merge + upsert loop folds every duplicate's status.
+  private func assertWithinBatch(reversed: Bool) async throws {
+    let (database, registry) = try makeRegistry()
+    let older = row(name: "Placeholder", status: .spam, date: Self.tOlder)
+    let newer = row(name: "RealToken", status: .priced, date: Self.tNewer)
+    let batch = reversed ? [newer, older] : [older, newer]
+
+    try registry.applyRemoteChangesSync(saved: batch, deleted: [])
+
+    let result = try #require(try await stored(database))
+    #expect(result.name == "RealToken")
+    #expect(result.pricingStatus == TokenPricingStatus.spam.rawValue)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
@@ -1,5 +1,4 @@
-// MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
-
+@preconcurrency import CloudKit
 import Foundation
 import GRDB
 import Testing
@@ -180,5 +179,71 @@ struct GRDBInstrumentRegistryRollbackTests {
     let surviving = try #require(try registry.fetchRowSync(id: eth.id))
     #expect(surviving.pricingStatus == TokenPricingStatus.spam.rawValue)
     #expect(surviving.coingeckoId == "ethereum")
+  }
+
+  /// Rollback contract for the issue-#1085 stale-echo branch of
+  /// `applyRemoteChangesSync`. When a stale echo (older `modificationDate`)
+  /// carries a `pricingStatus` that the merge resolves to a *different*
+  /// value, the gate writes ONLY `pricing_status` via a partial `updateAll`
+  /// (identity/mapping fields are date-gated out). If a later row in the
+  /// same batch throws, that partial write must roll back with the rest of
+  /// the transaction. Seeds a `.priced` row cached at the NEWER date so the
+  /// incoming older `.spam` echo takes the stale branch and fires the
+  /// `updateAll`, then trips a `BEFORE INSERT` trigger on a sentinel id.
+  @Test
+  func applyRemoteChangesSyncStaleEchoUpdateRollsBackOnFailure() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let zone = CKRecordZone.ID(zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+    let tOlder = Date(timeIntervalSince1970: 1_700_000_000)
+    let tNewer = Date(timeIntervalSince1970: 1_700_000_060)
+
+    let priorId = "1:0xabc"
+    let priorInstrument = Instrument.crypto(
+      chainId: 1, contractAddress: "0xabc", symbol: "PRE", name: "Prior", decimals: 18)
+    var prior = InstrumentRow(domain: priorInstrument)
+    prior.pricingStatus = TokenPricingStatus.priced.rawValue
+    prior.encodedSystemFields =
+      prior.toCKRecord(in: zone).withModificationDate(tNewer).encodedSystemFields
+    let priorRow = prior
+    try await database.write { database in try priorRow.insert(database) }
+
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_instrument_upsert
+          BEFORE INSERT ON instrument
+          WHEN NEW.id = '___FAIL___'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    // Stale echo (older date) carrying .spam → merge(.priced, .spam) = .spam,
+    // which differs from the stored .priced, so the stale branch fires the
+    // partial `updateAll(pricing_status = .spam)`.
+    var staleEcho = InstrumentRow(domain: priorInstrument)
+    staleEcho.pricingStatus = TokenPricingStatus.spam.rawValue
+    staleEcho.encodedSystemFields =
+      staleEcho.toCKRecord(in: zone).withModificationDate(tOlder).encodedSystemFields
+    var failing = InstrumentRow(
+      domain: Instrument.crypto(
+        chainId: 9, contractAddress: nil, symbol: "FAIL", name: "Fail", decimals: 18))
+    failing.id = "___FAIL___"
+    failing.recordName = "___FAIL___"
+
+    do {
+      try registry.applyRemoteChangesSync(saved: [staleEcho, failing], deleted: [])
+      Issue.record("applyRemoteChangesSync should have thrown but did not")
+    } catch {
+      // Expected — trigger raises ABORT mid-transaction.
+    }
+
+    // The partial pricing_status updateAll rolled back: status stays .priced.
+    let surviving = try #require(try registry.fetchRowSync(id: priorId))
+    #expect(surviving.pricingStatus == TokenPricingStatus.priced.rawValue)
+    #expect(try registry.fetchRowSync(id: "___FAIL___") == nil)
+    #expect(try registry.allRowIdsSync() == [priorId])
   }
 }

--- a/MoolahTests/Support/CKRecord+ModificationDateTestSupport.swift
+++ b/MoolahTests/Support/CKRecord+ModificationDateTestSupport.swift
@@ -1,0 +1,53 @@
+@preconcurrency import CloudKit
+import Foundation
+
+@testable import Moolah
+
+// Test-only helper for stamping a server `modificationDate` onto an
+// otherwise-local `CKRecord` (issue #1085). Production never stamps dates —
+// CloudKit assigns `modificationDate` server-side — but the sync tests
+// fabricate echoes via `row.toCKRecord(in:)`, which yields a fresh local
+// record with `modificationDate == nil`. With the modification-date gate
+// fully fail-open on `nil` dates, the loss reproductions can only exercise
+// the gate when the fabricated echoes carry distinct, realistic dates.
+//
+// The stamp writes the system-fields archive's `RecordMtime` key as a
+// `Date`, then re-applies the user fields (the encode/decode round-trip
+// drops them). Empirically verified end-to-end (design doc §6): the value
+// must be a `Date` (`Int64` / `Double` decode to `nil`), and it survives the
+// production `encodedSystemFields` → `fromEncodedSystemFields` secure-coding
+// round-trip the gate relies on.
+extension CKRecord {
+  func withModificationDate(_ date: Date) -> CKRecord {
+    let coder = NSKeyedArchiver(requiringSecureCoding: true)
+    encodeSystemFields(with: coder)
+    // `RecordMtime` is CKRecord's internal archive key for the server
+    // modification date. It is undocumented, so we assert the round-trip
+    // produced a non-nil `modificationDate` below — if Apple ever renames
+    // the key the helper fails loudly rather than silently fabricating a
+    // dateless record that would make a loss test pass for the wrong reason.
+    coder.encode(date as NSDate, forKey: "RecordMtime")
+    coder.finishEncoding()
+
+    let unarchiver: NSKeyedUnarchiver
+    do {
+      unarchiver = try NSKeyedUnarchiver(forReadingFrom: coder.encodedData)
+    } catch {
+      fatalError("withModificationDate: failed to build unarchiver: \(error)")
+    }
+    unarchiver.requiresSecureCoding = true
+    guard let stamped = CKRecord(coder: unarchiver) else {
+      fatalError("withModificationDate: failed to decode stamped CKRecord")
+    }
+    guard stamped.modificationDate != nil else {
+      fatalError(
+        "withModificationDate: RecordMtime did not survive the round-trip — "
+          + "Apple may have renamed the archive key")
+    }
+    // `encodeSystemFields` drops user fields, so re-apply them.
+    for key in allKeys() {
+      stamped[key] = self[key]
+    }
+    return stamped
+  }
+}

--- a/MoolahTests/Sync/ModificationDateGateTests.swift
+++ b/MoolahTests/Sync/ModificationDateGateTests.swift
@@ -1,0 +1,142 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Focused unit tests for the clean-path modification-date gate (issue
+/// #1085) on the per-profile-data handler, exercised through the real
+/// `applyRemoteChanges` entry point with `TransactionLeg` rows. Covers the
+/// gate decisions (reject older / reject tie / cached-date-advances), the
+/// regression-lock that the gate did NOT replace the dirty-path guard, and
+/// the §5f UUID-keyed within-batch dedup-to-max.
+@Suite("clean-path modification-date gate (issue #1085)")
+struct ModificationDateGateTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+  private static let tOlder = Date(timeIntervalSince1970: 1_700_000_000)
+  private static let tNewer = Date(timeIntervalSince1970: 1_700_000_060)
+
+  /// Seeds a clean leg row at `quantity`, caching system fields stamped at
+  /// `cachedDate`. Returns the row id.
+  @MainActor
+  private func seedCleanLeg(
+    _ harness: ProfileDataSyncHandlerTestSupport.HandlerHarness,
+    quantity: Int64,
+    cachedDate: Date
+  ) async throws -> UUID {
+    let id = UUID()
+    let repo = harness.handler.grdbRepositories.transactionLegs
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: UUID(), accountId: nil, quantity: quantity
+      ).insert(database)
+    }
+    let row = try #require(try repo.fetchRowSync(id: id))
+    _ = try repo.setEncodedSystemFieldsSync(
+      id: id,
+      data: row.toCKRecord(in: Self.zoneID).withModificationDate(cachedDate).encodedSystemFields)
+    return id
+  }
+
+  private func legEcho(id: UUID, quantity: Int64, date: Date) -> CKRecord {
+    ProfileDataSyncHandlerTestSupport.transactionLegRow(
+      id: id, transactionId: UUID(), accountId: nil, quantity: quantity
+    ).toCKRecord(in: Self.zoneID).withModificationDate(date)
+  }
+
+  private func quantity(
+    _ harness: ProfileDataSyncHandlerTestSupport.HandlerHarness, id: UUID
+  ) async throws -> Int64? {
+    try await harness.database.read { try TransactionLegRow.fetchOne($0, key: id)?.quantity }
+  }
+
+  @Test("clean row rejects an echo older than its cached version")
+  func cleanPathRejectsOlderEcho() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = try await seedCleanLeg(harness, quantity: 200, cachedDate: Self.tNewer)
+
+    _ = harness.handler.applyRemoteChanges(
+      saved: [legEcho(id: id, quantity: 1, date: Self.tOlder)], deleted: [])
+
+    #expect(try await quantity(harness, id: id) == 200)
+  }
+
+  @Test("clean row rejects an echo with a tied modification date (reject-on-tie)")
+  func cleanPathRejectsTie() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = try await seedCleanLeg(harness, quantity: 200, cachedDate: Self.tOlder)
+
+    _ = harness.handler.applyRemoteChanges(
+      saved: [legEcho(id: id, quantity: 1, date: Self.tOlder)], deleted: [])
+
+    #expect(try await quantity(harness, id: id) == 200)
+  }
+
+  @Test("dirty row keeps its unsent local edit against a newer-dated peer change")
+  func dirtyRowGuardSurvivesNewerPeerChange() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let repo = harness.handler.grdbRepositories.transactionLegs
+    // Unsent local edit: dirty row at qty 200, cached at the older acked date.
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: UUID(), accountId: nil, quantity: 200
+      ).insert(database)
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+    let row = try #require(try repo.fetchRowSync(id: id))
+    _ = try repo.setEncodedSystemFieldsSync(
+      id: id,
+      data: row.toCKRecord(in: Self.zoneID).withModificationDate(Self.tOlder).encodedSystemFields)
+
+    // A genuine, strictly-NEWER peer change must NOT overwrite the unsent
+    // local edit — the dirty-path guard, not the date gate, protects it.
+    _ = harness.handler.applyRemoteChanges(
+      saved: [legEcho(id: id, quantity: 500, date: Self.tNewer)], deleted: [])
+
+    #expect(try await quantity(harness, id: id) == 200)
+  }
+
+  @Test("cached date advances on apply, so a later stale echo is rejected")
+  func cachedDateAdvancesOnApply() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = try await seedCleanLeg(harness, quantity: 100, cachedDate: Self.tOlder)
+
+    // Genuine newer change applies and advances the cached date to tNewer.
+    _ = harness.handler.applyRemoteChanges(
+      saved: [legEcho(id: id, quantity: 500, date: Self.tNewer)], deleted: [])
+    #expect(try await quantity(harness, id: id) == 500)
+
+    // A stale echo at tOlder (< the now-cached tNewer) is rejected.
+    _ = harness.handler.applyRemoteChanges(
+      saved: [legEcho(id: id, quantity: 100, date: Self.tOlder)], deleted: [])
+    #expect(try await quantity(harness, id: id) == 500)
+  }
+
+  @Test("within one batch the newest-dated version wins even when not last in the array")
+  func withinBatchDedupToMaxKeepsNewest() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    // First-sync clean row (nil cached date → fail-open), so the within-batch
+    // dedup-to-max is the only thing deciding which version lands.
+    let id = UUID()
+    // Newest (tNewer, qty 500) appears BEFORE the older (tOlder, qty 1) in the array.
+    let newest = legEcho(id: id, quantity: 500, date: Self.tNewer)
+    let older = legEcho(id: id, quantity: 1, date: Self.tOlder)
+
+    _ = harness.handler.applyRemoteChanges(saved: [newest, older], deleted: [])
+
+    #expect(try await quantity(harness, id: id) == 500)
+  }
+}

--- a/MoolahTests/Sync/NeedsPushOutOfOrderEchoLossTests.swift
+++ b/MoolahTests/Sync/NeedsPushOutOfOrderEchoLossTests.swift
@@ -1,0 +1,218 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Reproduces the REAL single-device data-loss race that survives both the
+/// #1081 apply guard AND the #1081-follow-up ack-clear deferral (PR #1084),
+/// and is closed by the #1085 modification-date gate on the clean apply path.
+///
+/// The #1084 fix rested on one load-bearing assumption, stated verbatim in
+/// `ProfileDataSyncHandler+SystemFields.swift` and `+ApplyGuard.swift`:
+///
+///   > the flag stays set and is cleared later by the fetch/apply path when
+///   > the *confirming* echo of the current version arrives — safe because
+///   > CKSyncEngine delivers fetched changes in server-token order, so every
+///   > earlier-token stale echo has already been processed by then.
+///
+/// That assumption is FALSE under a heavy upload/echo backlog. When a record
+/// is created (V_create) and then updated (V_update) while sync is busy, the
+/// two versions upload as *separate* in-flight batches. Their echoes do NOT
+/// arrive in a single monotonic server-token stream — a save-completion echo,
+/// a conflict-loser echo, and an independent fetch operation each carry their
+/// own delivery, and under load the *newer* version's confirming echo can be
+/// applied BEFORE the *older* version's stale echo.
+///
+/// Losing interleaving (single device, no peers):
+///   1. create V_create, `needs_push = 1`, uploaded in batch N.
+///   2. update → V_update, `needs_push = 1` re-raised, uploaded in batch M.
+///   3. The CONFIRMING echo of V_update is applied first. The apply path's
+///      `clearNeedsPushForConfirmingEchoes` sees `current(V_update) ==
+///      echo(V_update)` and CLEARS `needs_push`. Row is now clean.
+///   4. The STALE echo of V_create — still queued from batch N's separate
+///      delivery — is applied LAST. The row is clean, so it would take the
+///      normal upsert path and clobber V_update back to V_create — UNLESS
+///      the modification-date gate rejects it: V_create's echo carries an
+///      OLDER server `modificationDate` than the cached V_update version,
+///      so the gate skips it and the newer edit survives.
+///
+/// This is the production symptom: a leg created as a placeholder
+/// (AUD/income/qty 1) then updated to a real token leg reverts to the
+/// placeholder; whole accounts end with only placeholder legs.
+///
+/// **#1085 amendment (design §5a).** As originally written the spec test
+/// fabricated both echoes via `row.toCKRecord(in:)`, which builds a fresh
+/// local `CKRecord` with `modificationDate == nil`. The gate fails open on
+/// `nil` dates, so the stale echo would still apply and the loss would still
+/// reproduce even with the fix. The echoes therefore carry distinct server
+/// dates (`T_create < T_update`) via the test-only `withModificationDate`
+/// helper, exactly as production does.
+@Suite("needs_push survives an out-of-order echo under backlog (single-device loss)")
+struct NeedsPushOutOfOrderEchoLossTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  /// Distinct server modification dates: V_create is older, V_update newer.
+  private static let tCreate = Date(timeIntervalSince1970: 1_700_000_000)
+  private static let tUpdate = Date(timeIntervalSince1970: 1_700_000_060)
+
+  /// Drives a leg through the REAL create→update repository flow so
+  /// `needs_push` and the cached system fields are left exactly as
+  /// production leaves them, then delivers the V_update confirming echo and
+  /// the V_create stale echo OUT OF ORDER (newer first) the way a heavy
+  /// backlog does.
+  @Test("TransactionLeg: V_update survives a V_update-echo-then-stale-V_create-echo")
+  func legUpdateSurvivesOutOfOrderEcho() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let transactionId = UUID()
+    let repo = harness.handler.grdbRepositories.transactionLegs
+
+    // create (V_create): placeholder AUD/income, quantity 1, dirty.
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: transactionId, accountId: nil, quantity: 1
+      ).insert(database)
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+    let vCreateRow = try #require(try repo.fetchRowSync(id: id))
+    // ack of V_create caches its (non-nil) server system fields; this is
+    // the version that will echo back stale, stamped with the OLDER date.
+    let vCreateEcho = vCreateRow.toCKRecord(in: Self.zoneID).withModificationDate(Self.tCreate)
+    _ = try repo.setEncodedSystemFieldsSync(id: id, data: vCreateEcho.encodedSystemFields)
+
+    // update → V_update: real token quantity 200, dirty again.
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == id)
+        .updateAll(database, [TransactionLegRow.Columns.quantity.set(to: 200)])
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+    let vUpdateRow = try #require(try repo.fetchRowSync(id: id))
+    let vUpdateEcho = vUpdateRow.toCKRecord(in: Self.zoneID).withModificationDate(Self.tUpdate)
+
+    // --- Heavy-backlog OUT-OF-ORDER delivery ---
+    // (3) The confirming echo of V_update arrives FIRST and clears the flag,
+    //     advancing the cached date to T_update.
+    let confirm = harness.handler.applyRemoteChanges(saved: [vUpdateEcho], deleted: [])
+    if case .saveFailed(let message) = confirm { Issue.record("confirm save failed: \(message)") }
+
+    // (4) The stale echo of V_create arrives LAST, on a now-clean row;
+    //     its older date is rejected by the gate.
+    let stale = harness.handler.applyRemoteChanges(saved: [vCreateEcho], deleted: [])
+    if case .saveFailed(let message) = stale { Issue.record("stale save failed: \(message)") }
+
+    let row = try await harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: id)
+    }
+    // The newer local edit must survive the out-of-order stale echo.
+    #expect(try #require(row).quantity == 200)
+  }
+
+  /// The same loss embedded in a HEAVY batch: hundreds of unrelated rows
+  /// applied alongside the out-of-order echoes, modelling the ~514-record
+  /// import upload backlog that triggers the real loss across many accounts.
+  @Test("TransactionLeg: V_update survives out-of-order echo amid a 200-record batch")
+  func legUpdateSurvivesOutOfOrderEchoUnderBatchLoad() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let transactionId = UUID()
+    let repo = harness.handler.grdbRepositories.transactionLegs
+
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: transactionId, accountId: nil, quantity: 1
+      ).insert(database)
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+    let vCreateRow = try #require(try repo.fetchRowSync(id: id))
+    let vCreateEcho = vCreateRow.toCKRecord(in: Self.zoneID).withModificationDate(Self.tCreate)
+    _ = try repo.setEncodedSystemFieldsSync(id: id, data: vCreateEcho.encodedSystemFields)
+
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == id)
+        .updateAll(database, [TransactionLegRow.Columns.quantity.set(to: 200)])
+      try repo.markNeedsPushSync(id: id, in: database)
+    }
+    let vUpdateRow = try #require(try repo.fetchRowSync(id: id))
+    let vUpdateEcho = vUpdateRow.toCKRecord(in: Self.zoneID).withModificationDate(Self.tUpdate)
+
+    // A large batch of unrelated incoming legs (the import backlog echoing).
+    let backlog: [CKRecord] = (0..<200).map { index in
+      ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: UUID(), transactionId: UUID(), accountId: nil, quantity: Int64(index)
+      ).toCKRecord(in: Self.zoneID)
+    }
+
+    // Confirming V_update echo lands inside a heavy batch; flag cleared.
+    let confirm = harness.handler.applyRemoteChanges(saved: backlog + [vUpdateEcho], deleted: [])
+    if case .saveFailed(let message) = confirm { Issue.record("confirm save failed: \(message)") }
+
+    // Stale V_create echo lands in a later heavy batch, on a clean row.
+    let stale = harness.handler.applyRemoteChanges(saved: [vCreateEcho] + backlog, deleted: [])
+    if case .saveFailed(let message) = stale { Issue.record("stale save failed: \(message)") }
+
+    let row = try await harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: id)
+    }
+    #expect(try #require(row).quantity == 200)
+  }
+
+  /// The constraint that defeats every single-cached-tag fix: a CLEAN,
+  /// already-synced row (non-nil cached system fields) receiving a
+  /// GENUINE remote change from a peer device MUST apply it. A stale
+  /// self-echo and a genuine peer change are both "clean row, cached
+  /// blob present, incoming fields differ" — they are distinguished only
+  /// by `modificationDate`: the genuine peer change is strictly NEWER, so
+  /// the gate applies it. This test must stay green.
+  ///
+  /// **#1085 amendment (design §5b).** The cached version carries an older
+  /// stamped date and the peer change a strictly-newer one, so this exercises
+  /// the gate's "newer → apply" branch explicitly rather than the `nil`
+  /// fail-open.
+  @Test("a clean, already-synced row still applies a genuine remote change")
+  func syncedCleanRowAppliesGenuineRemoteChange() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let id = UUID()
+    let transactionId = UUID()
+    let repo = harness.handler.grdbRepositories.transactionLegs
+
+    // Locally-synced clean row at quantity 100 with cached system fields
+    // stamped at the OLDER date.
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: transactionId, accountId: nil, quantity: 100
+      ).insert(database)
+    }
+    let localRow = try #require(try repo.fetchRowSync(id: id))
+    _ = try repo.setEncodedSystemFieldsSync(
+      id: id,
+      data: localRow.toCKRecord(in: Self.zoneID).withModificationDate(Self.tCreate)
+        .encodedSystemFields)
+    // needs_push stays 0 (clean — fully round-tripped).
+
+    // A peer device's genuine update: quantity 500, stamped with a NEWER date.
+    let remote = ProfileDataSyncHandlerTestSupport.transactionLegRow(
+      id: id, transactionId: transactionId, accountId: nil, quantity: 500
+    ).toCKRecord(in: Self.zoneID).withModificationDate(Self.tUpdate)
+
+    let result = harness.handler.applyRemoteChanges(saved: [remote], deleted: [])
+    if case .saveFailed(let message) = result { Issue.record("save failed: \(message)") }
+
+    let row = try await harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: id)
+    }
+    #expect(try #require(row).quantity == 500)
+  }
+}

--- a/MoolahTests/Sync/ProfileIndexOutOfOrderEchoTests.swift
+++ b/MoolahTests/Sync/ProfileIndexOutOfOrderEchoTests.swift
@@ -1,0 +1,65 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Reproduction for the #1085 out-of-order self-echo loss on the
+/// profile-index zone's profile apply path (`applyProfilesGuarded`). A
+/// profile created then renamed under backlog must not revert to its
+/// created name when the stale V_create echo lands after the eager
+/// index-zone `needs_push` ack-clear.
+@Suite("profile-index out-of-order echo gate (issue #1085)")
+@MainActor
+struct ProfileIndexOutOfOrderEchoTests {
+  private static let tOlder = Date(timeIntervalSince1970: 1_700_000_000)
+  private static let tNewer = Date(timeIntervalSince1970: 1_700_000_060)
+  private static let createdAt = Date(timeIntervalSince1970: 1_600_000_000)
+
+  @Test("a renamed profile survives a V_update-echo-then-stale-V_create-echo")
+  func renameSurvivesOutOfOrderEcho() throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let repository = GRDBProfileIndexRepository(database: database)
+    let handler = ProfileIndexSyncHandler(repository: repository)
+    let id = UUID()
+
+    // V_create: created profile "Old Profile", dirty, cached at tOlder.
+    let vCreate = ProfileRow(
+      id: id,
+      recordName: ProfileRow.recordName(for: id),
+      label: "Old Profile",
+      currencyCode: "AUD",
+      financialYearStartMonth: 7,
+      createdAt: Self.createdAt,
+      encodedSystemFields: nil)
+    try repository.applyRemoteChangesSync(saved: [vCreate], deleted: [])
+    try repository.markNeedsPushSync(id: id)
+    let vCreateEcho = vCreate.toCKRecord(in: handler.zoneID).withModificationDate(Self.tOlder)
+    _ = try repository.setEncodedSystemFieldsSync(id: id, data: vCreateEcho.encodedSystemFields)
+
+    // V_update: rename to "New Profile" (preserve the cached blob — update
+    // only the label column), dirty again.
+    try database.write { database in
+      _ =
+        try ProfileRow
+        .filter(ProfileRow.Columns.id == id)
+        .updateAll(database, [ProfileRow.Columns.label.set(to: "New Profile")])
+    }
+    try repository.markNeedsPushSync(id: id)
+    let current = try #require(try repository.fetchRowSync(id: id))
+    let vUpdateEcho = current.toCKRecord(in: handler.zoneID).withModificationDate(Self.tNewer)
+
+    // (3) Confirming echo of V_update arrives first: row dirty → system-fields
+    //     only, advancing the cached date to tNewer.
+    _ = handler.applyRemoteChanges(saved: [vUpdateEcho], deleted: [])
+    // Eager index-zone ack-clear makes the row clean.
+    handler.clearNeedsPushForConfirmed([vUpdateEcho])
+
+    // (4) Stale V_create echo arrives last on the now-clean row; its older
+    //     date is rejected by the gate.
+    _ = handler.applyRemoteChanges(saved: [vCreateEcho], deleted: [])
+
+    #expect(try #require(try repository.fetchRowSync(id: id)).label == "New Profile")
+  }
+}

--- a/plans/1085-sync-out-of-order-echo-fix.md
+++ b/plans/1085-sync-out-of-order-echo-fix.md
@@ -1,0 +1,601 @@
+# #1085 — Out-of-order self-echo data loss: root cause & fix design
+
+Status: **proposal** (design only — no implementation in this doc)
+Issue: https://github.com/moolah-rocks/moolah-native/issues/1085
+Worktree: `.claude/worktrees/fix-1085-sync-echo` (checked out at `main`, post-#1084)
+Failing spec test: `origin/spec/sync-out-of-order-echo-loss:MoolahTests/Sync/NeedsPushOutOfOrderEchoLossTests.swift`
+
+---
+
+## 1. Root cause (mechanism-level)
+
+A record that is **created then quickly updated** while the sync engine has a
+heavy upload/echo backlog can revert to its *created* version because a **stale
+self-echo of the earlier version is applied out of delivery order** onto a row
+that is no longer protected.
+
+Precise sequence (single device, no peers — the production symptom: a leg
+created as an AUD/income/qty-1 placeholder `V_create`, updated to a real token
+leg `V_update`, reverts to the placeholder):
+
+1. `V_create` is written locally, `needs_push = 1`, uploaded in batch *N*.
+   On ack, its server system fields (carrying server `modificationDate`
+   `T_create`) are cached in the row's `encoded_system_fields`.
+2. The row is edited to `V_update`, `needs_push = 1` re-raised, uploaded in a
+   **separate** in-flight batch *M*. Its server version has `modificationDate`
+   `T_update > T_create`.
+3. Under backlog the **confirming echo of `V_update` is fetched/applied first**.
+   In `applyBatchSaves` the row is dirty, so it takes the
+   system-fields-only + `clearNeedsPushForConfirmingEchoes` path; the field
+   compare matches (`current(V_update) == echo(V_update)`) → **`needs_push` is
+   cleared**. The row is now *clean*.
+4. The **stale echo of `V_create`** (still queued from batch *N*'s separate
+   delivery) is fetched/applied **last**. The row is clean, so `splitByDirtiness`
+   routes it to the normal `applyGRDBBatchSave` upsert, which **clobbers all
+   user fields back to `V_create`**. `V_update` is lost.
+
+### Why every prior fix only moved the window
+
+- **#1079** main-actor pre-snapshot guard — relocated, not closed.
+- **#1081 / #1083** transactional in-apply `needs_push` read
+  (`splitByDirtiness`) — protects a row *only while it is still dirty*. Step 4
+  lands on a *clean* row, so the guard does not engage.
+- **#1084** moved the `needs_push` clear off the upload-ack and onto the
+  confirming-echo apply path (`clearNeedsPushForConfirmingEchoes`).
+
+#### The false assumption that all three share
+
+`ProfileDataSyncHandler+SystemFields.swift` (`clearNeedsPushForConfirmed` doc)
+and `+ApplyGuard.swift` (`clearNeedsPushForConfirmingEchoes` doc) both state,
+verbatim:
+
+> …safe because CKSyncEngine delivers fetched changes in server-token order, so
+> every earlier-token stale echo has already been processed by then.
+
+**This is false.** Apple explicitly does *not* guarantee fetched-change
+ordering (see §7 citations). The clear in step 3 therefore can — and under
+backlog does — happen *before* the step-4 stale echo, reopening the clean-path
+upsert window. The bug is not "where we clear `needs_push`"; it is that **the
+clean apply path has no defence against applying a superseded version**. All
+four prior fixes guard the *dirty* window; none guards the *clean* path, which
+is where the loss actually happens.
+
+### The same hole exists on the profile-index zone (added after adversary review — I-1)
+
+The per-profile-data handler is **not the only** clean apply path. The
+`ProfileIndexSyncHandler` (profile-index zone) has the identical
+"clean-row upsert with no version check" shape at **three** sub-sites
+(verified against the worktree):
+
+- **Profiles — `applyProfilesGuarded`** (`+NeedsPush.swift:24-45`): same shape
+  as the per-profile-data clean path — `dirtyIdsSync → filter clean →
+  applyRemoteChangesSync(saved: clean)` with **no** modification-date gate. A
+  profile created→renamed under backlog reverts identically.
+- **Profiles — index-zone ack-clear** (`clearNeedsPushForConfirmed`,
+  `+NeedsPush.swift:60-81`): has **no** `preAckCached == nil` gate (unlike the
+  #1084 per-profile-data version), so profile rows clear `needs_push` *more
+  eagerly* and reach the unguarded clean path sooner.
+- **Instruments — `applyRemoteChanges`** (`ProfileIndexSyncHandler.swift:115-129`):
+  applies instrument rows via `instrumentRepository.applyRemoteChangesSync(
+  saved:deleted:)` **unconditionally** — no dirty split, no date gate, a full
+  server-wins `row.upsert` of every column except `pricingStatus`. Every stale
+  instrument echo clobbers all identity/mapping fields.
+  **This is the worst case and is directly on the crypto-migration critical
+  path:** the migration registers/updates instruments (`register-instrument`,
+  and `pricingStatus` mutations) through exactly this path, so an instrument
+  create→update reverts under the same backlog that motivates #1085.
+
+The fix must therefore cover **all three** clean-apply sites, not just
+`applyBatchSaves`. See §2 "Index-zone sites".
+
+---
+
+## 2. The fix
+
+### Signal that distinguishes a stale echo from a genuine change
+
+`CKRecord.recordChangeTag` is opaque and unorderable (§7), so it cannot order
+two versions. But **`CKRecord.modificationDate` can**: it is **server-assigned
+and monotonically increasing per record** across that record's saves, and it is
+present on every full record CloudKit delivers (it lives in the system-fields
+blob — encoded under the archive key `RecordMtime`; verified empirically, §6).
+
+Crucially we only ever compare **two versions of the *same* record**, both
+timestamped by the **same server clock** — so cross-device clock skew is
+irrelevant, and we never compare dates across different records.
+
+This is exactly Apple's canonical defence `setLastKnownRecordIfNewer()`, applied
+at every apply site in `apple/sample-cloudkit-sync-engine` (§7): *adopt the
+incoming record only when it is newer by `modificationDate`; otherwise "the
+other record is older than the one we already have."*
+
+### Apply-site change (the core fix)
+
+In `applyBatchSaves` (`ProfileDataSyncHandler+ApplyRemoteChanges.swift`), add a
+**modification-date gate on the clean path**, alongside the existing
+`splitByDirtiness`:
+
+```
+for (recordType, ckRecords) in grouped {
+  ids        = ckRecords.compactMap(uuid)
+  dirty      = dirtyIds(recordType, ids, in: db)
+  cachedMod  = cachedModificationDates(recordType, ids, in: db)   // NEW: id -> Date?
+  (clean, echoed) = splitByDirtiness(ckRecords, dirty)
+
+  // NEW — reject superseded echoes on the clean path:
+  (applicable, staleRejected) = splitByModificationDate(clean, incoming, cachedMod)
+
+  if !echoed.isEmpty { …system-fields-only + clearNeedsPushForConfirmingEchoes… }  // unchanged
+  applyGRDBBatchSave(recordType, applicable, systemFields, in: db)                 // was: clean
+  // staleRejected: skip entirely — older than what we hold; do NOT regress fields
+  //                and do NOT adopt their (older) system fields.
+}
+```
+
+`splitByModificationDate` decision per clean record (let `inc =
+record.modificationDate`, `cur = cachedMod[id]`):
+
+| `cur` (cached) | `inc` (incoming) | decision | rationale |
+|---|---|---|---|
+| `nil` | any | **apply** | first server version for this row — nothing to protect (fail-open) |
+| non-nil | `nil` | **apply** | defensive fail-open; fetched records always carry a date, so unreachable in production — see §4 |
+| non-nil | `inc > cur` | **apply** | strictly newer — genuine forward progress |
+| non-nil | `inc <= cur` | **reject** | older-or-equal → superseded stale echo |
+
+The cached date is read from the row's existing `encoded_system_fields` blob
+**inside the same write transaction** (decode → `.modificationDate`). The
+in-transaction reader already exists as
+`cachedSystemFields(recordType:id:in:)` in
+`+CurrentRecordInTransaction.swift`; add a batched
+`cachedModificationDates(recordType:ids:in:)` (one `WHERE id IN (…)` per type)
+to keep the gate O(1) queries per record type rather than O(rows).
+
+Because `applyGRDBBatchSave` stamps the row's cached blob **from the applied
+record's own system fields** (via the `systemFields` lookup built from each
+incoming `record.encodedSystemFields`), the cached date **advances to the
+applied version's date on every apply** — so once a device holds `V_final`, no
+older echo can pass the gate again.
+
+### Why this closes the bug independent of `needs_push` clear timing
+
+Step 4 of §1: the stale `V_create` echo has `inc = T_create`; the row's cached
+date is now `T_update` (set when the `V_update` echo was applied in step 3).
+`T_create < T_update` → **rejected**. The premature `needs_push` clear in step 3
+is now irrelevant to correctness — the date gate is the load-bearing guarantee.
+This is **defence-in-depth**: it does not depend on fetch ordering, on
+`needs_push`, or on the confirming-echo clear.
+
+### Interaction with the existing `needs_push` machinery — it **stays**
+
+`needs_push` keeps two distinct jobs, both still required:
+
+1. **Upload driver.** It is what tells CKSyncEngine (via
+   `pendingRecordZoneChanges`) there is an unsent local edit. Unchanged.
+2. **Unsent-local-edit apply guard.** While a local edit is written but **not
+   yet uploaded**, the row's cached date is still the *old* acked version's
+   (`V_update` has no server date yet). A genuine **peer** change with a newer
+   date would *pass* a date-only gate and **overwrite the un-uploaded local
+   edit** — data loss of the local edit. The dirty path
+   (`splitByDirtiness` → system-fields-only, fields untouched) is what prevents
+   that, deferring resolution to the normal upload/`serverRecordChanged`
+   conflict path. The date gate **cannot** replace this; it complements it.
+
+So the layering is:
+
+- **Dirty row (unsent local edit):** protected by `needs_push` (fields never
+  overwritten). *Unchanged.*
+- **Clean row (fully round-tripped):** protected by the **new date gate**
+  (older-or-equal echoes rejected). *This is the fix.*
+
+The `#1084` `clearNeedsPushForConfirmingEchoes` clear **stays** (it is harmless
+and still correct), but its **load-bearing rationale changes**: it no longer
+relies on fetch-order. The false "server-token order" sentences in
+`+ApplyGuard.swift` and `+SystemFields.swift` must be **rewritten** to cite the
+date gate as the actual guarantee. (Optional, out-of-scope follow-up: with the
+date gate in place, the ack-clear's `preAckCached == nil` gating in
+`clearNeedsPushForConfirmed` is no longer needed for safety and could be
+simplified — call out but do not do here.)
+
+The dirty path's system-fields-only write is left as-is. Adopting an older
+tag there is at worst a harmless extra `serverRecordChanged` on the next upload
+(self-healing), never data loss; a no-regress check there is optional hardening.
+
+### Index-zone sites (added after adversary review — I-1)
+
+The same strict-`>` modification-date gate extends to the profile-index zone.
+**Verified prerequisite:** both `ProfileRow` and `InstrumentRow` persist
+`encoded_system_fields` and `partitionSaved` copies each incoming record's blob
+onto the converted row (`+Instruments.swift:27,36`), so for both types a cached
+date is **readable** (from the stored row's blob) and **advances on apply** (the
+applied row's blob is written by the upsert). The gate is therefore feasible at
+all three sites without new schema.
+
+**Profiles (`applyProfilesGuarded`).** UUID-keyed, and the row already has a
+`needs_push` dirty guard. Mirror the per-profile-data design exactly: keep the
+dirty split, and add the date gate to the **clean** subset before
+`applyRemoteChangesSync(saved: clean)` — apply a clean profile row only if its
+incoming `modificationDate` is strictly `>` the stored row's cached date
+(`nil` cached → apply). The eager index-zone ack-clear (no `preAckCached==nil`
+gate) becomes safe for the same reason the per-profile-data clear does: the
+clean-path date gate is now the load-bearing guarantee, so the earlier clear no
+longer matters. (Optionally align it with the per-profile-data gating; not
+required once the date gate is in.)
+
+**Instruments (`GRDBInstrumentRegistryRepository.applyRemoteChangesSync`).**
+String-keyed (by `id`, e.g. `"AUD"`, contract address); **no `needs_push`
+column** — instruments use field-level merges instead, not a dirty guard. The
+gate piggybacks on the `fetchOne(existing)` the method **already performs** for
+the `pricingStatus` merge:
+
+```
+for each incoming row:
+  existing = fetchOne(id)                       // already done today
+  merged   = PricingStatusMerge(local: existing?.pricingStatus, incoming: row)  // already done
+  curDate  = existing?.encodedSystemFields → modificationDate
+  incDate  = row.encodedSystemFields → modificationDate
+  if existing != nil && curDate != nil && incDate != nil && incDate <= curDate {
+     // STALE echo: do NOT revert identity/mapping fields, do NOT regress blob.
+     // BUT still apply the pricingStatus merge result (see below).
+     if merged != existing.pricingStatus {            // M-6: skip the no-op write
+       write ONLY pricing_status = merged on the existing row
+     }
+  } else {
+     row.pricingStatus = merged; row.upsert(database)   // current behaviour
+  }
+```
+
+**`pricingStatus` is exempted from the date gate — this is essential.**
+`PricingStatusMerge` is a deliberately **recency-independent** field CRDT (a
+user's `.spam` classification is *sticky* and must survive an auto-resolver's
+later `.priced` from another device — that is the whole reason the merge
+exists). A naive *record-level* date gate that rejected a stale echo wholesale
+would skip that merge and could leave two devices **divergent** on
+`pricingStatus` (one `.spam`, one `.priced`). So the gate governs only the
+**identity / provider-mapping fields and the cached system-fields blob** (the
+fields that actually revert under #1085); `pricingStatus` always flows through
+its existing merge regardless of record date. This both fixes the identity
+reversion **and** preserves spam-stickiness convergence.
+
+Note instruments have no `needs_push`, so there is no dirty-path guard to
+preserve here — the date gate is purely additive (it can only *reduce*
+clobbering relative to today's unconditional server-wins upsert), so it cannot
+introduce a new local-edit loss.
+
+---
+
+## 3. Multi-device convergence argument
+
+Claim: every device converges to `V_final` (the highest-`modificationDate`
+server version) regardless of fetch delivery order.
+
+1. The server assigns a **total order** of `modificationDate`s per record across
+   its saves; `V_final` has the maximum.
+2. A device applies an incoming version on the clean path **iff** it is strictly
+   newer than the version it currently holds. Applying advances the cached date
+   to the applied version (§2).
+3. Therefore a device's held version is **monotonically non-decreasing** in
+   `modificationDate`: it never moves backward (older/equal rejected) and only
+   moves forward to strictly-newer versions.
+4. CKSyncEngine **eventually** delivers `V_final` to every device (delivery is
+   guaranteed; only *order* is not). When it arrives it is ≥ everything the
+   device has seen, so it is applied (or is already held).
+5. Stale/superseded echoes delivered before or after `V_final` are rejected and
+   cannot revert it.
+6. Unsent local edits upload, become a server version with a new maximum date,
+   echo back, and all devices converge to that. Concurrent peer edits resolve by
+   server acceptance order (last writer gets the maximum date) → all converge.
+
+Convergence depends only on the **server's per-record date total order**, never
+on delivery order — which is precisely the property #1084 wrongly assumed of
+fetch tokens, now correctly sourced from `modificationDate`.
+
+**Instruments split into two converging layers:** identity/mapping fields
+converge by the date gate exactly as above (to `V_final`); `pricingStatus`
+converges by its own `PricingStatusMerge` CRDT, which is intentionally
+recency-independent (sticky `.spam`) and is **not** subject to the date gate
+(§2). The two are orthogonal columns, so each converges on its own rule.
+
+Residual: see §4 (the equal-date tie).
+
+---
+
+## 4. Modification-date tie / granularity / clock-skew analysis
+
+- **Clock skew: not applicable.** `modificationDate` is **server-assigned**;
+  every version of a given record is timestamped by the same server clock, and
+  we only ever compare versions of the *same* record. No device clock is
+  involved. This is strictly safer than any local-timestamp scheme.
+
+- **Granularity.** `modificationDate` is sub-second. Two *sequential* saves of
+  the same record are two separate server round-trips, so in practice they
+  receive **distinct** timestamps. The real bug (`T_create` vs `T_update`) is a
+  strict inequality; the gate fixes it with the common `inc < cur` branch.
+
+- **The tie (`inc == cur`, fields differ).** Two genuinely different versions
+  sharing one `modificationDate` is near-unreachable for sequential saves but
+  not provably impossible. Chosen tie-breaker: **reject on tie** (apply only on
+  strict `>`). Justification:
+  - For the **stale-echo** case a tie is *correct to reject* (the echo is the
+    superseded version; rejecting preserves the newer local/cached version).
+  - The only cost is the symmetric **false negative**: a genuine peer change
+    that happens to share the cached version's exact server timestamp is
+    dropped → temporary single-record **divergence**, **not data loss**, and it
+    **self-heals** on that record's next modification (which gets a newer date)
+    or any full re-fetch.
+  - Per the project's non-negotiable "data loss" bar, a self-healing
+    divergence that requires a same-instant collision is strictly preferable to
+    reopening a silent data-loss window (which `>=` would do).
+
+  This residual is the single thing I most want the adversary to attack. A
+  stronger-but-heavier alternative (not proposed): on an equal-date / differing
+  -fields collision, treat it as a conflict and force a re-push rather than
+  silently keep the local copy. Flagged, not chosen, to avoid over-engineering.
+
+- **`nil` dates.** Fail-open (apply) — see the §2 table. Fetched server records
+  always carry a date; a `nil` incoming date is unreachable in production, and
+  failing open avoids ever rejecting a real change because of a missing date.
+  (Consequence: the spec tests, which fabricate dateless records, **must** stamp
+  real dates to exercise the gate — see §5.)
+
+---
+
+## 5. Test changes
+
+### 5a. `NeedsPushOutOfOrderEchoLossTests` — **must carry real modification dates**
+
+As written the spec test fabricates both echoes via `row.toCKRecord(in:)`,
+which builds a **fresh local `CKRecord` with `modificationDate == nil`**
+(verified §6). With the date gate, `nil` cached date → fail-open → the stale
+echo is still applied → **the loss tests would still fail even with the fix**.
+The tests therefore *must* be amended so `V_create` and `V_update` carry
+**distinct server `modificationDate`s** (`T_create < T_update`), exactly as
+production does. Without this the fix and the test are inconsistent.
+
+**How to stamp a `modificationDate` on a fabricated `CKRecord`** (empirically
+verified end-to-end in §6 — survives the production
+`encodedSystemFields` → `fromEncodedSystemFields` secure-coding round-trip):
+
+```swift
+// Test-only helper (UITestSupport or the sync test support file).
+// Stamps a server modificationDate onto an otherwise-local CKRecord by
+// writing the system-fields archive's `RecordMtime` key, then re-applying
+// the user fields (encodeSystemFields drops them on decode).
+extension CKRecord {
+  func withModificationDate(_ date: Date) -> CKRecord {
+    let coder = NSKeyedArchiver(requiringSecureCoding: true)
+    encodeSystemFields(with: coder)
+    coder.encode(date, forKey: "RecordMtime")   // CKRecord's archive key for mtime
+    coder.finishEncoding()
+    let unarchiver = try! NSKeyedUnarchiver(forReadingFrom: coder.encodedData)
+    unarchiver.requiresSecureCoding = true
+    let stamped = CKRecord(coder: unarchiver)!
+    for key in allKeys() { stamped[key] = self[key] }   // re-apply user fields
+    return stamped
+  }
+}
+```
+
+Notes / guard-rails for the helper:
+- `RecordMtime` is an internal CKRecord archive key, so the helper **must**
+  assert `result.modificationDate != nil` (fail loudly if Apple ever renames it)
+  and live in test support only — production never stamps dates.
+- The value **must be an `NSDate`/`Date`** — encoding ms-as-`Int64`/`Double`
+  decodes to `nil` (verified §6, techniques A/B/D all failed; C succeeded).
+
+Amend each loss test:
+
+```swift
+let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+let vCreateEcho = vCreateRow.toCKRecord(in: Self.zoneID).withModificationDate(t0)
+_ = try repo.setEncodedSystemFieldsSync(id: id, data: vCreateEcho.encodedSystemFields)
+…
+let vUpdateEcho = vUpdateRow.toCKRecord(in: Self.zoneID)
+  .withModificationDate(t0.addingTimeInterval(60))   // strictly newer
+```
+
+After amendment both `legUpdateSurvivesOutOfOrderEcho` and
+`…UnderBatchLoad` pass: step-3 applies `V_update`'s echo (cache → `t0+60`),
+step-4 `V_create` echo (`t0`) is `< t0+60` → rejected → row stays at qty 200.
+
+### 5b. `syncedCleanRowAppliesGenuineRemoteChange` — **stays green**
+
+This load-bearing test (a clean, already-synced row must accept a genuine peer
+change) passes **either way**: today its cached blob is built from a local
+`toCKRecord` → cached date `nil` → fail-open → genuine change applied.
+**Recommended** (for rigor, not required): amend it to give the cached version
+an older stamped date and the peer change a strictly-newer one, so it exercises
+the gate's "newer → apply" branch explicitly rather than the `nil` fail-open.
+
+### 5c. New unit tests to add
+
+- **Clean-path reject:** clean row cached at date `T2`; deliver an echo at
+  `T1 < T2`; assert fields unchanged (direct test of the gate, no `needs_push`).
+- **Tie reject:** clean row cached at `T`; deliver a differing-field echo at `T`;
+  assert the cached version is kept (documents the §4 tie decision).
+- **Unsent-edit peer guard (regression-lock for "needs_push stays"):** dirty row
+  (unsent local edit), deliver a *newer-dated* peer change; assert the local
+  fields are **not** overwritten (proves the date gate did not replace the
+  dirty-path guard).
+- **Cached-date advances:** apply a genuine newer change, then a stale echo;
+  assert the stale echo is rejected (proves the apply stamped the new date).
+
+### 5d. Existing byte-for-byte / round-trip tests
+
+`ProfileIndexSyncRoundTripTests.profileApplyRemoteChangesPreservesEncodedSystemFieldsByteForByte`
+and friends are unaffected — they deliver to clean rows with `nil` cached dates
+(fail-open) and assert blob preservation, which the gate does not change.
+
+### 5e. Index-zone reproduction tests (added — I-1)
+
+Analogues of the leg tests, one per index-zone site:
+
+- **Instrument register→update revert** (on the migration's critical path):
+  drive an instrument through create (`V_create`) then update (`V_update`,
+  changed mapping/decimals/ticker) with stamped dates `T1 < T2`, cache
+  `V_create`, then deliver `applyRemoteChangesSync` the `V_update` echo
+  followed by the stale `V_create` echo; assert the identity/mapping fields
+  stay at `V_update`. Add a sibling asserting a stale echo carrying an **older**
+  `pricingStatus` does **not** undo a sticky `.spam` (i.e. `pricingStatus`
+  still merges while identity fields are gated).
+- **Profile create→rename revert:** create `V_create`, rename to `V_update`
+  (dated `T1 < T2`), deliver the `V_update` confirming echo (clears
+  `needs_push`) then the stale `V_create` echo; assert the name stays renamed.
+
+Both fabricate dated records with the §5a `withModificationDate` helper.
+String-keyed instrument records stamp the same way (the helper is
+record-name-agnostic).
+
+### 5f. Within-batch dedup (M-2) — **UUID-keyed sites only** (scoped per I-2)
+
+Before applying, **dedup the clean set to the max-`modificationDate` per record
+id** — but **only at the UUID-keyed gate sites** (per-profile-data
+`applyBatchSaves`, and index-zone profiles). There each record is a whole-row
+server-wins upsert with no field-level CRDT, so collapsing duplicates to the
+newest date is correct and is cheap insurance: if a batch ever carried two
+versions of one id, last-write-by-date wins rather than last-by-array-order.
+State the "one fetch event coalesces to one version per record" assumption
+explicitly in code. Test: feed two versions of one id in a single batch (newest
+not last in array) and assert the newest wins.
+
+**Do NOT dedup at the instrument site.** Dedup-to-max would discard the dropped
+duplicate **entirely**, so its `pricingStatus` would never reach
+`PricingStatusMerge` — e.g. a same-batch `[V_create(T1, .spam),
+V_update(T2, .priced)]` would collapse to `.priced`, losing the sticky `.spam`.
+That is exactly the CRDT regression the pricingStatus exemption (§2) exists to
+prevent. The instrument site is **already within-batch-correct in either array
+order without dedup**: the existing per-row `fetchOne` + `PricingStatusMerge` +
+upsert loop means each iteration sees the prior iteration's upsert, so the
+identity/mapping fields converge to the newest-dated version (via the gate)
+**and** every duplicate's `pricingStatus` folds through the merge. (If a future
+change ever wants dedup here, it must first fold `pricingStatus` across the
+dropped duplicates via `PricingStatusMerge`, not discard them.)
+
+Test (instrument within-batch): deliver a same-batch
+`[older .spam, newer .priced]` pair for one id in **both** array orders and
+assert the identity fields end at the newer version **and** `pricingStatus`
+stays sticky `.spam`.
+
+---
+
+## 5.5 Implementation checklist (M-1, M-3)
+
+- **M-3 — rewrite the false ordering comments.** The "CKSyncEngine delivers
+  fetched changes in server-token order" rationale is wrong and must be replaced
+  (cite the date gate) in **all** of: `+ApplyGuard.swift`
+  (`clearNeedsPushForConfirmingEchoes`), `+SystemFields.swift`
+  (`clearNeedsPushForConfirmed`), and the index-zone equivalents in
+  `ProfileIndexSyncHandler+NeedsPush.swift`.
+- **M-1 — decode cost, do not add a column now.** The real per-batch cost of the
+  gate is N× `NSKeyedUnarchiver` + `CKRecord(coder:)` decodes inside the write
+  transaction (rough order ~25–50 ms for a ~514-record batch), not query count.
+  Acceptable for a one-time migration. Add a benchmark of the decode cost and
+  **only** consider a stored, indexed `server_modification_date` column if it
+  actually shows up as a regression. Do **not** add the column speculatively.
+- Add the batched cached-date readers:
+  `cachedModificationDates(recordType:ids:in:)` (per-profile-data + profiles,
+  one `WHERE id IN (…)` per type) and the string-keyed instrument variant
+  (piggyback on the existing `fetchOne`/`fetchRowsSync`).
+- Keep the `nil`-cached / `nil`-incoming **fail-open** behaviour (§2 table) at
+  every site, so genuine first-syncs and the round-trip tests are unaffected.
+- **M-5 — NON-GOAL (deletions).** This fix governs out-of-order *saves* only.
+  Out-of-order *deletions* (a stale delete echo arriving after a re-create, and
+  tombstone-vs-save ordering generally) are a separate, pre-existing class
+  **consciously out of scope** for #1085 — `modificationDate` does not exist on a
+  delete event, so the same signal does not apply. Call this out explicitly so a
+  future reader does not assume the gate covers it.
+- **M-6 — skip no-op pricing_status write.** In the instrument stale branch,
+  only write `pricing_status` when `merged != existing.pricingStatus`, to avoid
+  a redundant write (and a redundant cache invalidation) on the common case
+  where the stale echo's status matches.
+
+---
+
+## 6. Refuted / amended from the starting hypothesis + empirical evidence
+
+- **CONFIRMED** the issue's own recommendation (track this device's uploaded
+  change tags in new schema, reject recognized self-echoes) is the **wrong
+  layer**: (a) it gives **peers zero protection** under the identical failure
+  mode (a peer never uploaded `V_create`, so self-tag tracking can't recognize
+  its stale echo), and (b) it needs new schema for a signal
+  (`modificationDate`) CloudKit already ships on every record. The date gate
+  protects self-echoes and peer echoes **identically** and needs **no schema
+  change**.
+
+- **CONFIRMED** `recordChangeTag` is unusable for ordering (opaque, §7); the
+  hypothesis's pivot to `modificationDate` is correct.
+
+- **AMENDED — `needs_push` does not "shrink to the unsent window" as a code
+  change; it stays exactly as is.** The hypothesis framed needs_push as covering
+  "only the genuinely-unsent-local-edit window." That is its *role*, but no code
+  is removed: the dirty-path guard is still required to stop a *newer* peer
+  change clobbering an un-uploaded local edit (a date-only gate would wrongly
+  apply it). The date gate is **added** to the clean path; the needs_push guard
+  is **retained** on the dirty path. (Optional simplification of the ack-clear's
+  `preAckCached==nil` gating is noted as out-of-scope follow-up.)
+
+- **CONFIRMED & RESOLVED the test-consistency risk** the lead flagged.
+  Empirically established in this repo's CloudKit via `mcp__xcode__ExecuteSnippet`:
+  1. `row.toCKRecord(in:)` yields `modificationDate == nil` (fresh local record).
+  2. CKRecord's system-fields keyed archive uses **`RecordMtime`** (mod) and
+     `RecordCtime` (creation); date fields are `$null` when unset.
+  3. Encoding `RecordMtime` as a **`Date`** then decoding yields a record with
+     that `modificationDate`; encoding it as `Int64`/`Double` (ms or s) yields
+     `nil`.
+  4. The stamped date **survives** the production
+     `encodedSystemFields` → `fromEncodedSystemFields` (secure-coding) round-trip
+     and the gate's `<`/`>` comparisons.
+  5. Re-applying user fields onto the stamped record preserves **both** the date
+     and the fields.
+  ⇒ The §5a helper is sound, and the loss tests **cannot** pass on the fix
+  without it (the gate fails open on `nil` dates). Fix and test are now
+  consistent.
+
+- **NOTED residual (for the adversary):** the equal-date tie (§4) — reject-on-tie
+  trades a near-unreachable, self-healing divergence for closing the data-loss
+  window. This is the deliberate, and only, correctness compromise.
+
+- **ADDED after adversary review (I-1) — index-zone coverage, with the
+  instrument-path question resolved.** Verified in the worktree:
+  - `ProfileRow` and `InstrumentRow` **both persist `encoded_system_fields`**,
+    and `partitionSaved` copies each incoming record's blob onto the converted
+    row — so a cached date is readable AND advances on apply at all three index
+    -zone sites. The gate needs **no schema change**.
+  - Instruments are **string-keyed** (`id`) and have **no `needs_push`** column;
+    the gate keys by string id and piggybacks on the `fetchOne` the instrument
+    apply already does for the `pricingStatus` merge.
+  - **Newly surfaced interaction (resolved):** `PricingStatusMerge` is a
+    recency-independent field CRDT (sticky `.spam`). A record-level date gate
+    that rejected stale echoes wholesale would **regress** pricingStatus
+    convergence (devices could diverge `.spam` vs `.priced`). Resolution: the
+    gate governs only the identity/mapping fields + system-fields blob;
+    `pricingStatus` always flows through its existing merge. See §2 "Index-zone
+    sites".
+
+---
+
+## 7. Citations
+
+1. CKSyncEngine fetched-changes ordering is **not** guaranteed:
+   *"Although CloudKit doesn't guarantee the order of fetched record zone
+   changes, the typical order … is oldest to newest."*
+   https://developer.apple.com/documentation/cloudkit/cksyncengine-5sie5/event/fetchedrecordzonechanges
+2. `CKServerChangeToken` is opaque: *"Don't infer any behavior or order from a
+   token's contents."*
+   https://developer.apple.com/documentation/cloudkit/ckserverchangetoken
+3. Apple's canonical defence `setLastKnownRecordIfNewer()` (adopt only if newer
+   by `modificationDate`, at every apply site):
+   https://github.com/apple/sample-cloudkit-sync-engine/blob/main/SyncEngine/SyncedDatabase.swift
+4. Delivered server changes are **full records**, so a stale echo clobbers all
+   fields (motivates a gate, not field-level merge) — same sample / CloudKit
+   record-zone-changes semantics.
+5. `CKRecord.modificationDate` (server-assigned record metadata):
+   https://developer.apple.com/documentation/cloudkit/ckrecord/modificationdate
+6. Empirical (`RecordMtime` archive key, `Date`-typed, secure-coding
+   round-trip): established in-repo via `mcp__xcode__ExecuteSnippet` against
+   `Backends/CloudKit/Sync/CloudKitRecordConvertible.swift`, 2026-06-10 (§6).
+
+Caveat (carried from the research pass): no Apple source *positively* documents
+a token fetch replaying a superseded older same-record payload after a newer
+one. The justification is the **absence of any precluding ordering guarantee**
+(cit. 1, 2) plus Apple's own **defensive design** (cit. 3). Treat the gate as a
+defensive-correctness requirement, which is also exactly how Apple frames it.


### PR DESCRIPTION
## Summary

Closes the single-device CloudKit data-loss race in #1085 — the one behind the crypto-migration STEP-3 reversion (legs/instruments reverting to their `create` placeholder under a heavy upload/echo backlog). Fixes #1085.

**Root cause.** The loss happens on the **clean** apply path. After a record's confirming echo clears `needs_push`, the row is clean; an *out-of-order* stale echo of a superseded version then takes the normal upsert and clobbers the newer version. All four prior fixes (#1079/#1081/#1083/#1084) guard only the *dirty* window — none guards the clean path. #1084's clearing rested on an assumption Apple's docs explicitly contradict: *"CloudKit doesn't guarantee the order of fetched record zone changes."*

**Fix.** Apple's canonical `setLastKnownRecordIfNewer` pattern: a strict-`>` `modificationDate` gate on the clean apply path — apply a fetched record only if its server `modificationDate` is strictly newer than the version the row already caches; reject older-or-equal (reject-on-tie); fail-open on nil. `modificationDate` is server-assigned and monotonic per record, so it distinguishes a stale self-echo from a genuine change **and protects peer devices identically** (self-sent-tag tracking would not). **No schema change.** Convergence depends on the server's per-record date order, not on delivery order.

Applied at **all three** clean-apply sites (fix-all-instances):
- per-profile-data `applyBatchSaves` (legs, transactions, …)
- profile-index `applyProfilesGuarded` (profiles)
- the previously-**unguarded** instrument `applyRemoteChangesSync` — directly on the migration's `register-instrument` path.

`needs_push` is unchanged (still the unsent-local-edit guard). The instrument `pricingStatus` CRDT is exempt from the gate and keeps converging via its existing recency-independent sticky-`.spam` merge.

## Design + review trail

Design doc: `plans/1085-sync-out-of-order-echo-fix.md`. Converged over three adversarial-review rounds (which surfaced and closed the unguarded instrument path and a dedup-vs-CRDT interaction *before* implementation), then verified faithful against the diff; `sync-review` / `concurrency-review` / `database-code-review` / `code-review` findings all applied.

## Tests

TDD against the failing spec from `spec/sync-out-of-order-echo-loss`, amended to carry real distinct server `modificationDate`s (`CKRecord.withModificationDate` test helper, asserts non-nil). New: `ModificationDateGateTests`, `InstrumentOutOfOrderEchoTests`, `ProfileIndexOutOfOrderEchoTests`, an instrument stale-echo rollback contract. Full suites green (macOS 3953 / iOS 3849), `format-check` clean, zero warnings.

## Non-goals

Out-of-order *deletions* / tombstone ordering are a separate pre-existing class (no `modificationDate` on a delete event), consciously out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
