### PR TITLE
fix(sync): drain head-of-line upload wedge + close transient-error delete bug (#1087)

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -195,6 +195,10 @@ extension MoolahApp {
     store.onProfileRemoved = { [weak sessionManager, weak coordinator] profileID in
       sessionManager?.removeSession(for: profileID)
       coordinator?.evictCachedState(for: profileID)
+      // Drop the deleted profile's queued pending changes so stale saves
+      // can't wedge the upload queue (issue #1087). Genuine-deletion path
+      // only — never the data-format-incompatibility gate.
+      coordinator?.purgePendingChanges(forProfileZone: profileID)
     }
     return sessionManager
   }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
@@ -2,17 +2,26 @@
 import Foundation
 import GRDB
 
+/// Thrown by the record-lookup dispatch when a prefixed recordID names a
+/// record type this build does not handle. Surfaced (not swallowed) so the
+/// send path classifies it as `failed` and keeps the change pending rather
+/// than deleting a record of a type a newer build introduced.
+private struct UnknownRecordTypeError: Error {
+  let recordType: String
+}
+
 extension ProfileDataSyncHandler {
   // MARK: - Batch Record Lookup
 
   /// Looks up records grouped by their CKRecord recordType. Each group
   /// runs one batch fetch over its own GRDB repo so two different record
   /// types that happen to share a UUID don't collide in the result.
-  /// Returns `[recordType: [UUID: CKRecord]]`.
+  /// Returns a per-type `BatchLookupOutcome` so the caller can tell a
+  /// genuinely-absent id (query succeeded) from a failed query (issue #1087).
   func buildBatchRecordLookup(
     byRecordType groups: [String: Set<UUID>]
-  ) -> [String: [UUID: CKRecord]] {
-    var result: [String: [UUID: CKRecord]] = [:]
+  ) -> [String: BatchLookupOutcome] {
+    var result: [String: BatchLookupOutcome] = [:]
     for (recordType, uuids) in groups {
       guard !uuids.isEmpty else { continue }
       result[recordType] = batchFetchByType(recordType: recordType, uuids: uuids)
@@ -39,18 +48,36 @@ extension ProfileDataSyncHandler {
   /// String-keyed recordIDs (the bare `recordName` form used for
   /// `InstrumentRecord`) are also caught here: they have no legitimate
   /// per-profile path, so the same trap applies symmetrically.
-  func recordToSave(for recordID: CKRecord.ID) -> CKRecord? {
+  func recordToSave(for recordID: CKRecord.ID) -> RecordLookupOutcome {
     if let recordType = recordID.prefixedRecordType, let uuid = recordID.uuid {
       if recordType == InstrumentRow.recordType {
         return trapInstrumentOnPerProfileZone(detail: "prefixed UUID upload")
       }
-      return fetchAndBuild(recordType: recordType, uuid: uuid)
+      do {
+        if let record = try fetchAndBuild(recordType: recordType, uuid: uuid) {
+          return .found(record)
+        }
+        return .absent
+      } catch {
+        logger.error(
+          """
+          GRDB lookup failed for \(recordType, privacy: .public) \
+          \(uuid, privacy: .public): \(error.localizedDescription, privacy: .public) \
+          — keeping pending
+          """)
+        return .failed
+      }
     }
     return trapInstrumentOnPerProfileZone(
       detail: "string-keyed recordName \(recordID.recordName)")
   }
 
-  private func trapInstrumentOnPerProfileZone(detail: String) -> CKRecord? {
+  /// An `InstrumentRecord` reaching the per-profile handler is a routing bug
+  /// (instruments live on the shared profile-index registry). DEBUG traps so
+  /// the regression can't land; release keeps the change pending (`failed`)
+  /// rather than queueing a spurious server deletion — the startup
+  /// `purgeLegacyInstrumentPendingChanges` clears any residual entry.
+  private func trapInstrumentOnPerProfileZone(detail: String) -> RecordLookupOutcome {
     let message =
       """
       InstrumentRecord upload routed to per-profile zone \
@@ -62,7 +89,7 @@ extension ProfileDataSyncHandler {
       preconditionFailure(message)
     #else
       logger.error("\(message, privacy: .public)")
-      return nil
+      return .failed
     #endif
   }
 
@@ -76,7 +103,10 @@ extension ProfileDataSyncHandler {
   /// newer edit is pending and the flag stays set (issue #1081). Reuses
   /// the same per-type `fetchAndBuild` dispatch as the upload path.
   func currentCKRecord(recordType: String, id: UUID) -> CKRecord? {
-    fetchAndBuild(recordType: recordType, uuid: id)
+    // Ack comparison treats both "absent" and "lookup error" as "no current
+    // record" (→ leave `needs_push` set), so swallowing the throw to `nil`
+    // is correct here — unlike the upload path, which must distinguish them.
+    try? fetchAndBuild(recordType: recordType, uuid: id)
   }
 
   // The in-transaction counterpart `currentCKRecord(recordType:id:in:)`
@@ -84,90 +114,67 @@ extension ProfileDataSyncHandler {
 
   // MARK: - Per-Type Dispatch
 
-  /// Single-record dispatcher. Returns nil for unknown recordType
-  /// strings. The lookup is split between a reference-data half and a
-  /// financial-graph half (each returning a double-optional: outer
-  /// `.none` = "not this half's record type", inner `nil` = "handled,
-  /// no such row") so neither switch breaches the cyclomatic-complexity
+  /// Single-record dispatcher. Returns `nil` for a handled type whose row is
+  /// absent, and THROWS `UnknownRecordTypeError` for a record type this build
+  /// does not handle (so the caller keeps the change pending rather than
+  /// deleting it). The lookup is split between a reference-data half and a
+  /// financial-graph half (each returns a double-optional: outer `.none` =
+  /// "not this half's record type", `.some(inner)` = "handled", inner `nil` =
+  /// "no such row") so neither switch breaches the cyclomatic-complexity
   /// ceiling — same shape as `saveHandler` in `+GRDBDispatch`.
-  private func fetchAndBuild(recordType: String, uuid: UUID) -> CKRecord? {
-    if let referenceResult = fetchAndBuildReference(recordType: recordType, uuid: uuid) {
+  private func fetchAndBuild(recordType: String, uuid: UUID) throws -> CKRecord? {
+    if let referenceResult = try fetchAndBuildReference(recordType: recordType, uuid: uuid) {
       return referenceResult
     }
-    if let domainResult = fetchAndBuildDomain(recordType: recordType, uuid: uuid) {
+    if let domainResult = try fetchAndBuildDomain(recordType: recordType, uuid: uuid) {
       return domainResult
     }
     logger.warning(
-      "Unknown recordType '\(recordType, privacy: .public)' in prefixed recordID — skipping"
+      "Unknown recordType '\(recordType, privacy: .public)' in prefixed recordID — keeping pending"
     )
-    return nil
+    throw UnknownRecordTypeError(recordType: recordType)
   }
 
-  /// Reference-data side of the `fetchAndBuild` dispatch.
+  /// Wraps a fetched row in the dispatch's `CKRecord??` "handled" shape:
+  /// `.some(record)` for a present row, `.some(nil)` for an absent one. The
+  /// explicit `.some` is load-bearing — returning a bare `CKRecord?` would
+  /// flatten an absent row to the outer `.none` ("not handled"), which the
+  /// caller would then misread as an unknown type.
+  private func built<Row>(_ row: Row?) -> CKRecord??
+  where Row: CloudKitRecordConvertible & ValueTypeSystemFieldsReadable {
+    .some(row.map { buildCKRecord(from: $0, encodedSystemFields: $0.encodedSystemFields) })
+  }
+
+  /// Reference-data side of the `fetchAndBuild` dispatch. A thrown GRDB error
+  /// propagates to `recordToSave` (→ `.failed`); a `.some(nil)` is a
+  /// genuinely-absent row (→ `.absent`); the `default` `.none` means "not my
+  /// half".
   private func fetchAndBuildReference(
     recordType: String, uuid: UUID
-  ) -> CKRecord?? {
+  ) throws -> CKRecord?? {
     switch recordType {
-    case CategoryRow.recordType:
-      return fetchCategoryRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case TransferSuggestionRow.recordType:
-      return fetchTransferSuggestionRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case AccountGroupRow.recordType:
-      return fetchAccountGroupRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case InsightDismissalRow.recordType:
-      return fetchInsightDismissalRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case CSVImportProfileRow.recordType:
-      return fetchCSVImportProfileRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case ImportRuleRow.recordType:
-      return fetchImportRuleRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    default:
-      return nil
+    case CategoryRow.recordType: return built(try fetchCategoryRow(id: uuid))
+    case TransferSuggestionRow.recordType: return built(try fetchTransferSuggestionRow(id: uuid))
+    case AccountGroupRow.recordType: return built(try fetchAccountGroupRow(id: uuid))
+    case InsightDismissalRow.recordType: return built(try fetchInsightDismissalRow(id: uuid))
+    case CSVImportProfileRow.recordType: return built(try fetchCSVImportProfileRow(id: uuid))
+    case ImportRuleRow.recordType: return built(try fetchImportRuleRow(id: uuid))
+    default: return nil
     }
   }
 
   /// Financial-graph side of the `fetchAndBuild` dispatch.
   private func fetchAndBuildDomain(
     recordType: String, uuid: UUID
-  ) -> CKRecord?? {
+  ) throws -> CKRecord?? {
     switch recordType {
-    case AccountRow.recordType:
-      return fetchAccountRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case TransactionRow.recordType:
-      return fetchTransactionRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case TransactionLegRow.recordType:
-      return fetchTransactionLegRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case EarmarkRow.recordType:
-      return fetchEarmarkRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case EarmarkBudgetItemRow.recordType:
-      return fetchEarmarkBudgetItemRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    case InvestmentValueRow.recordType:
-      return fetchInvestmentValueRow(id: uuid).map { row in
-        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
-      }
-    default:
-      return nil
+    case AccountRow.recordType: return built(try fetchAccountRow(id: uuid))
+    case TransactionRow.recordType: return built(try fetchTransactionRow(id: uuid))
+    case TransactionLegRow.recordType: return built(try fetchTransactionLegRow(id: uuid))
+    case EarmarkRow.recordType: return built(try fetchEarmarkRow(id: uuid))
+    case EarmarkBudgetItemRow.recordType: return built(try fetchEarmarkBudgetItemRow(id: uuid))
+    case InvestmentValueRow.recordType: return built(try fetchInvestmentValueRow(id: uuid))
+    default: return nil
     }
   }
 
@@ -179,112 +186,90 @@ extension ProfileDataSyncHandler {
   /// `+GRDBDispatch`.
   private func batchFetchByType(
     recordType: String, uuids: Set<UUID>
-  ) -> [UUID: CKRecord] {
+  ) -> BatchLookupOutcome {
     let ids = Array(uuids)
     guard
       let fetch =
         batchFetchReference(for: recordType, ids: ids)
         ?? batchFetchDomain(for: recordType, ids: ids)
     else {
+      // Unhandled type (unreachable in practice): keep every id pending
+      // rather than deleting a record of a type a newer build introduced.
       logger.warning(
-        "Unknown recordType '\(recordType, privacy: .public)' in batch lookup — skipping"
+        "Unknown recordType '\(recordType, privacy: .public)' in batch lookup — keeping pending"
       )
-      return [:]
+      return .failed
     }
-    return fetch()
+    do {
+      return .succeeded(try fetch())
+    } catch {
+      logger.error(
+        """
+        GRDB batch fetch failed for \(recordType, privacy: .public): \
+        \(error.localizedDescription, privacy: .public) — keeping all \
+        \(ids.count, privacy: .public) pending
+        """)
+      return .failed
+    }
   }
 
   /// Reference-data side of the `batchFetchByType` dispatch. Returns the
-  /// batch-fetch thunk, or `nil` when `recordType` is not reference data.
+  /// throwing batch-fetch thunk, or `nil` when `recordType` is not reference
+  /// data. A thrown GRDB error propagates so the caller classifies the whole
+  /// group as `failed` (issue #1087).
   private func batchFetchReference(
     for recordType: String, ids: [UUID]
-  ) -> (() -> [UUID: CKRecord])? {
+  ) -> (() throws -> [UUID: CKRecord])? {
     switch recordType {
     case CategoryRow.recordType:
-      return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch { try self.grdbRepositories.categories.fetchRowsSync(ids: ids) })
-      }
+      return { self.mapBuiltRows(try self.grdbRepositories.categories.fetchRowsSync(ids: ids)) }
     case TransferSuggestionRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.transferSuggestions.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.transferSuggestions.fetchRowsSync(ids: ids))
       }
     case AccountGroupRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.accountGroups.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.accountGroups.fetchRowsSync(ids: ids))
       }
     case InsightDismissalRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.insightDismissals.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.insightDismissals.fetchRowsSync(ids: ids))
       }
     case CSVImportProfileRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.csvImportProfiles.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.csvImportProfiles.fetchRowsSync(ids: ids))
       }
     case ImportRuleRow.recordType:
-      return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch { try self.grdbRepositories.importRules.fetchRowsSync(ids: ids) })
-      }
+      return { self.mapBuiltRows(try self.grdbRepositories.importRules.fetchRowsSync(ids: ids)) }
     default:
       return nil
     }
   }
 
   /// Financial-graph side of the `batchFetchByType` dispatch. Returns
-  /// the batch-fetch thunk, or `nil` when `recordType` is not a
+  /// the throwing batch-fetch thunk, or `nil` when `recordType` is not a
   /// financial-graph row.
   private func batchFetchDomain(
     for recordType: String, ids: [UUID]
-  ) -> (() -> [UUID: CKRecord])? {
+  ) -> (() throws -> [UUID: CKRecord])? {
     switch recordType {
     case AccountRow.recordType:
-      return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch { try self.grdbRepositories.accounts.fetchRowsSync(ids: ids) })
-      }
+      return { self.mapBuiltRows(try self.grdbRepositories.accounts.fetchRowsSync(ids: ids)) }
     case TransactionRow.recordType:
-      return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch { try self.grdbRepositories.transactions.fetchRowsSync(ids: ids) })
-      }
+      return { self.mapBuiltRows(try self.grdbRepositories.transactions.fetchRowsSync(ids: ids)) }
     case TransactionLegRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.transactionLegs.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.transactionLegs.fetchRowsSync(ids: ids))
       }
     case EarmarkRow.recordType:
-      return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch { try self.grdbRepositories.earmarks.fetchRowsSync(ids: ids) })
-      }
+      return { self.mapBuiltRows(try self.grdbRepositories.earmarks.fetchRowsSync(ids: ids)) }
     case EarmarkBudgetItemRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.earmarkBudgetItems.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.earmarkBudgetItems.fetchRowsSync(ids: ids))
       }
     case InvestmentValueRow.recordType:
       return {
-        self.mapBuiltRows(
-          self.fetchRowsBatch {
-            try self.grdbRepositories.investmentValues.fetchRowsSync(ids: ids)
-          })
+        self.mapBuiltRows(try self.grdbRepositories.investmentValues.fetchRowsSync(ids: ids))
       }
     default:
       return nil
@@ -305,83 +290,57 @@ extension ProfileDataSyncHandler {
     return built
   }
 
-  /// Common error-handling wrapper for the batch-fetch closures used in
-  /// `batchFetchByType`. Logs at error level on throw and returns an
-  /// empty array (mirroring the SwiftData path's `fetchOrLog`
-  /// best-effort semantics).
-  private func fetchRowsBatch<T>(_ work: () throws -> [T]) -> [T] {
-    do {
-      return try work()
-    } catch {
-      logger.error(
-        """
-        GRDB batch fetch failed: \(error.localizedDescription, privacy: .public)
-        """)
-      return []
-    }
-  }
-
   // MARK: - Per-Row Lookups
+  //
+  // These propagate a GRDB error (rather than swallowing it to `nil`) so the
+  // upload path can tell a genuinely-absent row from a failed read (issue
+  // #1087). `nil` means "row absent"; a throw means "lookup failed".
 
-  private func fetchAccountRow(id: UUID) -> AccountRow? {
-    fetchRowOrLog { try grdbRepositories.accounts.fetchRowSync(id: id) }
+  private func fetchAccountRow(id: UUID) throws -> AccountRow? {
+    try grdbRepositories.accounts.fetchRowSync(id: id)
   }
 
-  private func fetchTransactionRow(id: UUID) -> TransactionRow? {
-    fetchRowOrLog { try grdbRepositories.transactions.fetchRowSync(id: id) }
+  private func fetchTransactionRow(id: UUID) throws -> TransactionRow? {
+    try grdbRepositories.transactions.fetchRowSync(id: id)
   }
 
-  private func fetchTransactionLegRow(id: UUID) -> TransactionLegRow? {
-    fetchRowOrLog { try grdbRepositories.transactionLegs.fetchRowSync(id: id) }
+  private func fetchTransactionLegRow(id: UUID) throws -> TransactionLegRow? {
+    try grdbRepositories.transactionLegs.fetchRowSync(id: id)
   }
 
-  private func fetchCategoryRow(id: UUID) -> CategoryRow? {
-    fetchRowOrLog { try grdbRepositories.categories.fetchRowSync(id: id) }
+  private func fetchCategoryRow(id: UUID) throws -> CategoryRow? {
+    try grdbRepositories.categories.fetchRowSync(id: id)
   }
 
-  private func fetchTransferSuggestionRow(id: UUID) -> TransferSuggestionRow? {
-    fetchRowOrLog { try grdbRepositories.transferSuggestions.fetchRowSync(id: id) }
+  private func fetchTransferSuggestionRow(id: UUID) throws -> TransferSuggestionRow? {
+    try grdbRepositories.transferSuggestions.fetchRowSync(id: id)
   }
 
-  private func fetchAccountGroupRow(id: UUID) -> AccountGroupRow? {
-    fetchRowOrLog { try grdbRepositories.accountGroups.fetchRowSync(id: id) }
+  private func fetchAccountGroupRow(id: UUID) throws -> AccountGroupRow? {
+    try grdbRepositories.accountGroups.fetchRowSync(id: id)
   }
 
-  private func fetchInsightDismissalRow(id: UUID) -> InsightDismissalRow? {
-    fetchRowOrLog { try grdbRepositories.insightDismissals.fetchRowSync(id: id) }
+  private func fetchInsightDismissalRow(id: UUID) throws -> InsightDismissalRow? {
+    try grdbRepositories.insightDismissals.fetchRowSync(id: id)
   }
 
-  private func fetchEarmarkRow(id: UUID) -> EarmarkRow? {
-    fetchRowOrLog { try grdbRepositories.earmarks.fetchRowSync(id: id) }
+  private func fetchEarmarkRow(id: UUID) throws -> EarmarkRow? {
+    try grdbRepositories.earmarks.fetchRowSync(id: id)
   }
 
-  private func fetchEarmarkBudgetItemRow(id: UUID) -> EarmarkBudgetItemRow? {
-    fetchRowOrLog { try grdbRepositories.earmarkBudgetItems.fetchRowSync(id: id) }
+  private func fetchEarmarkBudgetItemRow(id: UUID) throws -> EarmarkBudgetItemRow? {
+    try grdbRepositories.earmarkBudgetItems.fetchRowSync(id: id)
   }
 
-  private func fetchInvestmentValueRow(id: UUID) -> InvestmentValueRow? {
-    fetchRowOrLog { try grdbRepositories.investmentValues.fetchRowSync(id: id) }
+  private func fetchInvestmentValueRow(id: UUID) throws -> InvestmentValueRow? {
+    try grdbRepositories.investmentValues.fetchRowSync(id: id)
   }
 
-  private func fetchCSVImportProfileRow(id: UUID) -> CSVImportProfileRow? {
-    fetchRowOrLog { try grdbRepositories.csvImportProfiles.fetchRowSync(id: id) }
+  private func fetchCSVImportProfileRow(id: UUID) throws -> CSVImportProfileRow? {
+    try grdbRepositories.csvImportProfiles.fetchRowSync(id: id)
   }
 
-  private func fetchImportRuleRow(id: UUID) -> ImportRuleRow? {
-    fetchRowOrLog { try grdbRepositories.importRules.fetchRowSync(id: id) }
-  }
-
-  /// Common error-handling wrapper for the per-row fetch closures used
-  /// above. Logs at error level on throw and returns `nil`.
-  private func fetchRowOrLog<T>(_ work: () throws -> T?) -> T? {
-    do {
-      return try work()
-    } catch {
-      logger.error(
-        """
-        GRDB fetch failed: \(error.localizedDescription, privacy: .public)
-        """)
-      return nil
-    }
+  private func fetchImportRuleRow(id: UUID) throws -> ImportRuleRow? {
+    try grdbRepositories.importRules.fetchRowSync(id: id)
   }
 }

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
@@ -89,20 +89,22 @@ extension ProfileIndexSyncHandler {
   }
 
   /// Looks up an `InstrumentRow` by string-keyed `recordID` and builds
-  /// a CKRecord for upload. Returns `nil` when no `instrumentRepository`
-  /// is wired or the row does not exist.
-  func instrumentRecordToSave(for recordID: CKRecord.ID) -> CKRecord? {
-    guard let instrumentRepository else { return nil }
+  /// a CKRecord for upload, as a tri-state (issue #1087): `.found` on a hit,
+  /// `.absent` when the query succeeds but the row is gone (safe to drop the
+  /// stale save + queue a deletion), `.failed` when no registry is wired or
+  /// the fetch throws (keep pending — never delete a possibly-live record).
+  func instrumentRecordToSave(for recordID: CKRecord.ID) -> RecordLookupOutcome {
+    guard let instrumentRepository else { return .failed }
     do {
       guard
         let row = try instrumentRepository.fetchRowSync(id: recordID.recordName)
-      else { return nil }
-      return buildCKRecord(for: row)
+      else { return .absent }
+      return .found(buildCKRecord(for: row))
     } catch {
       logger.error(
-        "recordToSave: failed to fetch instrument row '\(recordID.recordName, privacy: .public)': \(error, privacy: .public)"
+        "recordToSave: failed to fetch instrument row '\(recordID.recordName, privacy: .public)': \(error, privacy: .public) — keeping pending"
       )
-      return nil
+      return .failed
     }
   }
 

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -172,14 +172,16 @@ final class ProfileIndexSyncHandler: Sendable {
   /// upload. Dispatches by record-name shape: a UUID-decoding name
   /// goes to the profile path; any other string is treated as an
   /// instrument id and dispatched to `instrumentRepository`.
-  func recordToSave(for recordID: CKRecord.ID) -> CKRecord? {
+  func recordToSave(for recordID: CKRecord.ID) -> RecordLookupOutcome {
     if let profileId = recordID.uuid {
       do {
-        guard let row = try repository.fetchRowSync(id: profileId) else { return nil }
-        return buildCKRecord(for: row)
+        guard let row = try repository.fetchRowSync(id: profileId) else { return .absent }
+        return .found(buildCKRecord(for: row))
       } catch {
-        logger.error("recordToSave: failed to fetch profile row: \(error, privacy: .public)")
-        return nil
+        logger.error(
+          "recordToSave: failed to fetch profile row: \(error, privacy: .public) — keeping pending"
+        )
+        return .failed
       }
     }
     return instrumentRecordToSave(for: recordID)

--- a/Backends/CloudKit/Sync/RecordLookupOutcome.swift
+++ b/Backends/CloudKit/Sync/RecordLookupOutcome.swift
@@ -1,0 +1,32 @@
+@preconcurrency import CloudKit
+import Foundation
+
+/// Tri-state outcome of looking up a single record for upload (issue #1087).
+/// The send path must distinguish a row that is genuinely gone (safe to drop
+/// the stale `.saveRecord` and queue a server deletion) from a lookup that
+/// could not complete (a transient GRDB error, or a record type this build
+/// does not handle — keep the change pending and retry, never delete a
+/// possibly-live record).
+///
+/// `Sendable` so an outcome can flow from a `nonisolated` lookup back to the
+/// `@MainActor` send path; `CKRecord` is `Sendable`-bridged under the file's
+/// `@preconcurrency import CloudKit`.
+enum RecordLookupOutcome: Sendable {
+  /// The row exists; upload this record.
+  case found(CKRecord)
+  /// The query succeeded and the row is genuinely absent — drop the stale
+  /// save and queue the compensating server deletion.
+  case absent
+  /// The lookup could not be completed (GRDB threw, or the record type is
+  /// not handled by this build) — keep the change pending; never delete.
+  case failed
+}
+
+/// Outcome of a per-recordType batch lookup (issue #1087). `succeeded`
+/// carries the hits keyed by UUID; any requested id absent from the map is
+/// genuinely gone. `failed` means the batch query threw (or the type is
+/// unhandled) — every id in the group stays pending, none removed.
+enum BatchLookupOutcome: Sendable {
+  case succeeded([UUID: CKRecord])
+  case failed
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -253,15 +253,12 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     recordIDs: [CKRecord.ID],
     into recordsToSave: inout [CKRecord]
   ) {
-    var missing: [CKRecord.ID] = []
-    for recordID in recordIDs {
-      if let record = profileIndexHandler.recordToSave(for: recordID) {
-        recordsToSave.append(record)
-      } else {
-        missing.append(recordID)
-      }
+    let entries = recordIDs.map { recordID in
+      (recordID: recordID, outcome: profileIndexHandler.recordToSave(for: recordID))
     }
-    handleMissingRecordsToSave(missing)
+    let (toSave, absent) = Self.classifyLookups(entries)
+    recordsToSave.append(contentsOf: toSave)
+    handleMissingRecordsToSave(absent)
   }
 
   /// Looks up profile-data records using a batch UUID lookup (plus an
@@ -278,6 +275,10 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     do {
       handler = try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
     } catch {
+      // Handler build failed: return WITHOUT classifying any id, so every
+      // record stays pending and nothing is removed or queued for deletion
+      // (issue #1087 safety invariant — a transient handler failure must
+      // never delete a live record). The next batch retries.
       logger.error(
         "Failed to build handler for profile \(profileId): \(error, privacy: .public) — \(recordIDs.count, privacy: .public) records remain pending for retry"
       )
@@ -303,61 +304,66 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     // One IN-predicate fetch per recordType; result is keyed by recordType
     // and then by UUID, so cross-type collisions are impossible.
     let groups = byRecordType.mapValues { Set($0.map(\.1)) }
-    let recordLookup = handler.buildBatchRecordLookup(byRecordType: groups)
+    let batchOutcomes = handler.buildBatchRecordLookup(byRecordType: groups)
 
-    var missing: [CKRecord.ID] = []
+    // Expand the per-type batch outcomes (plus the per-record / instrument
+    // string-keyed path) into per-id tri-state lookups (issue #1087). A
+    // recordType group whose batch query FAILED keeps every id pending
+    // (classified `failed`); only an id absent from a SUCCEEDED query is
+    // removed + queued for deletion.
+    var entries: [(recordID: CKRecord.ID, outcome: RecordLookupOutcome)] = []
     for (recordType, items) in byRecordType {
-      let typeLookup = recordLookup[recordType] ?? [:]
-      for (recordID, uuid) in items {
-        if let record = typeLookup[uuid] {
-          recordsToSave.append(record)
-        } else {
-          missing.append(recordID)
+      switch batchOutcomes[recordType] ?? .failed {
+      case .failed:
+        for (recordID, _) in items { entries.append((recordID, .failed)) }
+      case .succeeded(let hits):
+        for (recordID, uuid) in items {
+          entries.append((recordID, hits[uuid].map(RecordLookupOutcome.found) ?? .absent))
         }
       }
     }
-
     // String-keyed (InstrumentRecord) and any remaining unprefixed IDs go
     // through the single-record path which detects strings vs UUIDs.
     for recordID in unprefixedIDs {
-      if let record = handler.recordToSave(for: recordID) {
-        recordsToSave.append(record)
-      } else {
-        missing.append(recordID)
-      }
+      entries.append((recordID, handler.recordToSave(for: recordID)))
     }
 
-    handleMissingRecordsToSave(missing)
+    let (toSave, absent) = Self.classifyLookups(entries)
+    recordsToSave.append(contentsOf: toSave)
+    handleMissingRecordsToSave(absent)
   }
 
-  /// When `recordToSave` returns nil for one or more recordIDs (records
-  /// deleted locally before the batch was built), queue a single
-  /// `.deleteRecord` for each that isn't already pending — in one
-  /// `state.add(_:)` call.
+  /// Handles records that are confirmed GONE locally (the lookup query
+  /// succeeded and the row was absent — never a failed lookup; see the
+  /// `RecordLookupOutcome` tri-state, issue #1087):
   ///
-  /// Prior history: this fired per-record and re-scanned the entire
-  /// pending queue every call (a Sequence.contains over an
-  /// `[CKSyncEngine.PendingRecordZoneChange]` is linear), so a batch
-  /// where N records were missing did N × pending equality checks on the
-  /// main thread. With a stale 50K-row queue left over from a deleted
-  /// profile, that's the source of the freeze observed during CSV import:
-  /// every `nextRecordZoneChangeBatch` cycle re-found the same 400
-  /// missing records, the scan was quadratic, and the synchronous
-  /// `state.add(_:)` hop to CloudKit's serial queue ran 400 times per
-  /// cycle. The batched call collapses all of that into one set-build,
-  /// one filter pass, and one engine hop.
+  /// 1. **Remove the stale `.saveRecord`s.** Without this the dead saves stay
+  ///    at the head of the queue and `nextRecordZoneChangeBatch` re-selects
+  ///    the same un-buildable 400 every cycle (`built=0`), wedging all
+  ///    uploads. Removing them lets the queue drain to the next buildable
+  ///    batch.
+  /// 2. **Queue a compensating server deletion** for each id not already
+  ///    pending-delete, in one `state.add(_:)` call.
+  ///
+  /// `newMissingDeleteIDs` dedups against existing pending deletions with one
+  /// set build + one filter pass (O(pending + candidates)) so a large stale
+  /// queue drains without a per-record linear scan on the main thread.
   @MainActor
   private func handleMissingRecordsToSave(_ recordIDs: [CKRecord.ID]) {
     guard let syncEngine, !recordIDs.isEmpty else { return }
+    // Drop the stale saves so the head of the queue clears.
+    syncEngine.state.remove(
+      pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
     let novel = Self.newMissingDeleteIDs(
       among: recordIDs,
       pendingChanges: syncEngine.state.pendingRecordZoneChanges)
-    guard !novel.isEmpty else { return }
-    logger.info(
-      "\(novel.count, privacy: .public) record(s) deleted locally before batch — queueing server deletion"
-    )
-    syncEngine.state.add(
-      pendingRecordZoneChanges: novel.map { .deleteRecord($0) })
+    if !novel.isEmpty {
+      logger.info(
+        "\(novel.count, privacy: .public) record(s) deleted locally before batch — queueing server deletion"
+      )
+      syncEngine.state.add(
+        pendingRecordZoneChanges: novel.map { .deleteRecord($0) })
+    }
     refreshPendingUploadsMirror()
   }
 }

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -81,6 +81,33 @@ extension SyncCoordinator {
     cachedGRDBRepositories.removeValue(forKey: profileId)
   }
 
+  /// Removes every pending change queued for a deleted profile's data zone
+  /// (issue #1087 — root prevention of the upload-queue wedge).
+  /// Profile deletion tears down the per-profile DB/zone, but the profile's
+  /// already-queued `.saveRecord`s would otherwise linger in engine state
+  /// forever: their local rows are gone, so every batch build misses them
+  /// (`built=0`) and the dead head re-selects each cycle, starving uploads.
+  ///
+  /// **Call ONLY from the genuine-deletion path** (`onProfileRemoved`), never
+  /// from the data-format-incompatibility gate (`SessionManager`), where the
+  /// profile still exists locally and on the server — dropping its pending
+  /// edits there would lose unsynced user data. That gate uses
+  /// `evictCachedState` (cache only); this purge is deliberately separate.
+  func purgePendingChanges(forProfileZone profileId: UUID) {
+    guard let syncEngine else { return }
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+    let stale = Self.pendingChanges(
+      syncEngine.state.pendingRecordZoneChanges, inZone: zoneID)
+    guard !stale.isEmpty else { return }
+    logger.warning(
+      "Purging \(stale.count, privacy: .public) pending change(s) for deleted profile \(profileId, privacy: .public)"
+    )
+    syncEngine.state.remove(pendingRecordZoneChanges: stale)
+    refreshPendingUploadsMirror()
+  }
+
   /// Removes the per-profile `ProfileDataSyncHandler` from `dataHandlers`.
   /// Called by `SessionManager` on mid-session teardown when a remote bump
   /// pushes the profile's `dataFormatVersion` above

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -86,9 +86,15 @@ extension SyncCoordinator {
     // `CKSyncEngine.init(configuration:)` synchronously unarchives the
     // `stateSerialization` blob via `NSKeyedUnarchiver`, which blocks the
     // calling thread for many seconds when the pending-record-zone-changes
-    // queue has grown large. Run it off the main actor so app launch stays
-    // snappy. The end-of-startup signpost + "Started" log fire in
-    // `completeStart` once the engine object is back on the main actor.
+    // queue has grown large (issue #1087: a bloated 42.5 MB persisted state).
+    // It must not run on the MainActor. `prepareEngine` is `nonisolated
+    // async`, so calling it from this `@MainActor`-originating `Task` runs its
+    // body — including `CKSyncEngine.init` — on the cooperative pool, never on
+    // the main thread (SE-0338; verified empirically, issue #565). A plain
+    // `Task` (not `Task.detached`) keeps caller priority / task-locals per
+    // CONCURRENCY_GUIDE §8 while still getting init off-main. The
+    // end-of-startup signpost + "Started" log fire in `completeStart` once the
+    // engine object is back on the main actor.
     let stateURL = self.stateFileURL
     let delegate: any CKSyncEngineDelegate & Sendable = self
     startTask = Task { [weak self] in

--- a/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
@@ -43,17 +43,14 @@ extension SyncCoordinator {
   /// Subset of `candidates` whose record IDs are NOT already queued for
   /// deletion in `pendingChanges`. Builds a `Set<CKRecord.ID>` from the
   /// pending `.deleteRecord` entries once (O(pending)) and then filters
-  /// `candidates` against it (O(candidates)). Replaces a prior per-record
-  /// `Sequence.contains(_:)` scan that was O(candidates × pending) on the
-  /// main thread — pathological when a deleted profile leaves tens of
-  /// thousands of stale uploads queued (the same record names re-surface
-  /// every `nextRecordZoneChangeBatch` cycle until the queue drains).
+  /// `candidates` against it (O(candidates)) — linear, so a deleted profile
+  /// that left tens of thousands of stale uploads drains without a
+  /// per-record scan on the main thread.
   ///
-  /// Pending `.saveRecord` entries do not shadow a candidate: a stale
-  /// save and a fresh deletion can legitimately co-exist in the queue,
-  /// and CKSyncEngine resolves the order itself. We only dedup against
-  /// existing `.deleteRecord` entries so the same record-name isn't
-  /// queued for deletion twice.
+  /// Only `.deleteRecord` entries are consulted, so the same record-name is
+  /// not queued for deletion twice. `.saveRecord` entries are not checked:
+  /// the caller (`handleMissingRecordsToSave`) has already removed the
+  /// candidate's stale save before calling this.
   nonisolated static func newMissingDeleteIDs(
     among candidates: [CKRecord.ID],
     pendingChanges: [CKSyncEngine.PendingRecordZoneChange]
@@ -68,5 +65,43 @@ extension SyncCoordinator {
     }
     if pendingDeleteIds.isEmpty { return candidates }
     return candidates.filter { !pendingDeleteIds.contains($0) }
+  }
+
+  /// Partitions per-id upload lookups into the records to upload and the
+  /// genuinely-absent ids to drop + delete. `.found` → upload; `.absent`
+  /// (query succeeded, row gone) → remove the stale save and queue a server
+  /// deletion; `.failed` (GRDB threw / unhandled type / no registry) →
+  /// omitted entirely so the change stays pending and retries (issue #1087).
+  /// Pure and `nonisolated static` so the send-path classification is
+  /// unit-testable without a live `CKSyncEngine`.
+  nonisolated static func classifyLookups(
+    _ entries: [(recordID: CKRecord.ID, outcome: RecordLookupOutcome)]
+  ) -> (toSave: [CKRecord], absent: [CKRecord.ID]) {
+    var toSave: [CKRecord] = []
+    var absent: [CKRecord.ID] = []
+    for entry in entries {
+      switch entry.outcome {
+      case .found(let record): toSave.append(record)
+      case .absent: absent.append(entry.recordID)
+      case .failed: break
+      }
+    }
+    return (toSave, absent)
+  }
+
+  /// The subset of `changes` whose record lives in `zoneID`. Used by the
+  /// profile-delete purge to drop every pending change for a deleted
+  /// profile's data zone in one pass (issue #1087). Pure + `nonisolated
+  /// static` so the zone match is unit-testable without a live engine.
+  nonisolated static func pendingChanges(
+    _ changes: [CKSyncEngine.PendingRecordZoneChange], inZone zoneID: CKRecordZone.ID
+  ) -> [CKSyncEngine.PendingRecordZoneChange] {
+    changes.filter { change in
+      switch change {
+      case .saveRecord(let id): return id.zoneID == zoneID
+      case .deleteRecord(let id): return id.zoneID == zoneID
+      @unknown default: return false
+      }
+    }
   }
 }

--- a/MoolahTests/Backends/CloudKit/ProfileIndexInstrumentDispatchTests.swift
+++ b/MoolahTests/Backends/CloudKit/ProfileIndexInstrumentDispatchTests.swift
@@ -117,7 +117,7 @@ struct ProfileIndexInstrumentDispatchTests {
       recordName: "1:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       zoneID: harness.handler.zoneID)
     let record = harness.handler.recordToSave(for: recordID)
-    let built = try #require(record)
+    let built = try #require(record.foundRecord)
     #expect(built.recordType == InstrumentRow.recordType)
     #expect(built.recordID.recordName == recordID.recordName)
     #expect(built["coingeckoId"] as? String == "weth")

--- a/MoolahTests/Backends/GRDB/ProfileIndexSyncRoundTripTests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileIndexSyncRoundTripTests.swift
@@ -114,7 +114,7 @@ struct ProfileIndexSyncRoundTripTests {
     try await harnessA.repository.upsert(domain)
     let recordID = CKRecord.ID(
       recordType: ProfileRow.recordType, uuid: id, zoneID: Self.zoneID)
-    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID))
+    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID).foundRecord)
 
     // Stamp the server-issued change-tag bytes onto device A's row (a
     // real CKSyncEngine save populates these via the post-send

--- a/MoolahTests/Backends/GRDB/SyncRoundTripCSVImportTests.swift
+++ b/MoolahTests/Backends/GRDB/SyncRoundTripCSVImportTests.swift
@@ -172,7 +172,7 @@ struct SyncRoundTripCSVImportTests {
     _ = try await harnessA.handler.grdbRepositories.csvImportProfiles.create(domain)
     let recordID = CKRecord.ID(
       recordType: CSVImportProfileRow.recordType, uuid: id, zoneID: harnessA.handler.zoneID)
-    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID))
+    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID).foundRecord)
 
     // Stamp the server-issued change-tag bytes onto the record (a real
     // CKSyncEngine save populates these) and feed them back to Device A
@@ -227,7 +227,7 @@ struct SyncRoundTripCSVImportTests {
     _ = try await harnessA.handler.grdbRepositories.importRules.create(domain)
     let recordID = CKRecord.ID(
       recordType: ImportRuleRow.recordType, uuid: id, zoneID: harnessA.handler.zoneID)
-    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID))
+    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID).foundRecord)
 
     // Stamp server-issued change tag and write it back to the row.
     let stampedFields = outgoing.encodedSystemFields

--- a/MoolahTests/Support/RecordLookupOutcome+TestHelpers.swift
+++ b/MoolahTests/Support/RecordLookupOutcome+TestHelpers.swift
@@ -1,0 +1,26 @@
+@preconcurrency import CloudKit
+import Foundation
+
+@testable import Moolah
+
+// Test-only conveniences for the issue-#1087 record-lookup tri-states, so
+// existing round-trip / dispatch tests that just want the built `CKRecord`
+// (the pre-#1087 `CKRecord?` shape) stay concise. Production callers must
+// switch over all three cases — these helpers are deliberately test-only.
+extension RecordLookupOutcome {
+  /// The built record on `.found`, otherwise `nil` (`.absent` / `.failed`).
+  var foundRecord: CKRecord? {
+    if case .found(let record) = self { return record }
+    return nil
+  }
+}
+
+extension BatchLookupOutcome {
+  /// The hit map on `.succeeded`, or an empty map on `.failed`. Tests that
+  /// use this expect a `.succeeded` outcome and assert on the hits; the
+  /// `.failed` case is exercised directly via `guard case .failed`.
+  var succeededHits: [UUID: CKRecord] {
+    if case .succeeded(let hits) = self { return hits }
+    return [:]
+  }
+}

--- a/MoolahTests/Sync/ProfileDataSyncHandlerLookupTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerLookupTests.swift
@@ -54,8 +54,10 @@ struct ProfileDataSyncHandlerLookupTests {
       TransactionRow.recordType: [txnId],
     ])
 
-    #expect(lookup[AccountRow.recordType]?[accountId]?.recordType == "AccountRecord")
-    #expect(lookup[TransactionRow.recordType]?[txnId]?.recordType == "TransactionRecord")
+    #expect(
+      lookup[AccountRow.recordType]?.succeededHits[accountId]?.recordType == "AccountRecord")
+    #expect(
+      lookup[TransactionRow.recordType]?.succeededHits[txnId]?.recordType == "TransactionRecord")
   }
 
   @Test
@@ -80,7 +82,7 @@ struct ProfileDataSyncHandlerLookupTests {
 
     let recordID = CKRecord.ID(
       recordType: AccountRow.recordType, uuid: accountId, zoneID: handler.zoneID)
-    let result = handler.recordToSave(for: recordID)
+    let result = handler.recordToSave(for: recordID).foundRecord
     #expect(result != nil)
     #expect(result?.recordType == "AccountRecord")
     #expect(result?["name"] as? String == "Found")
@@ -100,7 +102,10 @@ struct ProfileDataSyncHandlerLookupTests {
 
     let recordID = CKRecord.ID(
       recordType: AccountRow.recordType, uuid: UUID(), zoneID: handler.zoneID)
-    let result = handler.recordToSave(for: recordID)
-    #expect(result == nil)
+    // Missing row, query succeeded → `.absent` (issue #1087 tri-state).
+    guard case .absent = handler.recordToSave(for: recordID) else {
+      Issue.record("expected .absent for a missing record")
+      return
+    }
   }
 }

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTestsMore.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTestsMore.swift
@@ -58,7 +58,7 @@ struct ProfileIndexSyncHandlerTestsMore {
 
     let recordID = CKRecord.ID(
       recordType: ProfileRow.recordType, uuid: profileId, zoneID: handler.zoneID)
-    let result = handler.recordToSave(for: recordID)
+    let result = handler.recordToSave(for: recordID).foundRecord
     #expect(result != nil)
     #expect(result?.recordType == ProfileRow.recordType)
     #expect(result?["label"] as? String == "Found")
@@ -70,8 +70,11 @@ struct ProfileIndexSyncHandlerTestsMore {
 
     let recordID = CKRecord.ID(
       recordType: ProfileRow.recordType, uuid: UUID(), zoneID: handler.zoneID)
-    let result = handler.recordToSave(for: recordID)
-    #expect(result == nil)
+    // Missing row, query succeeded → `.absent` (issue #1087 tri-state).
+    guard case .absent = handler.recordToSave(for: recordID) else {
+      Issue.record("expected .absent for a missing profile")
+      return
+    }
   }
 
   // MARK: - clearAllSystemFields

--- a/MoolahTests/Sync/RecordLookupTriStateTests.swift
+++ b/MoolahTests/Sync/RecordLookupTriStateTests.swift
@@ -1,0 +1,135 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tri-state record-lookup tests (issue #1087): the upload path must
+/// distinguish a row that is genuinely absent (safe to drop the stale save +
+/// queue a server deletion) from a lookup that FAILED (keep pending — never
+/// delete a possibly-live record). These drive the real
+/// `ProfileDataSyncHandler` lookups against an in-memory GRDB database,
+/// forcing the `failed` case by dropping the queried table so the fetch
+/// throws — proving the classification comes from the fetch wrappers
+/// themselves, not from the caller guessing.
+@Suite("record-lookup tri-state (issue #1087)")
+@MainActor
+struct RecordLookupTriStateTests {
+  private func legRecordID(_ id: UUID, zone: CKRecordZone.ID) -> CKRecord.ID {
+    CKRecord.ID(recordType: TransactionLegRow.recordType, uuid: id, zoneID: zone)
+  }
+
+  private func seedLeg(
+    _ harness: ProfileDataSyncHandlerTestSupport.HandlerHarness, id: UUID
+  ) async throws {
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: id, transactionId: UUID(), accountId: nil, quantity: 1
+      ).insert(database)
+    }
+  }
+
+  /// Forces every subsequent leg fetch to throw by dropping the table.
+  private func dropLegTable(
+    _ harness: ProfileDataSyncHandlerTestSupport.HandlerHarness
+  ) async throws {
+    try await harness.database.write { database in
+      try database.execute(sql: "DROP TABLE transaction_leg")
+    }
+  }
+
+  // MARK: - Single-record path (recordToSave)
+
+  @Test("recordToSave → .found for a present row")
+  func recordToSaveFound() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    let id = UUID()
+    try await seedLeg(harness, id: id)
+    let outcome = harness.handler.recordToSave(
+      for: legRecordID(id, zone: harness.handler.zoneID))
+    guard case .found = outcome else {
+      Issue.record("expected .found")
+      return
+    }
+  }
+
+  @Test("recordToSave → .absent for a missing row (query succeeded)")
+  func recordToSaveAbsent() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    let outcome = harness.handler.recordToSave(
+      for: legRecordID(UUID(), zone: harness.handler.zoneID))
+    guard case .absent = outcome else {
+      Issue.record("expected .absent")
+      return
+    }
+  }
+
+  @Test("recordToSave → .failed when the GRDB fetch throws")
+  func recordToSaveFailed() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    try await dropLegTable(harness)
+    let outcome = harness.handler.recordToSave(
+      for: legRecordID(UUID(), zone: harness.handler.zoneID))
+    guard case .failed = outcome else {
+      Issue.record("expected .failed")
+      return
+    }
+  }
+
+  @Test("recordToSave → .failed for a record type this build does not handle")
+  func recordToSaveFailedForUnknownType() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    // A prefixed recordID naming a type the dispatch doesn't handle must keep
+    // the change pending (never delete a record of a type a newer build
+    // introduced), not be treated as absent.
+    let unknown = CKRecord.ID(
+      recordType: "FutureUnknownRecord", uuid: UUID(), zoneID: harness.handler.zoneID)
+    guard case .failed = harness.handler.recordToSave(for: unknown) else {
+      Issue.record("expected .failed for an unhandled record type")
+      return
+    }
+  }
+
+  // MARK: - Batch path (buildBatchRecordLookup)
+
+  @Test("buildBatchRecordLookup → .succeeded with a hit for a present row")
+  func batchSucceededWithHit() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    let id = UUID()
+    try await seedLeg(harness, id: id)
+    let outcome = harness.handler.buildBatchRecordLookup(
+      byRecordType: [TransactionLegRow.recordType: [id]])
+    guard case .succeeded(let hits) = outcome[TransactionLegRow.recordType] else {
+      Issue.record("expected .succeeded")
+      return
+    }
+    #expect(hits[id] != nil)
+  }
+
+  @Test("buildBatchRecordLookup → .succeeded with no hit for a missing row")
+  func batchSucceededAbsent() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    let id = UUID()
+    let outcome = harness.handler.buildBatchRecordLookup(
+      byRecordType: [TransactionLegRow.recordType: [id]])
+    guard case .succeeded(let hits) = outcome[TransactionLegRow.recordType] else {
+      Issue.record("expected .succeeded")
+      return
+    }
+    #expect(hits[id] == nil)
+  }
+
+  @Test("buildBatchRecordLookup → .failed for the whole group when the fetch throws")
+  func batchFailedWhenFetchThrows() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    try await dropLegTable(harness)
+    let id = UUID()
+    let outcome = harness.handler.buildBatchRecordLookup(
+      byRecordType: [TransactionLegRow.recordType: [id]])
+    guard case .failed = outcome[TransactionLegRow.recordType] else {
+      Issue.record("expected .failed")
+      return
+    }
+  }
+}

--- a/MoolahTests/Sync/RecordNameCollisionTests.swift
+++ b/MoolahTests/Sync/RecordNameCollisionTests.swift
@@ -34,8 +34,9 @@ struct RecordNameCollisionTests {
       TransactionRow.recordType: [sharedId],
     ])
 
-    let accountRecord = try #require(lookup[AccountRow.recordType]?[sharedId])
-    let transactionRecord = try #require(lookup[TransactionRow.recordType]?[sharedId])
+    let accountRecord = try #require(lookup[AccountRow.recordType]?.succeededHits[sharedId])
+    let transactionRecord = try #require(
+      lookup[TransactionRow.recordType]?.succeededHits[sharedId])
     #expect(
       accountRecord.recordID.recordName
         == "\(AccountRow.recordType)|\(sharedId.uuidString)")
@@ -235,7 +236,7 @@ struct RecordNameCollisionTests {
       uuid: profileId,
       zoneID: handler.zoneID)
 
-    let result = try #require(handler.recordToSave(for: prefixedID))
+    let result = try #require(handler.recordToSave(for: prefixedID).foundRecord)
     #expect(result.recordType == ProfileRow.recordType)
     #expect(
       result.recordID.recordName

--- a/MoolahTests/Sync/UploadQueueWedgeTests.swift
+++ b/MoolahTests/Sync/UploadQueueWedgeTests.swift
@@ -1,0 +1,201 @@
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pure-helper tests for the upload-queue wedge fix (issue #1087):
+/// `SyncCoordinator.classifyLookups` (the send-path partition: which records
+/// upload, which absent records are removed + deleted, which failed lookups
+/// stay pending) and `SyncCoordinator.pendingChanges(_:inZone:)` (the
+/// delete-time purge of a removed profile's queued changes). Both are
+/// `nonisolated static` and pure, so the behaviour is locked without driving a
+/// live `CKSyncEngine` (whose `State` cannot be fabricated in a test process)
+/// — the same shape as `NewMissingDeleteIDsTests`.
+@Suite("upload-queue wedge fix (issue #1087)")
+struct UploadQueueWedgeTests {
+  private static let zone = CKRecordZone.ID(
+    zoneName: "profile-A", ownerName: CKCurrentUserDefaultName)
+
+  private static func recordID(_ name: String, in zone: CKRecordZone.ID) -> CKRecord.ID {
+    CKRecord.ID(recordName: name, zoneID: zone)
+  }
+
+  private static func record(_ name: String) -> CKRecord {
+    CKRecord(recordType: "Test", recordID: recordID(name, in: zone))
+  }
+
+  // MARK: - classifyLookups (send-path partition)
+
+  /// The core wedge-drain + safety partition: a `.found` row uploads, an
+  /// `.absent` row (query succeeded, row gone) is removed + queued for
+  /// deletion, and a `.failed` lookup is left pending (neither uploaded nor
+  /// deleted).
+  @Test("found→upload, absent→remove+delete, failed→stay pending")
+  func classifyPartitionsByOutcome() {
+    let foundID = Self.recordID("found", in: Self.zone)
+    let absentID = Self.recordID("absent", in: Self.zone)
+    let failedID = Self.recordID("failed", in: Self.zone)
+    let entries: [(recordID: CKRecord.ID, outcome: RecordLookupOutcome)] = [
+      (foundID, .found(Self.record("found"))),
+      (absentID, .absent),
+      (failedID, .failed),
+    ]
+
+    let (toSave, absent) = SyncCoordinator.classifyLookups(entries)
+
+    #expect(toSave.map(\.recordID) == [foundID])
+    #expect(absent == [absentID])
+    // The failed id appears in NEITHER bucket → it stays pending and is
+    // never queued for server deletion.
+    #expect(!absent.contains(failedID))
+  }
+
+  /// Safety regression-lock: when a whole recordType batch query FAILS (every
+  /// id classified `.failed`), nothing is removed and nothing is queued for
+  /// deletion — a transient GRDB error must never mass-delete live records
+  /// server-side (the conflation bug this fix closes; issue #1087).
+  @Test("a failed batch group removes and deletes nothing")
+  func failedGroupRemovesNothing() {
+    let entries = (0..<5).map { index in
+      (recordID: Self.recordID("rec-\(index)", in: Self.zone), outcome: RecordLookupOutcome.failed)
+    }
+
+    let (toSave, absent) = SyncCoordinator.classifyLookups(entries)
+
+    #expect(toSave.isEmpty)
+    #expect(absent.isEmpty)
+  }
+
+  /// The wedge: a stale `.saveRecord` for a record that is gone locally (the
+  /// query succeeds, the row is absent) is routed to the remove+delete bucket
+  /// — the input `handleMissingRecordsToSave` uses to clear the head (2a).
+  @Test("an absent record is routed to the remove+delete bucket (drains the wedge)")
+  func absentRecordDrains() {
+    let staleID = Self.recordID("stale-deleted-profile-leg", in: Self.zone)
+    let (toSave, absent) = SyncCoordinator.classifyLookups([(staleID, .absent)])
+    #expect(toSave.isEmpty)
+    #expect(absent == [staleID])
+  }
+
+  // MARK: - pendingChanges(_:inZone:) (delete-time purge)
+
+  @Test("delete-time purge selects only the target zone's pending changes")
+  func pendingChangesFiltersByZone() {
+    let zoneA = CKRecordZone.ID(zoneName: "profile-A", ownerName: CKCurrentUserDefaultName)
+    let zoneB = CKRecordZone.ID(zoneName: "profile-B", ownerName: CKCurrentUserDefaultName)
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      .saveRecord(Self.recordID("a1", in: zoneA)),
+      .deleteRecord(Self.recordID("a2", in: zoneA)),
+      .saveRecord(Self.recordID("b1", in: zoneB)),
+    ]
+
+    #expect(SyncCoordinator.pendingChanges(changes, inZone: zoneA).count == 2)
+    #expect(SyncCoordinator.pendingChanges(changes, inZone: zoneB).count == 1)
+  }
+
+  @Test("delete-time purge returns nothing when no change is in the zone")
+  func pendingChangesEmptyWhenZoneAbsent() {
+    let zoneA = CKRecordZone.ID(zoneName: "profile-A", ownerName: CKCurrentUserDefaultName)
+    let zoneB = CKRecordZone.ID(zoneName: "profile-B", ownerName: CKCurrentUserDefaultName)
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      .saveRecord(Self.recordID("b1", in: zoneB))
+    ]
+    #expect(SyncCoordinator.pendingChanges(changes, inZone: zoneA).isEmpty)
+  }
+
+  // MARK: - Multi-cycle drain
+
+  /// Applies one `nextRecordZoneChangeBatch` cycle to a simulated pending
+  /// queue using the SAME production helpers the real path uses — the batch
+  /// `prefix`, `classifyLookups`, and `handleMissingRecordsToSave`'s
+  /// remove-stale-save + `newMissingDeleteIDs` semantics — plus a model of the
+  /// engine removing a successfully-uploaded save on ack. Returns the next
+  /// queue state.
+  ///
+  /// `lookup` classifies each pending save's record id (`.found`/`.absent`);
+  /// `.found` saves are "uploaded" (removed, as CKSyncEngine does on ack),
+  /// `.absent` saves are removed and a server deletion is queued.
+  private static func drainCycle(
+    _ pending: [CKSyncEngine.PendingRecordZoneChange],
+    batchLimit: Int,
+    lookup: (CKRecord.ID) -> RecordLookupOutcome
+  ) -> [CKSyncEngine.PendingRecordZoneChange] {
+    let saveIDs: [CKRecord.ID] = pending.compactMap {
+      if case .saveRecord(let id) = $0 { return id }
+      return nil
+    }
+    let batch = Array(saveIDs.prefix(batchLimit))
+    guard !batch.isEmpty else { return pending }
+
+    let (toSave, absent) = SyncCoordinator.classifyLookups(
+      batch.map { (recordID: $0, outcome: lookup($0)) })
+
+    // `handleMissingRecordsToSave`: remove the stale saves, queue novel deletes.
+    let novelDeletes = SyncCoordinator.newMissingDeleteIDs(
+      among: absent, pendingChanges: pending)
+    let removedSaves = Set(absent).union(toSave.map(\.recordID))  // absent + uploaded
+
+    var next = pending.filter { change in
+      if case .saveRecord(let id) = change { return !removedSaves.contains(id) }
+      return true
+    }
+    next.append(contentsOf: novelDeletes.map { .deleteRecord($0) })
+    return next
+  }
+
+  /// A queue seeded with a block of stale `.saveRecord`s for gone records plus
+  /// a few live ones must EMPTY of saves across repeated cycles: stale saves
+  /// are removed (so the head advances instead of re-selecting the same dead
+  /// 400 forever — the wedge), live saves upload, and no live record is ever
+  /// queued for server deletion.
+  ///
+  /// This drives the real classification + dedup helpers in a multi-cycle
+  /// loop. TODO(#1088): a full engine-harness e2e that drives the literal
+  /// `nextRecordZoneChangeBatchOnMain` against a live `CKSyncEngine.State`
+  /// (batch selection + the actual `state.remove`/`state.add` calls) is a
+  /// fast-follow — https://github.com/moolah-rocks/moolah-native/issues/1088
+  @Test("a queue of stale saves drains across cycles; live records survive, none deleted")
+  func multiCycleDrainEmptiesStaleSaves() {
+    let zone = CKRecordZone.ID(zoneName: "profile-Z", ownerName: CKCurrentUserDefaultName)
+    let staleIDs = (0..<50).map { Self.recordID("stale-\($0)", in: zone) }
+    let liveIDs = (0..<5).map { Self.recordID("live-\($0)", in: zone) }
+    let liveSet = Set(liveIDs)
+    // Interleave: a live save after every 10 stale ones, so the live records
+    // are spread through the queue rather than trivially at the tail.
+    var ordered: [CKRecord.ID] = []
+    var liveIterator = liveIDs.makeIterator()
+    for (index, stale) in staleIDs.enumerated() {
+      ordered.append(stale)
+      if index % 10 == 9, let live = liveIterator.next() { ordered.append(live) }
+    }
+    while let live = liveIterator.next() { ordered.append(live) }
+    var queue: [CKSyncEngine.PendingRecordZoneChange] = ordered.map { .saveRecord($0) }
+
+    let lookup: (CKRecord.ID) -> RecordLookupOutcome = { id in
+      liveSet.contains(id) ? .found(CKRecord(recordType: "Test", recordID: id)) : .absent
+    }
+
+    // Drain to a fixed point; cap cycles well above the ceil(55/10) needed so a
+    // regression that fails to drain trips the post-loop assertion, not a hang.
+    func saves(_ changes: [CKSyncEngine.PendingRecordZoneChange]) -> [CKSyncEngine
+      .PendingRecordZoneChange]
+    {
+      changes.filter { if case .saveRecord = $0 { return true } else { return false } }
+    }
+    for _ in 0..<50 where !saves(queue).isEmpty {
+      queue = Self.drainCycle(queue, batchLimit: 10, lookup: lookup)
+    }
+
+    let deletedIDs: [CKRecord.ID] = queue.compactMap {
+      if case .deleteRecord(let id) = $0 { return id }
+      return nil
+    }
+    // The queue drained: no `.saveRecord` remains (stale removed, live uploaded).
+    #expect(saves(queue).isEmpty)
+    // Every stale record was queued for server deletion exactly once.
+    #expect(Set(deletedIDs) == Set(staleIDs))
+    // No LIVE record was ever queued for deletion (the safety invariant).
+    #expect(deletedIDs.allSatisfy { !liveSet.contains($0) })
+  }
+}

--- a/plans/upload-queue-wedge-fix.md
+++ b/plans/upload-queue-wedge-fix.md
@@ -1,0 +1,412 @@
+# Upload-queue wedge — root cause & fix design
+
+Status: **proposal** (design only)
+Worktree: `.claude/worktrees/fix-upload-queue-wedge` (off `main`, includes #1085).
+Symptom (Development container): `…/Application Support/Development/Moolah-v2-sync.syncstate`
+is **42.5 MB, frozen since 10:26**, ~152 k pending changes, **nothing uploads**;
+the crypto migration is blocked. Not CloudKit rate-limiting.
+
+---
+
+## 1. Root cause — TWO compounding problems (confirmed against code + the live artifact)
+
+### Problem 1 (primary): startup never reaches a running engine — most likely MainActor starvation, NOT init-on-main
+
+**Symptom:** the log shows "CloudKit available — starting sync coordinator" but
+**never** "Started unified sync coordinator" (`+Lifecycle.swift:145`, the first
+line of the back-on-MainActor `completeStart`). So `completeStart` /
+zone-setup / `sendChanges` never run, and nothing can drain.
+
+**Revised diagnosis (corrected after adversary review — see §9).** My first
+draft asserted `CKSyncEngine.init` blocks the *main* thread internally, on the
+strength of a single process `sample`. That contradicts the code and is most
+likely wrong:
+
+- `SyncCoordinator` is `@MainActor` (`SyncCoordinator.swift:20`); `start()`
+  (`:80`) spawns `Task { await Self.prepareEngine(...) }`. `prepareEngine`
+  (`:113`) is `nonisolated async`, and it calls `CKSyncEngine(configuration:)`
+  **synchronously** from that nonisolated context. For that to compile,
+  `CKSyncEngine.init` is **not** `@MainActor`-isolated — so it runs on the
+  cooperative pool, **off** the main thread. Issue #565 verified exactly this
+  (`Thread.isMainThread == false`, distinct OS TID). The codebase deliberately
+  put init here for this reason (`:86-91`, `:104-112`).
+- The far more code-consistent reading of the `sample`: the **main thread is
+  pinned by the concurrent Insights/Analysis crypto-conversion storm**
+  (~14 k conversions / 6 min in the open profiles), while
+  `CKSyncEngine.init` grinds **off-main** on the 31 MB blob. With the
+  MainActor saturated, the continuation that resumes `prepareEngine` and runs
+  the `@MainActor` `completeStart` **cannot get scheduled** — so "Started…"
+  never logs even though init may have finished (or is finishing) off-main.
+
+So the blocker is most plausibly **MainActor starvation delaying `completeStart`**
+(and/or a genuinely slow but completing off-main 31 MB deserialization) — **not**
+init executing on the main thread. This flips the fix: the lever is to **free
+the MainActor / guarantee off-main init**, not to shrink the state by a
+data-losing reset. The decisive question is empirical (the spike in §2 Layer 1).
+
+> The earlier "only lever is to reduce what we hand init" framing — and the
+> reset built on it — is **withdrawn** as the primary fix; see §2 Layer 1 and
+> §9. The existing purges (`purgeStaleBareUUIDPendingChanges`, `:156`;
+> `purgeLegacyInstrumentPendingChanges`, `:165`) do run only after the engine
+> exists, but if init completes off-main with the MainActor free, that is no
+> longer a problem.
+
+### Problem 2 (steady-state): head-of-line wedge — stale `.saveRecord`s never removed
+
+Independently, even when sends *do* run, the front ~400 pending are stale
+`.saveRecord`s for prefixed records **deleted locally** (left from a deleted
+profile). Per send pass (`nextRecordZoneChangeBatchOnMain`, `+Delegate.swift:88`):
+
+1. `dedupedPendingChanges` (`:194`) keeps them (their zone is **not** in
+   `pendingZoneCreation`; a deleted zone isn't pending-creation).
+2. `selectBatchKind`→`.profileData`; `filterChanges(...).prefix(400)`
+   (`+BatchKind.swift:50`) takes them **in stable queue order** — the same dead
+   head every cycle.
+3. `buildRecordsToSave`→`appendProfileDataRecords` (`:271`): `handlerForProfileZone`
+   does **not** throw for a deleted profile — `containerManager.database(for:)`
+   (`ProfileContainerManager.swift:68`) re-opens `ProfileDatabase.open(at:
+   data.sqlite)`, which **re-creates a fresh empty migrated DB**. The batch
+   lookup finds no rows → every id is a miss → `built = 0`.
+4. `handleMissingRecordsToSave` (`:350`) tail-queues `.deleteRecord`s via
+   `state.add(...)` — appended **beyond** the `prefix(400)` window — and the
+   stale `.saveRecord`s are **never removed**. `newMissingDeleteIDs`
+   (`+QueueChanges.swift:57`) even documents (`:51-56`) that it deliberately
+   leaves the save, assuming "CKSyncEngine resolves the order itself." **It does
+   not.** Both coexist; the head is re-selected forever. `built=0`, `deletes=0`
+   in-batch → `nextBatch` returns nil. Total upload starvation.
+
+Observed signature (already emitted by `logBatchOutcome`, `+Delegate.swift:178`):
+`pending=152298 deduped=152298 batch=400 saves=0/400 deletes=0` + the `.error`
+"expected 400 saves but built 0 records — records remain pending".
+
+> Note on the verb `synchronize`: it is the crypto-import refetch, **not**
+> `CKSyncEngine.sendChanges`. `sendChanges` fires only via the startup
+> zone-ready path (`+Lifecycle.swift:211-214`, `if hasPendingChanges`) or
+> CKSyncEngine's discretionary `automaticallySync`. With Problem 1 blocking
+> startup, neither runs — so the existing state cannot drain at all today.
+
+### The persisted state is opaque (decisive for the fix shape)
+
+I inspected the actual frozen artifact read-only. `CKSyncEngine.State.Serialization`'s
+Codable form is `{"data": "<base64>"}`; the base64 decodes to a **`bplist00`
+binary plist of 31.7 MB** — CloudKit's internal, undocumented keyed archive
+bundling **both** the server change tokens **and** the 152 k pending changes.
+There is **no JSON-level pending-changes array to filter**: surgically dropping
+pending changes while preserving tokens would require editing CloudKit's private
+binary-plist structure — version-dependent and unsafe (a malformed edit risks
+`init` rejecting the state or silently corrupting the tokens). **Token-preserving
+surgical slim is therefore rejected** — which matters because it means the only
+"slim pre-init" option is a *full* token-losing reset. Combined with the
+save-completeness and delete-resurrection failures of a reset (§3, §9), this is a
+further reason the primary fix is **off-main init**, not slimming.
+
+---
+
+## 2. The fix — off-main startup (primary) + steady-state purges (Layer 2)
+
+### Which layer fixes which regime (read this first)
+
+| regime | what happens | who fixes it |
+|---|---|---|
+| **Existing bloated state (the current blocker)** | startup never reaches `completeStart` — MainActor starved by the conversion storm and/or slow off-main 31 MB init | **Layer 1: free the MainActor / guarantee off-main init** (token-preserving). Reset only as a proven last resort |
+| **Head-of-line wedge (engine already running)** | `nextBatch` runs but `built=0` on a stale dead head | **Layer 2a** (remove-in-place) + **2c** (delete-time purge) |
+| **Healthy-but-stale install (sub-pathological leftover saves)** | engine starts; some stale saves linger | **Layer 2b** (post-init bulk purge) |
+
+### Layer 1 (primary) — make startup complete on the bloated state WITHOUT a reset
+
+The goal is to get `completeStart` to run on the existing 42.5 MB state with
+**no token loss and no data loss**. Two complementary levers, both cheap to try;
+implementing them *is* the empirical spike that settles §1's diagnosis:
+
+The fix is a single change — **guarantee `CKSyncEngine.init` runs off the main
+thread and resumes on the MainActor**: construct the engine in a `Task.detached`
+(defensively off-actor regardless of actor-inheritance subtleties), then hop the
+finished engine back to the `@MainActor` `SyncCoordinator` for `completeStart`.
+The code already intends this (`:86-112`); make it robust and explicit.
+
+**Do NOT pre-emptively build a conversion-storm quiesce.** The Insights/Analysis
+crypto-conversion workload (~14 k conversions / 6 min) pegs the MainActor and is
+the suspected reason the `completeStart` continuation can't schedule — but
+whether it actually blocks `completeStart` is exactly what the spike measures.
+The realistic spike condition is **off-main init with the storm present**.
+
+**Decisive empirical test (the spike, owned with the verifier):** on the live
+42.5 MB state, with init forced off-main **and the conversion storm present
+(realistic condition)**, does `CKSyncEngine.init` **complete** and does
+**"Started unified sync coordinator"** log, and the queue drain?
+- **If yes** (expected — the storm is likely bursty, so `completeStart`
+  schedules once init returns and the burst subsides): Layer 1 is done with the
+  off-main change **alone** — tokens preserved, no refetch, no resurrection, no
+  save-completeness risk. The two reset criticals (§3) never arise.
+- **If `completeStart` is starved** because the storm *continuously* pins the
+  MainActor: that is a **separate Analysis-path performance issue** ("conversion
+  storm starves the MainActor"), filed and owned **separately** — NOT folded into
+  this sync wedge fix. The wedge fix stays scoped to the sync layer.
+- **If init genuinely cannot complete off-main** (e.g. OOM / pathological
+  deserialization): escalate to the reset *fallback* below (extra safety work +
+  owner sign-off).
+
+### Layer 1 fallback (last resort only) — size-gated reset, IFF made data-safe
+
+Only if the spike proves init cannot complete even off-main with a free
+MainActor. A reset (`stateSerialization: nil`) makes init trivial but is
+**data-losing as designed** — it must NOT ship without both of the following
+(see §3 for why each is mandatory):
+
+- **Save-complete re-queue:** use the **`isFirstLaunch = true` →
+  `queueAllExistingRecordsForAllZones`** path (re-queues *every* local row, which
+  holds the newest version; correct re-upload under the #1085 gate). Do **NOT**
+  use `queueUnsyncedRecordsForAllProfiles` — it filters `encoded_system_fields IS
+  NULL` and so **misses every record edited after first sync** (blob preserved,
+  only `needs_push=1`), silently dropping exactly the migration's
+  create→update edits. *(This corrects the prior draft's `isFirstLaunch=false`
+  optimisation, which was a data-loss bug — CRITICAL-1.)*
+- **Delete-safe replay:** there is **no tombstone table**, so a reset loses every
+  pending `.deleteRecord` and the token-less refetch **resurrects user-deleted
+  data** (CRITICAL-2). A reset therefore additionally requires a durable
+  deletion-intent record (tombstone) that the post-reset path replays as
+  `.deleteRecord`s — net-new infrastructure.
+- **Size-gate caveat:** a false-positive reset now means **data loss**, not just
+  a refetch, so the threshold (if a reset survives at all) must be set far above
+  any legitimate state and treated as an emergency valve, not a routine path.
+
+Given the off-main route preserves all data, the recommendation is to **ship
+Layer 1 primary and likely drop the reset entirely**; keep the fallback documented
+only against the unlikely "init can't complete off-main" spike result.
+
+### Layer 2 — stop the state ever re-bloating (steady-state; lands regardless of Layer 1 outcome)
+
+Adversary-endorsed; closes a real latent data-loss path today (§3 ii). These keep
+the pending queue small so the bloated-state regime does not recur.
+
+**2a. Remove the stale `.saveRecord` in `handleMissingRecordsToSave`** (the
+verifier's core ask). On a **clean miss** (record genuinely gone locally),
+`state.remove(pendingRecordZoneChanges: [.saveRecord(id)])` in addition to
+queueing the compensating delete. `state.remove(...)` is an established idiom
+(`+Lifecycle.swift:308`, `+LegacyInstrumentDrain.swift:69`). This clears the
+head so the queue drains.
+
+**2b. Start-time purge of prefixed-records-gone-locally**, analogous to
+`purgeStaleBareUUIDPendingChanges`. After the engine exists, drop pending
+`.saveRecord`s whose local row no longer exists. Because a naive scan is up to
+152 k per-record DB lookups, scope it: only needed on the non-reset path (the
+reset path already starts with an empty pending set), and it can piggyback on the
+backfill scan that already walks each profile. Extend the existing purge
+function family rather than adding a parallel one where practical.
+
+**2c. Purge a profile's pending changes at delete time** (root prevention). The
+true origin is that profile deletion (`evictCachedState`, `+HandlerAccess.swift:79`;
+`ProfileContainerManager.deleteStore`, `:115`) tears down the DB/zone but leaves
+the profile's queued changes in engine state forever. Add a
+`state.remove(pendingRecordZoneChanges:)` of all pending changes for that
+profile's zone at the delete path. With 2c the wedge cannot form; 2a is the
+general guard; 2b repairs an already-accumulated (sub-pathological) queue.
+
+---
+
+## 3. Safety — never drop a save for a record that still exists / has an unsynced edit
+
+This is the critical invariant. Two distinct hazards:
+
+**(i) The primary (off-main) Layer 1 is inherently data-safe** — it preserves the
+state verbatim (tokens + pending), so there is nothing to lose. The safety
+analysis below applies to the *reset fallback*, which is why the fallback carries
+hard preconditions.
+
+**A reset is NOT save-complete via `queueUnsyncedRecordsForAllProfiles`
+(CRITICAL-1, corrected).** That backfill filters `encoded_system_fields IS NULL`
+(`unsyncedRowIdsSync`, `GRDBTransactionLegRepository.swift:189-196`), but the
+#1081/#1085 update path **preserves the cached blob and only sets
+`needs_push=1`** (`GRDBTransactionRepository+Update.swift:55-61`, comment: blob
+preserved specifically so the row is *not* re-uploaded as unsynced). So any
+record edited after first sync has blob ≠ NULL and is **invisible** to the
+backfill → its pending save is dropped on reset → permanent loss of the
+create→update edit (the exact migration pattern). The backfill also skips
+profiles with `hasCompletedBackfillScan` (`+Backfill.swift:74`; persisted, cleared
+only on sign-out) → on an existing install it queues **zero**. Therefore a reset
+**must** use the `isFirstLaunch=true` → `queueAllExistingRecordsForAllZones` path,
+which enumerates *every* local row (save-complete) regardless of blob/needs_push.
+
+**A reset resurrects deleted data (CRITICAL-2).** No tombstone table exists; a
+pending `.deleteRecord` lives only in engine state, and the local row is already
+gone, so nothing re-derives it. Reset + token-less refetch re-downloads the
+server copy → user-deleted financial data **reappears**. #1085 gates saves, not
+deletes. This fails the project's no-data-loss bar, so a reset must replay
+deletions from a durable tombstone — net-new infrastructure (§2 fallback).
+
+These two are why the reset is demoted to a last-resort fallback and the off-main
+route is primary.
+
+**(ii) Layer-2 (2a/2b) must distinguish "genuinely deleted" from "transiently
+missing".** Today the lookup **conflates** them: `recordToSave` /
+`buildBatchRecordLookup` return `nil` for *both* "row absent" *and* "GRDB fetch
+errored", because `fetchRowOrLog` / `fetchRowsBatch`
+(`ProfileDataSyncHandler+RecordLookup.swift:376,312`) swallow errors into
+`nil`/`[]`. Removing a save on that conflated `nil` would convert a transient
+read error into a queued **server deletion** — a latent data-loss path that
+exists *today* (it already queues a delete). **Prerequisite for 2a/2b:** surface
+a tri-state from the lookup —
+
+| outcome | classify as | action |
+|---|---|---|
+| row genuinely absent | **absent** | remove `.saveRecord` (+ queue delete) |
+| GRDB fetch threw | **failed** | keep pending, retry — never remove/delete |
+| handler build threw (`+Delegate.swift:281`) | **failed** | unchanged: keep pending ("exit-on-unresolved-id" safety, preserved verbatim) |
+
+Only **absent** removes a save. This *strengthens* the send path: a transient
+GRDB blip can no longer silently delete a live record server-side.
+
+---
+
+## 4. How the EXISTING 42.5 MB state gets unblocked
+
+**Primary path (off-main, no data loss).** On first launch of the fixed build,
+`CKSyncEngine.init` runs off-main (Task.detached) on the 42.5 MB state while the
+MainActor is kept free (conversion storm deferred). Init completes, the engine
+hops back to the MainActor, **"Started unified sync coordinator" logs**, and
+`completeStart` runs: the existing purges + Layer 2a/2b clear the dead head,
+`sendChanges` builds > 0, and the queue drains with **tokens and all pending
+data preserved**. No refetch, no resurrection. The migration unblocks.
+
+The decisive uncertainty is whether off-main init **completes in acceptable
+time** on the 31 MB blob with main free — that is the spike the implementer +
+verifier run on the live state (§2 Layer 1). Recovery is automatic on next
+launch; no manual tool.
+
+**Fallback path (only if the spike fails).** The size-gated reset (§2 fallback),
+which would need the save-complete re-queue (`isFirstLaunch=true` /
+`queueAllExistingRecordsForAllZones`) **and** tombstone-based deletion replay
+before it is safe to ship. Documented, not recommended.
+
+---
+
+## 5. Production relevance (not a dev-only band-aid)
+
+The trigger here is deleted *test* profiles, but **deleting any real profile with
+a large pending queue reproduces it in production**: deletion never purges the
+profile's queued changes (Problem 2 / §2c), and a large enough leftover queue
+re-bloats the state until startup stalls (Problem 1). Both layers are therefore
+scoped to be production-correct: 2c prevents accumulation at the source for all
+users; off-main startup (Layer 1) keeps any pathological-state launch from
+freezing without sacrificing data.
+
+---
+
+## 6. Tests
+
+- **Problem-2 head-of-line reproduction (load-bearing):** seed engine state with
+  N `.saveRecord`s for a profile-data zone whose local rows don't exist; drive
+  `nextRecordZoneChangeBatchOnMain` repeatedly. Today: builds 0, saves persist.
+  After 2a: stale saves are **removed**, queue drains to the next buildable batch.
+- **Clean-miss vs error (safety):** a per-type lookup that **throws** leaves the
+  `.saveRecord` pending and queues **no** delete; a clean **absent** row removes
+  the save and queues the delete. Locks §3(ii).
+- **Handler-throw preserved:** `handlerForProfileZone` throw → records stay
+  pending, nothing removed/deleted (regression-lock on `+Delegate.swift:281`).
+- **Off-main startup (Layer 1, the decisive spike — live, not a unit test):** on
+  the 42.5 MB state with init forced off-main and the conversion storm quiesced,
+  confirm `CKSyncEngine.init` completes and **"Started unified sync coordinator"**
+  logs (verifier owns this on the live machine). Unit-side: assert `start()`
+  constructs the engine off the MainActor and `completeStart` runs even while a
+  synthetic MainActor-bound workload is enqueued.
+- **Delete-time purge (2c):** delete a profile with queued saves → its pending
+  changes are gone from engine state; a surviving profile's are untouched.
+- **Start-time purge (2b):** seed pending saves for gone-locally prefixed records
+  + live records; assert only the gone ones are removed.
+- **Reset fallback (only if the spike fails, and only once built):** after a
+  reset, `completeStart` runs `queueAllExistingRecordsForAllZones` (save-complete
+  — every local row re-queued, including blob≠NULL/`needs_push=1` edited rows),
+  **not** `queueUnsyncedRecordsForAllProfiles`; and queued deletions are replayed
+  from the tombstone so deleted records are not resurrected.
+
+---
+
+## 7. Decisions & scope (resolved with the owner)
+
+The spike result — **not** another doc round — gates the design from here.
+
+1. **The spike is the gate.** Does off-main init complete on the live 42.5 MB
+   state (storm present) and the queue drain? Yes → design settled (off-main +
+   Layer 2), adversary reviews the *implementation*. No → re-engage on the reset
+   fallback. Owned by implementer + verifier.
+2. **Conversion-storm quiesce — NOT built pre-emptively (resolved).** The spike
+   runs with the storm present. Only if the storm *continuously* starves
+   `completeStart` do we act, and then "conversion storm starves the MainActor"
+   is a **separate Analysis-path performance issue with its own owner**, filed
+   separately — **not** part of this sync wedge fix.
+3. **Deletion tombstone — OUT of scope (conditional prerequisite, resolved).**
+   Not built now. **IF** the off-main spike fails and a reset becomes necessary,
+   the durable deletion-intent tombstone replay is a **required prerequisite
+   task** (separate PR) before any reset ships, alongside the save-complete
+   `queueAllExistingRecordsForAllZones` re-queue and owner sign-off.
+4. **2b scope/cost (still open).** Is the start-time purge worth its per-record
+   lookups, or are 2a (remove-in-place) + 2c (delete-time purge) sufficient, with
+   2b folded into the existing backfill scan only? — for the implementation
+   review.
+
+---
+
+## 8. Citations (code in this worktree + the live artifact)
+
+- Startup/init stall: `SyncCoordinator+Lifecycle.swift` — `start():80`,
+  `prepareEngine:113` (`CKSyncEngine(configuration):127`), `completeStart:133`
+  ("Started…" `:145`), existing purges `:156/:165`, `hasPendingChanges:277`,
+  `sendChanges:314`. `SyncCoordinator.swift:20` (`@MainActor`),
+  `:54` (`PreparedEngine`), `:87` (`stateFileURL`).
+- State persistence/shape: `SyncCoordinator+StatePersistence.swift` (JSON
+  encode/decode of `State.Serialization`); live artifact
+  `…/Development/Moolah-v2-sync.syncstate` = 42.5 MB `{"data": base64(bplist00,
+  31.7 MB)}` (opaque; tokens+pending bundled).
+- Head-of-line wedge: `SyncCoordinator+Delegate.swift` —
+  `nextRecordZoneChangeBatchOnMain:88`, `appendProfileDataRecords:271`
+  (handler-throw early-return `:281`), `handleMissingRecordsToSave:350`,
+  `logBatchOutcome:178`. `+BatchKind.swift` `selectBatchKind:29`/`filterChanges:50`.
+  `+QueueChanges.swift` `newMissingDeleteIDs:57` (comment `:51-56`).
+- Re-derivation from `needs_push`: `SyncCoordinator+Backfill.swift`
+  `queueUnsyncedRecordsForAllProfiles:65` (→ `queueUnsyncedRecords()`,
+  `encodedSystemFields == nil`), `queueAllExistingRecordsForAllZones:131`.
+- Lookup error-swallowing (the conflation): `ProfileDataSyncHandler+RecordLookup.swift`
+  `fetchRowsBatch:312`, `fetchRowOrLog:376`.
+- Empty-DB re-creation for a deleted profile: `+HandlerAccess.swift:44` →
+  `ProfileContainerManager.swift:68` (`database(for:)` → `ProfileDatabase.open`);
+  delete path `deleteStore:115`, `evictCachedState:79`.
+- `state.remove` precedent: `+Lifecycle.swift:308`,
+  `+LegacyInstrumentDrain.swift:69`.
+- CRITICAL-1 evidence: `GRDBTransactionLegRepository.swift:189-196`
+  (`unsyncedRowIdsSync` = `encoded_system_fields IS NULL`);
+  `GRDBTransactionRepository+Update.swift:55-61,105` (blob preserved, only
+  `needs_push` set); `+Backfill.swift:74` (`hasCompletedBackfillScan` skip).
+
+---
+
+## 9. Reconciliation with the adversary review (what changed and why)
+
+This revision **withdraws the reset as the primary fix** and pivots to off-main
+startup, after the adversary surfaced two data-loss criticals and a likely
+misdiagnosis. All three are accepted, verified against the code:
+
+- **CRITICAL-1 (accepted, code-confirmed).** The prior draft claimed a reset is
+  save-safe because `queueUnsyncedRecordsForAllProfiles` re-derives unsynced
+  records. False: that backfill filters `encoded_system_fields IS NULL`, but the
+  update path **preserves the blob and only sets `needs_push=1`**
+  (`GRDBTransactionRepository+Update.swift:57-61` says so explicitly), so
+  edited-after-sync records are invisible to it and would be dropped — exactly the
+  migration's create→update edits. Fix: a reset must use
+  `queueAllExistingRecordsForAllZones` (`isFirstLaunch=true`); the prior
+  `isFirstLaunch=false` optimisation was a data-loss bug and is removed.
+- **CRITICAL-2 (accepted).** No tombstone table exists, so a reset loses pending
+  deletes and resurrects deleted data on refetch. A reset now requires durable
+  deletion-intent replay before it can ship.
+- **IMPORTANT-3 / #565 reconciliation (accepted).** I over-read a single process
+  `sample` as "init blocks main." The code shows `CKSyncEngine.init` is called
+  synchronously from the `nonisolated` `prepareEngine`, so it is **not**
+  `@MainActor`-isolated and runs off-main (#565 verified `isMainThread==false`).
+  The sample is far more consistent with the **main thread pinned by the
+  Insights/Analysis conversion storm** while init runs off-main and the
+  `@MainActor` `completeStart` continuation is starved. So the lever is to free
+  the MainActor / guarantee off-main init — preserving all data — not to slim the
+  state. The reset is demoted to a last-resort fallback pending the spike result.
+
+**Endorsed and unchanged:** Layer 2 (2a remove-in-place + 2c delete-time purge +
+the tri-state clean-miss/lookup-error/handler-throw safety, §3 ii) — it closes a
+real latent data-loss path today and lands regardless of the Layer-1 outcome.


### PR DESCRIPTION
## Summary

Fixes #1087 — a CKSyncEngine upload-queue wedge that blocked all uploads (and the crypto migration's STEP 3). Surfaced while verifying #1085.

**Root cause.** A bloated/stale persisted pending-change queue. When a profile is deleted, its queued `.saveRecord`s are left in `CKSyncEngine.State.pendingRecordZoneChanges`; on each send pass the batch builder selects the front `prefix(400)`, `recordToSave` returns nil (records gone), so `built=0` and the compensating `.deleteRecord`s are appended *past* the 400-window — the dead head is re-selected forever and **every real upload is starved**. The queue grows unbounded; eventually the serialized state is large enough that `CKSyncEngine.init` (off-main, but a single-threaded `NSKeyedUnarchiver` over ~150k pending changes) no longer completes in usable time, so `start()` never returns.

This PR ships the **prevention** (no risky recovery/reset — see below):
- **Remove the stale `.saveRecord` on a clean miss** in `handleMissingRecordsToSave` (not just queue the compensating delete), so the head clears and the queue drains ~400/cycle.
- **Purge a profile's pending changes when it's deleted** (`purgePendingChanges(forProfileZone:)`, wired into `onProfileRemoved` only — *not* `evictCachedState`, which also fires on the data-format gate where the profile still exists) — the root cause of the bloat.

**Also closes a latent data-loss bug that existed today.** The lookup wrappers swallowed GRDB read errors to `nil`/`[]`, indistinguishable from "row absent" — so a *transient* read error queued a server **deletion of a live record**. This PR introduces a tri-state (`RecordLookupOutcome`: found / absent / failed; `BatchLookupOutcome`: succeeded / failed): only a query that **succeeds** with a missing id is `absent` (→ remove stale save + queue delete); any **throw** (per-record, batch — whole group — or handler) is `failed` → everything stays pending, nothing removed or deleted. Threaded through the batch, per-record/`recordToSave`, and instrument string-keyed paths; unknown record types now throw rather than mis-classify as absent.

## What this deliberately does NOT do

No in-app state reset / `stateSerialization: nil` recovery for *already*-bloated installs. The adversarial review showed a reset would itself be data-lossy (the `needs_push`-only backfill misses edited-after-sync records; pending deletions aren't re-derivable → deleted data resurrects on refetch). Prevention (this PR) stops the queue ever reaching that state. A safe recovery path for pre-existing bloated installs is left as a separate, deferred decision.

## Tests

`RecordLookupTriStateTests` (found→upload / absent→remove+delete / failed→stays-pending / batch-throw-removes-nothing, with real GRDB throws via `DROP TABLE`), `UploadQueueWedgeTests` incl. `multiCycleDrainEmptiesStaleSaves` (50 stale + 5 live → queue empties across cycles, every stale id deleted once, no live record ever deleted). A literal engine-bound `nextRecordZoneChangeBatchOnMain` e2e is fast-follow #1088 (needs an injectable pending-change store). Full macOS suite green (3966), `format-check` clean, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
