### PR TITLE
fix(sync): start-time reconciliation purges pending for profiles deleted before sync started (#1091)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -180,6 +180,13 @@ extension SyncCoordinator {
     // `containerManager.allProfileIds()` is now async (it must not block
     // the main thread on the GRDB queue).
     zoneSetupTask = Task {
+      // Start-time reconciliation (issue #1091): purge pending orphaned by a
+      // profile deleted before the engine existed — see
+      // `reconcilePendingAgainstLiveProfiles()`. It fetches its OWN live set via
+      // the throwing path — must NOT use `profileIds` below (`allProfileIds()`
+      // swallows errors to `[]`).
+      await self.reconcilePendingAgainstLiveProfiles()
+
       // On first launch (migration or truly first launch), queue all existing records
       if runFirstLaunchQueue {
         await self.queueAllExistingRecordsForAllZones()

--- a/Backends/CloudKit/Sync/SyncCoordinator+StartupReconciliation.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+StartupReconciliation.swift
@@ -1,0 +1,119 @@
+@preconcurrency import CloudKit
+import Foundation
+
+// Start-time reconciliation of the pending-change queue against the live
+// profile set (issue #1091). `purgePendingChanges(forProfileZone:)` no-ops on a
+// nil `syncEngine`, so a profile deleted before or during `init` orphans its
+// queued `.saveRecord`/`.deleteRecord` in the persisted state, re-bloating it on
+// every subsequent launch. This reconciliation runs once the engine is up (in
+// `completeStart`'s `zoneSetupTask`) and removes pending for any profile-data
+// zone whose profile is absent from the live set.
+
+extension SyncCoordinator {
+  /// Result of reading the authoritative live profile set for reconciliation.
+  /// The `available` / `unavailable` split is load-bearing: `available([])`
+  /// (all profiles really deleted — safe to act on) must be distinguishable
+  /// from `unavailable` (the read threw — never purge), so the result is NOT a
+  /// plain `Set` where "empty" would conflate the two.
+  enum LiveProfileSet: Equatable {
+    /// The read succeeded; these are the live profile ids (possibly empty).
+    case available(Set<UUID>)
+    /// The read failed — leave all pending intact and retry next launch.
+    case unavailable
+  }
+
+  /// The subset of `changes` that target a `.profileData(pid)` zone whose `pid`
+  /// is not in `liveIds` (a deleted profile). Profile-index and unknown zones
+  /// are never purged. Pure + `nonisolated static` so the classification is
+  /// unit-testable without a live `CKSyncEngine`.
+  nonisolated static func pendingToPurge(
+    _ changes: [CKSyncEngine.PendingRecordZoneChange], liveIds: Set<UUID>
+  ) -> [CKSyncEngine.PendingRecordZoneChange] {
+    changes.filter { isPendingForDeadProfile($0, liveIds: liveIds) }
+  }
+
+  /// True when `change` targets a profile-data zone whose profile is absent
+  /// from the live set. `.profileIndex` (shared registry — no separate
+  /// instrument zone) and `.unknown` zones return `false` (never purged).
+  nonisolated private static func isPendingForDeadProfile(
+    _ change: CKSyncEngine.PendingRecordZoneChange, liveIds: Set<UUID>
+  ) -> Bool {
+    let zoneID: CKRecordZone.ID
+    switch change {
+    case .saveRecord(let id): zoneID = id.zoneID
+    case .deleteRecord(let id): zoneID = id.zoneID
+    @unknown default: return false
+    }
+    switch parseZone(zoneID) {
+    case .profileData(let profileId): return !liveIds.contains(profileId)
+    case .profileIndex, .unknown: return false
+    }
+  }
+}
+
+@MainActor
+extension SyncCoordinator {
+  /// Purges pending changes for profile-data zones whose profile is absent from
+  /// the live set. Fetches the live set via the `throws`-propagating path and
+  /// skips entirely on any error — see `liveProfileIdsForReconciliation()`. The
+  /// profile-index zone (shared instrument registry) and unknown zones are
+  /// never touched.
+  func reconcilePendingAgainstLiveProfiles() async {
+    guard syncEngine != nil else { return }
+    // The live set could not be positively determined (the read threw) → skip
+    // and retry next launch. NEVER purge on an unknown live set, or a transient
+    // read error would orphan every profile-data zone.
+    guard case .available(let liveIds) = await liveProfileIdsForReconciliation()
+    else { return }
+    purgePendingForDeadProfiles(liveIds: liveIds)
+  }
+
+  /// The authoritative live profile id set, fetched via the `throws`-propagating
+  /// `allRowIds()`, or `.unavailable` when the read fails (→ caller skips).
+  ///
+  /// **Load-bearing safety.** This MUST NOT use `containerManager.allProfileIds()`,
+  /// which swallows GRDB errors to `[]` — keying on that would let a transient
+  /// index-DB read error present as "zero live profiles", marking every
+  /// profile-data zone dead and purging all profile-data pending (catastrophic
+  /// loss). The throwing path distinguishes "really empty" (all profiles
+  /// deleted — `available([])`) from "couldn't read" (`unavailable`). Do NOT
+  /// reuse `completeStart`'s `profileIds`.
+  func liveProfileIdsForReconciliation() async -> LiveProfileSet {
+    do {
+      return .available(Set(try await profileIndexHandler.repository.allRowIds()))
+    } catch {
+      // Intentional non-propagation — see the doc comment: a failed read must
+      // degrade to "skip purging", never throw out of startup.
+      logger.error(
+        """
+        Start-time reconciliation skipped — live-profile read failed: \
+        \(error, privacy: .public). Leaving all pending intact; retry next launch.
+        """)
+      return .unavailable
+    }
+  }
+
+  /// Removes the pending changes for dead-profile zones in one `state.remove`.
+  ///
+  /// **Atomicity.** There is NO `await` between the `pendingRecordZoneChanges`
+  /// snapshot and the `remove`, so no concurrent MainActor mutation can
+  /// interleave the read and the write — do not insert an `await` here.
+  ///
+  /// A profile created in the gap between the `liveIds` snapshot and this
+  /// filter could in principle have its just-queued pending purged (it isn't in
+  /// `liveIds`); that is benign. A brand-new profile's records all have
+  /// `encoded_system_fields == nil`, so the `queueUnsyncedRecordsForAllProfiles`
+  /// pass later in the same `zoneSetupTask` re-queues every affected row before
+  /// the first send.
+  private func purgePendingForDeadProfiles(liveIds: Set<UUID>) {
+    guard let syncEngine else { return }
+    let stale = Self.pendingToPurge(
+      syncEngine.state.pendingRecordZoneChanges, liveIds: liveIds)
+    guard !stale.isEmpty else { return }
+    logger.warning(
+      "Start-time reconciliation: purging \(stale.count, privacy: .public) orphaned pending change(s) for deleted profile(s)"
+    )
+    syncEngine.state.remove(pendingRecordZoneChanges: stale)
+    refreshPendingUploadsMirror()
+  }
+}

--- a/MoolahTests/Sync/StartupReconciliationTests.swift
+++ b/MoolahTests/Sync/StartupReconciliationTests.swift
@@ -1,0 +1,151 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for the start-time pending-change reconciliation (issue #1091): once
+/// the engine is up, pending changes for a profile-data zone whose profile is
+/// no longer live are purged, while the profile-index zone, unknown zones, and
+/// live profiles are left intact — and the live set is fetched via the
+/// THROWING path so a transient read error never purges anything.
+///
+/// The `state.remove` itself runs against a live `CKSyncEngine` (unfabricatable
+/// in the test process), so it is covered via the pure `pendingToPurge`
+/// classification plus the `liveProfileIdsForReconciliation()` throwing gate —
+/// the two pieces `reconcilePendingAgainstLiveProfiles` composes.
+@Suite("start-time pending reconciliation (issue #1091)")
+@MainActor
+struct StartupReconciliationTests {
+  private static func zone(_ name: String) -> CKRecordZone.ID {
+    CKRecordZone.ID(zoneName: name, ownerName: CKCurrentUserDefaultName)
+  }
+
+  private static func dataZone(_ profileId: UUID) -> CKRecordZone.ID {
+    zone("profile-\(profileId.uuidString)")
+  }
+
+  private static func save(_ name: String, in zone: CKRecordZone.ID)
+    -> CKSyncEngine.PendingRecordZoneChange
+  {
+    .saveRecord(CKRecord.ID(recordName: name, zoneID: zone))
+  }
+
+  private static func delete(_ name: String, in zone: CKRecordZone.ID)
+    -> CKSyncEngine.PendingRecordZoneChange
+  {
+    .deleteRecord(CKRecord.ID(recordName: name, zoneID: zone))
+  }
+
+  // MARK: - Classification (pure)
+
+  @Test("purges a dead profile's pending; keeps live, profile-index, and unknown zones")
+  func purgesOnlyDeadProfileZones() {
+    let live = UUID()
+    let dead = UUID()
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      Self.save("live-save", in: Self.dataZone(live)),
+      Self.save("dead-save", in: Self.dataZone(dead)),
+      Self.delete("dead-delete", in: Self.dataZone(dead)),
+      Self.save("index", in: Self.zone("profile-index")),
+      Self.save("weird", in: Self.zone("some-other-zone")),
+    ]
+
+    let purge = SyncCoordinator.pendingToPurge(changes, liveIds: [live])
+
+    // Exactly the two dead-profile-zone changes (save + delete).
+    #expect(purge.count == 2)
+    #expect(purge.contains(Self.save("dead-save", in: Self.dataZone(dead))))
+    #expect(purge.contains(Self.delete("dead-delete", in: Self.dataZone(dead))))
+    // Live, profile-index, and unknown zones are never purged.
+    #expect(!purge.contains(Self.save("live-save", in: Self.dataZone(live))))
+    #expect(!purge.contains(Self.save("index", in: Self.zone("profile-index"))))
+    #expect(!purge.contains(Self.save("weird", in: Self.zone("some-other-zone"))))
+  }
+
+  @Test("an empty live set purges every profile-data zone (all profiles deleted)")
+  func emptyLiveSetPurgesAllProfileData() {
+    let first = UUID()
+    let second = UUID()
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      Self.save("a", in: Self.dataZone(first)),
+      Self.save("b", in: Self.dataZone(second)),
+      Self.save("index", in: Self.zone("profile-index")),
+      Self.save("weird", in: Self.zone("xyz")),
+    ]
+
+    let purge = SyncCoordinator.pendingToPurge(changes, liveIds: [])
+
+    // Both profile-data zones purged; profile-index + unknown kept.
+    #expect(purge.count == 2)
+    #expect(!purge.contains(Self.save("index", in: Self.zone("profile-index"))))
+    #expect(!purge.contains(Self.save("weird", in: Self.zone("xyz"))))
+  }
+
+  @Test("no dead-profile pending → removes nothing (idempotent)")
+  func noDeadProfilesRemovesNothing() {
+    let live = UUID()
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      Self.save("live", in: Self.dataZone(live)),
+      Self.save("index", in: Self.zone("profile-index")),
+    ]
+    #expect(SyncCoordinator.pendingToPurge(changes, liveIds: [live]).isEmpty)
+  }
+
+  // MARK: - Live-set fetch (throwing gate)
+
+  private func makeCoordinator() throws -> (SyncCoordinator, ProfileContainerManager) {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = try #require(
+      UserDefaults(suiteName: "reconcile-test-\(UUID().uuidString)"))
+    let coordinator = SyncCoordinator(containerManager: manager, userDefaults: defaults)
+    return (coordinator, manager)
+  }
+
+  private func seedProfile(_ manager: ProfileContainerManager, id: UUID) async throws {
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: id, label: "P", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+  }
+
+  /// REQUIRED safety lock: the reconciliation's OWN live-set read actually
+  /// throws (the profile table is dropped) → `nil`, so the caller purges
+  /// nothing. Exercises the real `allRowIds()` throwing path — a stub of
+  /// `allProfileIds() → []` would NOT cover this.
+  @Test("a throwing live-set read yields nil (skip — never purge on an unknown live set)")
+  func throwingLiveSetReadYieldsNil() async throws {
+    let (coordinator, manager) = try makeCoordinator()
+    // Force `allRowIds()` to throw by dropping the table it queries.
+    try await manager.profileIndexRepository.database.write { database in
+      try database.execute(sql: "DROP TABLE profile")
+    }
+
+    let result = await coordinator.liveProfileIdsForReconciliation()
+
+    #expect(result == .unavailable)
+  }
+
+  /// A genuinely-empty live set (no profiles, no error) is distinguished from a
+  /// failed read: it returns an empty set (non-nil), which IS safe to act on.
+  @Test("a genuinely-empty live set returns an empty set, not nil")
+  func genuinelyEmptyLiveSetReturnsEmpty() async throws {
+    let (coordinator, _) = try makeCoordinator()
+    let result = await coordinator.liveProfileIdsForReconciliation()
+    #expect(result == .available(Set<UUID>()))
+  }
+
+  @Test("a populated live set returns exactly the registered profile ids")
+  func populatedLiveSetReturnsIds() async throws {
+    let (coordinator, manager) = try makeCoordinator()
+    let first = UUID()
+    let second = UUID()
+    try await seedProfile(manager, id: first)
+    try await seedProfile(manager, id: second)
+
+    let result = await coordinator.liveProfileIdsForReconciliation()
+
+    #expect(result == .available(Set([first, second])))
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1091. A profile deleted **before the sync engine has started** (engine still initializing, or app launched suspended) orphaned its queued pending changes: `onProfileRemoved` → `queueDeletion` → `syncEngine?.state.add(...)` no-ops while `syncEngine` is nil, so the deletion never propagated and the records sat pending forever. (Surfaced live: deleting profiles during a slow init left ~310k pending orphaned.) This is the deferred "start-time reconciliation" from the #1087 wedge work — now load-bearing.

## Fix

A start-time reconciliation (`SyncCoordinator+StartupReconciliation.swift`), run as the first step of `completeStart`'s `zoneSetupTask` (after the engine is installed, before the backfill): it fetches the live profile set and purges any pending change whose `.profileData(pid)` zone's `pid` is no longer live. So a profile deleted at any time — before sync started, while the app was closed, mid-init — self-heals on the next sync start, with no timing dependency.

**Load-bearing safety (this purges pending — a wrong live set would be data loss):**
- The live set comes **only** from the throwing `profileIndexHandler.repository.allRowIds()`, modelled as `LiveProfileSet { .available(Set<UUID>) | .unavailable }`. **Any throw → `.unavailable` → return without purging.** It never uses the error-swallowing `allProfileIds()` (which fails to `[]` — that would make a transient read error look like "no profiles exist" → purge everything), and never reuses `completeStart`'s `profileIds`.
- A genuine `.available([])` (all profiles really deleted) *is* acted on — the throwing path is what distinguishes "really empty" from "couldn't read."
- Only `.profileData(pid)` with a non-live `pid` is purged; the profile-index/instrument zone and unknown zones are left intact.
- The snapshot→filter→`state.remove` runs with no `await` interleave (atomic on the main actor); a profile created in the live-set-fetch gap self-heals via the backfill that runs immediately after.

Composes with the #1087 purge-on-delete (2c, the immediate path) — this is the start-time backstop for the engine-down case.

## Tests

`StartupReconciliationTests`: dead-profile pending purged; live / profile-index / unknown kept; genuine-empty live set purges all profile-data; idempotent; and the **forced-throw lock** — `DROP TABLE profile` so the real `allRowIds()` throws → `.unavailable` → nothing purged (a stub of `allProfileIds()→[]` would not cover this). Full macOS suite green (3972), format-check clean, zero warnings.

## Scope

Out of scope (separate, tracked): durable deletion of the index *record* itself when deleted-while-engine-down (#1090 — empty-shell resurrection); this PR purges orphaned *data-zone pending*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
