### PR TITLE
fix(sync): preserve encoded_system_fields across leg edits — close the automation write-path echo-clobber (#1085 follow-up)

### DIFF
--- a/Automation/AutomationService+Legs.swift
+++ b/Automation/AutomationService+Legs.swift
@@ -103,7 +103,7 @@ extension AutomationService {
     // intact) and append the new manual leg, which carries no externalId.
     var updated = transaction
     updated.legs.append(newLeg)
-    return try await save(updated, id: transactionId, session: session)
+    return try await save(updated, session: session)
   }
 
   /// Edits one leg in place, identified by `legId`. Every supplied field in
@@ -154,7 +154,7 @@ extension AutomationService {
 
     var updated = located.transaction
     updated.legs[located.index] = edited
-    return try await save(updated, id: located.transaction.id, session: session)
+    return try await save(updated, session: session)
   }
 
   /// Drops the leg identified by `legId` from its transaction. Throws
@@ -172,25 +172,28 @@ extension AutomationService {
 
     var updated = located.transaction
     updated.legs.remove(at: located.index)
-    return try await save(updated, id: located.transaction.id, session: session)
+    return try await save(updated, session: session)
   }
 
   // MARK: - Helpers
 
-  /// Re-saves `transaction` under its own id via `replace(deletingIds:creating:)`
-  /// — an atomic delete-then-insert that re-writes every leg from the in-memory
-  /// model, so the carried-through legs persist exactly as supplied. Returns the
-  /// freshly persisted transaction.
+  /// Re-saves `transaction` in place via `update(_:)` — an in-place upsert
+  /// that diffs legs against the persisted set by stable id, so every
+  /// carried-through leg (and the header) keeps its cached
+  /// `encoded_system_fields` blob and therefore its CloudKit sync identity.
+  ///
+  /// This is the load-bearing choice over `replace(deletingIds:creating:)`:
+  /// a delete-then-insert nulls those blobs on the re-created same-id rows,
+  /// and once such a row goes clean the #1085 modification-date gate fails
+  /// open on the nil cache, letting a stale self-echo clobber the edit back
+  /// to its previous version (the placeholder-revert data loss — issue #1090
+  /// follow-up). `update` re-attaches the blobs, so the gate protects the row
+  /// unconditionally. Returns the freshly persisted transaction.
   private func save(
-    _ transaction: Transaction, id: UUID, session: ProfileSession
+    _ transaction: Transaction, session: ProfileSession
   ) async throws -> Transaction {
     do {
-      let created = try await session.backend.transactions.replace(
-        deletingIds: [id], creating: [transaction])
-      guard let result = created.first else {
-        throw AutomationError.operationFailed("Saving the transaction produced no result")
-      }
-      return result
+      return try await session.backend.transactions.update(transaction)
     } catch let error as AutomationError {
       throw error
     } catch {

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
@@ -1,5 +1,3 @@
-// Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
-
 import Foundation
 import GRDB
 
@@ -43,9 +41,11 @@ extension GRDBTransactionRepository {
   /// blob can never cross-attach to a header that happens to share a UUID).
   /// When a re-created row reuses a deleted row's id, its blob is re-attached
   /// here so the row keeps its CloudKit sync identity and the #1085 gate
-  /// protects it; a row whose id is absent from the map lands with `nil`
-  /// (a genuine new record). Both default to empty, so `createMany` inserts
-  /// fresh rows with `nil` blobs exactly as before. See issue #1090 follow-up.
+  /// protects it. A row whose id is absent from the map lands with `nil`
+  /// (a genuine new record); a present entry whose value is `nil` (the
+  /// deleted row had never synced) re-attaches `nil`, which is also correct.
+  /// Both maps default to empty, so a call from `createMany` inserts fresh
+  /// rows with `nil` blobs (genuine new records). See issue #1090.
   static func performCreateMany(
     database: Database,
     transactions: [Transaction],

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
@@ -35,24 +35,45 @@ extension GRDBTransactionRepository {
   /// instrument registration happens *before* this write via
   /// `registerNonFiatLegInstruments` — see
   /// `GRDBTransactionRepository.createMany(_:)`.
+  ///
+  /// `preservedTransactionFields` / `preservedLegFields` carry the cached
+  /// `encoded_system_fields` blobs of rows being deleted in the same
+  /// `replace` write, keyed by record id and STRICTLY per record type (a
+  /// header map and a leg map — never one flat `[UUID: Data?]`, so a leg
+  /// blob can never cross-attach to a header that happens to share a UUID).
+  /// When a re-created row reuses a deleted row's id, its blob is re-attached
+  /// here so the row keeps its CloudKit sync identity and the #1085 gate
+  /// protects it; a row whose id is absent from the map lands with `nil`
+  /// (a genuine new record). Both default to empty, so `createMany` inserts
+  /// fresh rows with `nil` blobs exactly as before. See issue #1090 follow-up.
   static func performCreateMany(
     database: Database,
-    transactions: [Transaction]
+    transactions: [Transaction],
+    preservedTransactionFields: [UUID: Data?] = [:],
+    preservedLegFields: [UUID: Data?] = [:]
   ) throws -> [UUID] {
     var legIds: [UUID] = []
     legIds.reserveCapacity(transactions.reduce(0) { $0 + $1.legs.count })
 
     for transaction in transactions {
-      let txnRow = TransactionRow(domain: transaction)
+      var txnRow = TransactionRow(domain: transaction)
+      // Re-attach a reused header's cached blob (outer `if let` unwraps the
+      // map miss; an existing entry carrying `nil` still overwrites).
+      if let preserved = preservedTransactionFields[transaction.id] {
+        txnRow.encodedSystemFields = preserved
+      }
       try txnRow.insert(database)
       try markTransactionNeedsPush(id: transaction.id, in: database)
 
       for (index, leg) in transaction.legs.enumerated() {
-        let legRow = TransactionLegRow(
+        var legRow = TransactionLegRow(
           id: leg.id,
           domain: leg,
           transactionId: transaction.id,
           sortOrder: index)
+        if let preserved = preservedLegFields[leg.id] {
+          legRow.encodedSystemFields = preserved
+        }
         try legRow.insert(database)
         try markLegNeedsPush(id: leg.id, in: database)
         legIds.append(leg.id)

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Replace.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Replace.swift
@@ -1,5 +1,3 @@
-// Backends/GRDB/Repositories/GRDBTransactionRepository+Replace.swift
-
 import Foundation
 import GRDB
 
@@ -16,16 +14,21 @@ extension GRDBTransactionRepository {
   /// `delete(id:)` / `createMany(_:)`.
   ///
   /// When a `creating` transaction (or one of its legs) REUSES a
-  /// `deletingIds` row's id — as automation's in-place leg edits once did,
-  /// and as any caller that rewrites a row under its own id does — the
-  /// deleted row's cached `encoded_system_fields` blob is snapshotted
-  /// (strictly per record type) and re-attached to the re-created row, and
-  /// the self-queued `.deleteRecord` for that id is suppressed. Without that,
-  /// the re-created row would land with a `nil` cache; once it goes clean the
-  /// #1085 modification-date gate fails open and a stale self-echo clobbers
-  /// it back to the deleted version (the placeholder-revert data loss —
-  /// issue #1090 follow-up). Headers and legs whose ids are NOT reused are
-  /// deleted and fan out a `.deleteRecord` exactly as before.
+  /// `deletingIds` row's id — any caller that rewrites a row under its own
+  /// id — the deleted row's cached `encoded_system_fields` blob is
+  /// snapshotted (strictly per record type) and re-attached to the
+  /// re-created row, and the self-queued `.deleteRecord` for that id is
+  /// suppressed. Without that, the re-created row would land with a `nil`
+  /// cache; once it goes clean the #1085 modification-date gate fails open
+  /// and a stale self-echo clobbers it back to the deleted version (the
+  /// placeholder-revert data loss — issue #1090). Headers and legs whose ids
+  /// are NOT reused are deleted and fan out a `.deleteRecord`.
+  ///
+  /// A re-attached blob carries the change tag of the server's last-seen
+  /// version of that id, so the row's re-upload is a normal conditional
+  /// update on the existing record — not a fresh create that CloudKit would
+  /// reject with `.serverRecordChanged`. A genuine cross-device conflict is
+  /// still resolved by the existing conflict path; nothing here is new.
   func replace(
     deletingIds: [UUID],
     creating: [Transaction]
@@ -89,13 +92,16 @@ extension GRDBTransactionRepository {
         try TransactionLegRow
         .filter(TransactionLegRow.Columns.transactionId == id)
         .fetchAll(database)
+      let legIds = legRows.map(\.id)
       for legRow in legRows {
         preservedLegFields[legRow.id] = legRow.encodedSystemFields
       }
-      _ =
-        try TransactionLegRow
-        .filter(TransactionLegRow.Columns.transactionId == id)
-        .deleteAll(database)
+      if !legIds.isEmpty {
+        _ =
+          try TransactionLegRow
+          .filter(legIds.contains(TransactionLegRow.Columns.id))
+          .deleteAll(database)
+      }
       // Snapshot the header's blob before the row is removed.
       if let headerRow =
         try TransactionRow
@@ -108,7 +114,7 @@ extension GRDBTransactionRepository {
       guard didDelete else {
         throw BackendError.notFound("Transaction not found")
       }
-      deletedLegIds.append(contentsOf: legRows.map(\.id))
+      deletedLegIds.append(contentsOf: legIds)
     }
     return ReplaceDeletionSnapshot(
       deletedLegIds: deletedLegIds,
@@ -120,7 +126,7 @@ extension GRDBTransactionRepository {
 /// The deleted-side result of one `replace` write: the leg ids removed plus
 /// the per-record-type cached-blob snapshots used to re-attach a reused id's
 /// CloudKit system fields to its re-created row.
-private struct ReplaceDeletionSnapshot {
+private struct ReplaceDeletionSnapshot: Sendable {
   let deletedLegIds: [UUID]
   let preservedTransactionFields: [UUID: Data?]
   let preservedLegFields: [UUID: Data?]
@@ -130,7 +136,7 @@ private struct ReplaceDeletionSnapshot {
 /// the `database.write` closure so the post-commit sync hooks fan out
 /// after the transaction commits (a hook fired inside the write would
 /// observe rows that a later rollback discards).
-private struct ReplaceOutcome {
+private struct ReplaceOutcome: Sendable {
   let deletedLegIds: [UUID]
   let createdLegIds: [UUID]
 }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Replace.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Replace.swift
@@ -14,6 +14,18 @@ extension GRDBTransactionRepository {
   /// before the write for the same cross-database reason as `create`.
   /// Post-commit hooks fan out per deleted and per created row, matching
   /// `delete(id:)` / `createMany(_:)`.
+  ///
+  /// When a `creating` transaction (or one of its legs) REUSES a
+  /// `deletingIds` row's id — as automation's in-place leg edits once did,
+  /// and as any caller that rewrites a row under its own id does — the
+  /// deleted row's cached `encoded_system_fields` blob is snapshotted
+  /// (strictly per record type) and re-attached to the re-created row, and
+  /// the self-queued `.deleteRecord` for that id is suppressed. Without that,
+  /// the re-created row would land with a `nil` cache; once it goes clean the
+  /// #1085 modification-date gate fails open and a stale self-echo clobbers
+  /// it back to the deleted version (the placeholder-revert data loss —
+  /// issue #1090 follow-up). Headers and legs whose ids are NOT reused are
+  /// deleted and fan out a `.deleteRecord` exactly as before.
   func replace(
     deletingIds: [UUID],
     creating: [Transaction]
@@ -22,27 +34,15 @@ extension GRDBTransactionRepository {
       creating.flatMap(\.legs), using: instrumentRegistrar)
 
     let outcome = try await database.write { database -> ReplaceOutcome in
-      var deletedLegIds: [UUID] = []
-      for id in deletingIds {
-        let legIds =
-          try TransactionLegRow
-          .filter(TransactionLegRow.Columns.transactionId == id)
-          .fetchAll(database)
-          .map(\.id)
-        _ =
-          try TransactionLegRow
-          .filter(TransactionLegRow.Columns.transactionId == id)
-          .deleteAll(database)
-        let didDelete = try TransactionRow.deleteOne(database, id: id)
-        guard didDelete else {
-          throw BackendError.notFound("Transaction not found")
-        }
-        deletedLegIds.append(contentsOf: legIds)
-      }
+      let snapshot = try Self.deleteAndSnapshot(
+        deletingIds: deletingIds, in: database)
       let createdLegIds = try Self.performCreateMany(
-        database: database, transactions: creating)
+        database: database,
+        transactions: creating,
+        preservedTransactionFields: snapshot.preservedTransactionFields,
+        preservedLegFields: snapshot.preservedLegFields)
       return ReplaceOutcome(
-        deletedLegIds: deletedLegIds, createdLegIds: createdLegIds)
+        deletedLegIds: snapshot.deletedLegIds, createdLegIds: createdLegIds)
     }
 
     // Post-commit fan-out order: all deleted headers, then all deleted
@@ -50,10 +50,17 @@ extension GRDBTransactionRepository {
     // engine processes each emit independently by `(recordType, id)`,
     // so this grouped order is observationally equivalent to the
     // per-transaction header-then-legs order `delete(id:)` uses.
-    for id in deletingIds {
+    //
+    // Suppress the `.deleteRecord` for any id re-created in this same
+    // `replace`: the re-create already emits a `.saveRecord` (an upsert) for
+    // the reused id, so also queuing a delete would race a stale delete
+    // against that save. Genuinely-removed ids still fan out a delete.
+    let recreatedTransactionIds = Set(creating.map(\.id))
+    let recreatedLegIds = Set(outcome.createdLegIds)
+    for id in deletingIds where !recreatedTransactionIds.contains(id) {
       onRecordDeleted(TransactionRow.recordType, id)
     }
-    for legId in outcome.deletedLegIds {
+    for legId in outcome.deletedLegIds where !recreatedLegIds.contains(legId) {
       onRecordDeleted(TransactionLegRow.recordType, legId)
     }
     for transaction in creating {
@@ -64,6 +71,59 @@ extension GRDBTransactionRepository {
     }
     return creating
   }
+
+  /// Deletes every `deletingIds` transaction (legs first, then the header) and,
+  /// in the same pass, snapshots each deleted row's cached
+  /// `encoded_system_fields` blob — strictly per record type — so `replace`
+  /// can re-attach a blob to any re-created same-id row. Throws
+  /// `BackendError.notFound` if a header id is absent, preserving the original
+  /// all-or-nothing contract.
+  private static func deleteAndSnapshot(
+    deletingIds: [UUID], in database: Database
+  ) throws -> ReplaceDeletionSnapshot {
+    var deletedLegIds: [UUID] = []
+    var preservedTransactionFields: [UUID: Data?] = [:]
+    var preservedLegFields: [UUID: Data?] = [:]
+    for id in deletingIds {
+      let legRows =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.transactionId == id)
+        .fetchAll(database)
+      for legRow in legRows {
+        preservedLegFields[legRow.id] = legRow.encodedSystemFields
+      }
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.transactionId == id)
+        .deleteAll(database)
+      // Snapshot the header's blob before the row is removed.
+      if let headerRow =
+        try TransactionRow
+        .filter(TransactionRow.Columns.id == id)
+        .fetchOne(database)
+      {
+        preservedTransactionFields[id] = headerRow.encodedSystemFields
+      }
+      let didDelete = try TransactionRow.deleteOne(database, id: id)
+      guard didDelete else {
+        throw BackendError.notFound("Transaction not found")
+      }
+      deletedLegIds.append(contentsOf: legRows.map(\.id))
+    }
+    return ReplaceDeletionSnapshot(
+      deletedLegIds: deletedLegIds,
+      preservedTransactionFields: preservedTransactionFields,
+      preservedLegFields: preservedLegFields)
+  }
+}
+
+/// The deleted-side result of one `replace` write: the leg ids removed plus
+/// the per-record-type cached-blob snapshots used to re-attach a reused id's
+/// CloudKit system fields to its re-created row.
+private struct ReplaceDeletionSnapshot {
+  let deletedLegIds: [UUID]
+  let preservedTransactionFields: [UUID: Data?]
+  let preservedLegFields: [UUID: Data?]
 }
 
 /// Per-write tally of the leg ids touched by `replace`, carried out of

--- a/MoolahTests/Automation/AutomationLegEditSyncIdentityTests.swift
+++ b/MoolahTests/Automation/AutomationLegEditSyncIdentityTests.swift
@@ -4,20 +4,17 @@ import Testing
 
 @testable import Moolah
 
-/// Pins Fix #1 of the automation-write-path gap (issue #1090 follow-up): the
-/// genuine `AutomationService.updateLeg` verb must preserve the edited leg's
-/// cached `encoded_system_fields` (its CloudKit sync identity).
+/// Pins the automation-write-path fix (issue #1090): the genuine
+/// `AutomationService.updateLeg` verb must preserve the edited leg's cached
+/// `encoded_system_fields` (its CloudKit sync identity).
 ///
-/// `updateLeg` / `addLeg` / `removeLeg` funnel through `save(...)`, which now
-/// calls `transactions.update(_:)` (an in-place, diff-by-id upsert that
-/// re-attaches each surviving leg's blob) instead of
-/// `replace(deletingIds:creating:)` (a delete-then-insert that nulled the
-/// blob on the re-created same-id row). With a nil cache, a clean row falls
-/// through the #1085 modification-date gate's fail-open and a stale self-echo
-/// reverts the edit — the placeholder-revert data loss.
-///
-/// RED before Fix #1 (`save` → `replace` nulls the cache); GREEN after
-/// (`save` → `update` preserves it).
+/// `updateLeg` / `addLeg` / `removeLeg` funnel through `save(...)`, which
+/// calls `transactions.update(_:)` — an in-place, diff-by-id upsert that
+/// re-attaches each surviving leg's blob. A delete-then-insert
+/// `replace(deletingIds:creating:)` would instead null the blob on the
+/// re-created same-id row; with a nil cache a clean row falls through the
+/// #1085 modification-date gate's fail-open and a stale self-echo reverts the
+/// edit — the placeholder-revert data loss.
 @MainActor
 @Suite("automation leg edits preserve the leg's CloudKit sync identity")
 struct AutomationLegEditSyncIdentityTests {
@@ -50,8 +47,8 @@ struct AutomationLegEditSyncIdentityTests {
 
     // The edit applied …
     #expect(updated.legs.first { $0.id == legId }?.quantity == 200)
-    // … and the leg kept its CloudKit sync identity (Fix #1: update, not
-    // replace). A nil cache here is the gap that lets a stale echo clobber.
+    // … and the leg kept its CloudKit sync identity (update, not replace).
+    // A nil cache here is the gap that lets a stale echo clobber.
     let editedRow = try #require(try legs.fetchRowSync(id: legId))
     #expect(editedRow.encodedSystemFields != nil)
   }

--- a/MoolahTests/Automation/AutomationLegEditSyncIdentityTests.swift
+++ b/MoolahTests/Automation/AutomationLegEditSyncIdentityTests.swift
@@ -1,0 +1,58 @@
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins Fix #1 of the automation-write-path gap (issue #1090 follow-up): the
+/// genuine `AutomationService.updateLeg` verb must preserve the edited leg's
+/// cached `encoded_system_fields` (its CloudKit sync identity).
+///
+/// `updateLeg` / `addLeg` / `removeLeg` funnel through `save(...)`, which now
+/// calls `transactions.update(_:)` (an in-place, diff-by-id upsert that
+/// re-attaches each surviving leg's blob) instead of
+/// `replace(deletingIds:creating:)` (a delete-then-insert that nulled the
+/// blob on the re-created same-id row). With a nil cache, a clean row falls
+/// through the #1085 modification-date gate's fail-open and a stale self-echo
+/// reverts the edit — the placeholder-revert data loss.
+///
+/// RED before Fix #1 (`save` → `replace` nulls the cache); GREEN after
+/// (`save` → `update` preserves it).
+@MainActor
+@Suite("automation leg edits preserve the leg's CloudKit sync identity")
+struct AutomationLegEditSyncIdentityTests {
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test("updateLeg keeps the leg's cached system fields and applies the edit")
+  func updateLegPreservesLegSyncIdentity() async throws {
+    let (service, session) = try await AutomationTestSession.make()
+    let backend = try #require(session.backend as? CloudKitBackend)
+    let legs = backend.grdbTransactionLegs
+
+    let bank = try await service.createAccount(
+      profileIdentifier: "Test", name: "Bank", type: .bank)
+    let transaction = try await LegTestSupport.makeSingleLeg(
+      session: session, accountId: bank.id, quantity: 1, payee: "Buy")
+    let legId = try #require(transaction.legs.first).id
+
+    // Ack the leg: stamp a non-nil cached server system-fields blob, modelling
+    // a fully round-tripped (clean, synced) leg.
+    let row = try #require(try legs.fetchRowSync(id: legId))
+    _ = try legs.setEncodedSystemFieldsSync(
+      id: legId, data: row.toCKRecord(in: Self.zoneID).encodedSystemFields)
+
+    // Edit the leg through the real automation verb.
+    let updated = try await service.updateLeg(
+      profileIdentifier: "Test",
+      legId: legId,
+      changes: AutomationService.LegChanges(amount: 200))
+
+    // The edit applied …
+    #expect(updated.legs.first { $0.id == legId }?.quantity == 200)
+    // … and the leg kept its CloudKit sync identity (Fix #1: update, not
+    // replace). A nil cache here is the gap that lets a stale echo clobber.
+    let editedRow = try #require(try legs.fetchRowSync(id: legId))
+    #expect(editedRow.encodedSystemFields != nil)
+  }
+}

--- a/MoolahTests/Backends/GRDB/TransactionReplaceRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/TransactionReplaceRollbackTests.swift
@@ -1,5 +1,3 @@
-// MoolahTests/Backends/GRDB/TransactionReplaceRollbackTests.swift
-
 import Foundation
 import GRDB
 import Testing
@@ -51,6 +49,54 @@ struct TransactionReplaceRollbackTests {
       newId: newTx.id)
   }
 
+  /// Companion to the delete-phase test: the failure trigger fires on the
+  /// CREATE half of `replace`, AFTER the deleted rows have been snapshotted
+  /// and removed. Proves the reordered write (snapshot → delete → create)
+  /// still rolls back atomically when `performCreateMany` throws — the
+  /// snapshotted/deleted source must be restored and the new row absent.
+  @Test
+  func replaceRollsBackDeleteWhenCreateFails() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let txRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .AUD,
+      conversionService: FixedConversionService(),
+      instrumentResolver: registry,
+      instrumentRegistrar: registry)
+    let existingId = UUID()
+    let existingLegId = UUID()
+    let accountId = UUID()
+    try await seedSourceAndInsertFailureTrigger(
+      in: database,
+      existingId: existingId,
+      existingLegId: existingLegId,
+      accountId: accountId)
+
+    let newTx = Transaction(
+      date: Date(timeIntervalSince1970: 1_700_000_000),
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: .USD,
+          quantity: -50,
+          type: .expense)
+      ])
+
+    do {
+      _ = try await txRepo.replace(deletingIds: [existingId], creating: [newTx])
+      Issue.record("Expected replace to throw")
+    } catch {
+      // Expected.
+    }
+
+    try await assertNothingChanged(
+      in: database,
+      existingId: existingId,
+      existingLegId: existingLegId,
+      newId: newTx.id)
+  }
+
   /// Seeds one source transaction (header + leg) plus a BEFORE-DELETE
   /// trigger that raises ABORT so the `replace` write fails
   /// mid-transaction. SQL comments inside the literal use `--`, not
@@ -72,6 +118,34 @@ struct TransactionReplaceRollbackTests {
           CREATE TRIGGER force_failure BEFORE DELETE ON "transaction"
           BEGIN
             SELECT RAISE(ABORT, 'forced failure for replace rollback test');
+          END;
+          """,
+        arguments: [existingId, existingLegId, existingId, accountId])
+    }
+  }
+
+  /// Seeds one source transaction (header + leg), then installs a
+  /// BEFORE-INSERT trigger that raises ABORT. The trigger is created AFTER
+  /// the seed inserts (SQLite runs the statements in order), so it fires only
+  /// on the `replace`'s create half — exercising rollback of an
+  /// already-completed snapshot+delete. SQL comments use `--`, not `//`.
+  private func seedSourceAndInsertFailureTrigger(
+    in database: any DatabaseWriter,
+    existingId: UUID,
+    existingLegId: UUID,
+    accountId: UUID
+  ) async throws {
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO "transaction" (id, record_name, date)
+            VALUES (?, 'tx-existing', '2026-01-01');
+          INSERT INTO transaction_leg (id, record_name, transaction_id, account_id,
+                                       instrument_id, quantity, type, sort_order)
+            VALUES (?, 'leg-existing', ?, ?, 'USD', 100, 'expense', 0);
+          CREATE TRIGGER force_insert_failure BEFORE INSERT ON "transaction"
+          BEGIN
+            SELECT RAISE(ABORT, 'forced create failure for replace rollback test');
           END;
           """,
         arguments: [existingId, existingLegId, existingId, accountId])

--- a/MoolahTests/Sync/ReplacePreservesCacheEchoLossTests.swift
+++ b/MoolahTests/Sync/ReplacePreservesCacheEchoLossTests.swift
@@ -1,0 +1,213 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Regression harness for the confirmed automation-write-path gap (issue
+/// #1090 follow-up to the #1085 modification-date gate; task #14).
+///
+/// ## The gap
+///
+/// The automation leg edits (`AutomationService.updateLeg` / `addLeg` /
+/// `removeLeg`) all funnel through `AutomationService.save(...)`, which calls
+/// `transactions.replace(deletingIds: [txId], creating: [rebuilt])` — a
+/// delete-then-insert that keeps the SAME `TransactionLeg.id` (the automation
+/// layer rebuilds the leg "keeping id"). `GRDBTransactionRepository.replace`
+/// deletes the old leg row and re-inserts a fresh one via `performCreateMany`,
+/// which leaves `encoded_system_fields == nil` on the re-created same-id row
+/// (a fresh insert has no cached server blob).
+///
+/// That nil cache is the hole the #1085 gate falls through: the
+/// modification-date gate is deliberately fail-OPEN when the cached date is
+/// nil (`applicableAfterDateGate` returns `true` for an absent cached date,
+/// so a genuine first-time peer change is never dropped). So once the
+/// re-created leg is clean again (`needs_push == 0`), a STALE self-echo of the
+/// deleted placeholder version — still queued from an earlier upload batch —
+/// is applied unconditionally and clobbers the real edit back to the
+/// placeholder. This is the live STEP-3 symptom: a placeholder leg
+/// (AUD/income/qty 1) updated to a real token leg reverts to the placeholder,
+/// and `needs_push == 0` on the lost rows.
+///
+/// Unlike the in-place `performUpdate` path — which snapshots each surviving
+/// leg's blob and re-attaches it (`GRDBTransactionRepository+Update.swift`),
+/// so the cache is never nil and the gate protects unconditionally — the
+/// `replace` path has no such re-attach. The traced flows survive only because
+/// `replace` re-raises `needs_push = 1`, and a dirty row takes the
+/// system-fields-only apply path (protected) rather than the clobbering
+/// upsert. That is a timing invariant, not an unconditional guarantee: the
+/// moment the row goes clean with a nil cache, the clobber is live.
+///
+/// ## The fix these tests pin (task #14)
+///
+/// `replace` / `performCreateMany` must snapshot the deleted rows'
+/// `encoded_system_fields` by id and re-attach them to any re-created same-id
+/// row — exactly as `performUpdate` already does. With the cache preserved,
+/// the gate sees the placeholder echo's date as `<=` the cached date and
+/// rejects it (reject-on-tie), so the real edit survives regardless of the
+/// `needs_push` timing.
+///
+/// ## State of these tests
+///
+/// Both are RED against current `main` and go GREEN once `replace` preserves
+/// the blob. The fix lives in `replace` / `performCreateMany`, NOT the gate,
+/// so it is safe regardless of whether any single deterministic echo trace
+/// reproduces the live loss.
+@Suite("replace must preserve encoded_system_fields so a stale echo can't clobber a reused leg id")
+struct ReplacePreservesCacheEchoLossTests {
+  /// The post-`replace` fixture the two tests assert against.
+  private struct Fixture {
+    let harness: ProfileDataSyncHandlerTestSupport.HandlerHarness
+    let legId: UUID
+    /// Stale echo of the deleted placeholder version, stamped with the older
+    /// server date.
+    let placeholderEcho: CKRecord
+    /// The token leg's stored (scaled minor-unit) quantity as persisted by
+    /// `replace` — the survivor is asserted against this.
+    let tokenStoredQuantity: Int64
+  }
+
+  /// Echoes are stamped in a fixed zone; `applyRemoteChanges` dispatches by
+  /// record type + name, so the zone need not match the handler's own.
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  /// The placeholder version's server date is OLDER than any later edit, so a
+  /// preserved cache rejects its stale echo on a tie-or-older comparison.
+  private static let tPlaceholder = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private static let placeholderQuantity: Int64 = 1
+  private static let tokenQuantity: Int64 = 200
+
+  /// Builds the placeholder transaction (header + one leg) through the REAL
+  /// `create` path, acks the placeholder leg's server system fields (so it has
+  /// a non-nil cached blob, like a fully-synced row), then drives the REAL
+  /// automation update shape — `replace(deletingIds: [txId], creating:
+  /// [rebuilt])` keeping the same leg id — swapping the placeholder leg for the
+  /// real token leg.
+  ///
+  /// Returns the post-`replace` `Fixture`: the handler harness, the reused leg
+  /// id, the stale placeholder echo, and the token leg's stored quantity (the
+  /// leg row stores a scaled minor-unit `Int64`, so the survivor is asserted
+  /// against this captured value rather than a raw domain number).
+  private func seedPlaceholderThenReplaceWithToken() async throws -> Fixture {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    let transactionId = UUID()
+    let legId = UUID()
+    let accountId = UUID()
+    let transactions = harness.handler.grdbRepositories.transactions
+    let legs = harness.handler.grdbRepositories.transactionLegs
+
+    // create (placeholder): AUD/income/qty 1 — header + leg, both dirty.
+    let placeholder = Transaction(
+      id: transactionId,
+      date: Self.tPlaceholder,
+      payee: "Buy",
+      legs: [
+        TransactionLeg(
+          id: legId,
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: Decimal(Self.placeholderQuantity),
+          type: .income)
+      ])
+    _ = try await transactions.create(placeholder)
+
+    // ack: cache the placeholder leg's (non-nil) server system fields stamped
+    // with the OLDER date — this is the version that echoes back stale — then
+    // clear needs_push so the placeholder leg is clean + cached (fully synced).
+    let placeholderRow = try #require(try legs.fetchRowSync(id: legId))
+    let placeholderEcho =
+      placeholderRow
+      .toCKRecord(in: Self.zoneID)
+      .withModificationDate(Self.tPlaceholder)
+    _ = try legs.setEncodedSystemFieldsSync(
+      id: legId, data: placeholderEcho.encodedSystemFields)
+    _ = try legs.clearNeedsPushBatchSync([legId])
+
+    // automation update → replace: rebuild keeping the SAME leg id, swap the
+    // placeholder for the real token (qty 200). This is the exact call
+    // `AutomationService.save(...)` issues.
+    let tokenTransaction = Transaction(
+      id: transactionId,
+      date: Self.tPlaceholder,
+      payee: "Buy",
+      legs: [
+        TransactionLeg(
+          id: legId,
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: Decimal(Self.tokenQuantity),
+          type: .income)
+      ])
+    _ = try await transactions.replace(
+      deletingIds: [transactionId], creating: [tokenTransaction])
+
+    // Capture the token leg's stored (scaled) quantity straight after the
+    // replace, before any echo, so the survivor assertions compare against the
+    // real persisted value.
+    let tokenRow = try #require(try legs.fetchRowSync(id: legId))
+    return Fixture(
+      harness: harness,
+      legId: legId,
+      placeholderEcho: placeholderEcho,
+      tokenStoredQuantity: tokenRow.quantity)
+  }
+
+  /// Structural pin: after a same-id `replace`, the re-created leg row MUST
+  /// keep the deleted row's cached `encoded_system_fields`. RED today
+  /// (`replace` → `performCreateMany` inserts a fresh row with a nil blob);
+  /// GREEN once the fix snapshots + re-attaches the blob by id.
+  @Test("replace preserves the cached system fields on the re-created same-id leg")
+  func replacePreservesCachedSystemFieldsForReusedLegId() async throws {
+    let fixture = try await seedPlaceholderThenReplaceWithToken()
+
+    let row = try await fixture.harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: fixture.legId)
+    }
+    // The load-bearing assertion: a non-nil cache is what lets the #1085 gate
+    // protect the row unconditionally.
+    #expect(try #require(row).encodedSystemFields != nil)
+  }
+
+  /// End-to-end loss pin: the real edit must survive a stale echo of the
+  /// deleted placeholder version arriving on a now-clean row.
+  ///
+  /// `needs_push` is cleared after `replace` to model the observed production
+  /// state — the live STEP-3 placeholder legs were `needs_push == 0` when they
+  /// reverted. A clean row with a nil cache is the only state in which the
+  /// clean-path date gate runs, and it is precisely where the gap bites: the
+  /// dirty-path guard (`needs_push == 1`) that protects the traced flows no
+  /// longer applies.
+  ///
+  /// RED today: nil cache → gate fails open → the stale placeholder echo (qty
+  /// 1) clobbers the token (qty 200). GREEN once `replace` preserves the blob:
+  /// the placeholder echo's date is `<=` the cached date → rejected.
+  @Test("token leg survives a stale placeholder echo after an automation replace")
+  func tokenLegSurvivesStalePlaceholderEchoAfterReplace() async throws {
+    let fixture = try await seedPlaceholderThenReplaceWithToken()
+    let legs = fixture.harness.handler.grdbRepositories.transactionLegs
+
+    // Model the observed production state: the re-created token leg has gone
+    // clean (its own upload acked / confirmed) while its cache reflects only
+    // the cache-nulling replace.
+    _ = try legs.clearNeedsPushBatchSync([fixture.legId])
+
+    // The stale placeholder echo — still queued from the pre-edit upload —
+    // arrives last, on a clean row.
+    let stale = fixture.harness.handler.applyRemoteChanges(
+      saved: [fixture.placeholderEcho], deleted: [])
+    if case .saveFailed(let message) = stale {
+      Issue.record("stale save failed: \(message)")
+    }
+
+    let row = try await fixture.harness.database.read { database in
+      try TransactionLegRow.fetchOne(database, key: fixture.legId)
+    }
+    // The real edit must survive the out-of-order stale echo.
+    #expect(try #require(row).quantity == fixture.tokenStoredQuantity)
+  }
+}

--- a/MoolahTests/Sync/ReplacePreservesCacheEchoLossTests.swift
+++ b/MoolahTests/Sync/ReplacePreservesCacheEchoLossTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 @testable import Moolah
 
-/// Regression harness for the confirmed automation-write-path gap (issue
-/// #1090 follow-up to the #1085 modification-date gate; task #14).
+/// Regression harness for the automation-write-path gap (issue #1090), a
+/// follow-up to the #1085 modification-date gate.
 ///
 /// ## The gap
 ///
@@ -39,21 +39,15 @@ import Testing
 /// upsert. That is a timing invariant, not an unconditional guarantee: the
 /// moment the row goes clean with a nil cache, the clobber is live.
 ///
-/// ## The fix these tests pin (task #14)
+/// ## What these tests pin
 ///
-/// `replace` / `performCreateMany` must snapshot the deleted rows'
+/// `replace` / `performCreateMany` snapshot the deleted rows'
 /// `encoded_system_fields` by id and re-attach them to any re-created same-id
-/// row — exactly as `performUpdate` already does. With the cache preserved,
-/// the gate sees the placeholder echo's date as `<=` the cached date and
-/// rejects it (reject-on-tie), so the real edit survives regardless of the
-/// `needs_push` timing.
-///
-/// ## State of these tests
-///
-/// Both are RED against current `main` and go GREEN once `replace` preserves
-/// the blob. The fix lives in `replace` / `performCreateMany`, NOT the gate,
-/// so it is safe regardless of whether any single deterministic echo trace
-/// reproduces the live loss.
+/// row — exactly as `performUpdate` does. With the cache preserved, the gate
+/// sees the placeholder echo's date as `<=` the cached date and rejects it
+/// (reject-on-tie), so the real edit survives regardless of the `needs_push`
+/// timing. The guarantee lives in `replace` / `performCreateMany`, NOT the
+/// gate, so it holds for every same-id reuse rather than any one echo trace.
 @Suite("replace must preserve encoded_system_fields so a stale echo can't clobber a reused leg id")
 struct ReplacePreservesCacheEchoLossTests {
   /// The post-`replace` fixture the two tests assert against.
@@ -158,9 +152,9 @@ struct ReplacePreservesCacheEchoLossTests {
   }
 
   /// Structural pin: after a same-id `replace`, the re-created leg row MUST
-  /// keep the deleted row's cached `encoded_system_fields`. RED today
-  /// (`replace` → `performCreateMany` inserts a fresh row with a nil blob);
-  /// GREEN once the fix snapshots + re-attaches the blob by id.
+  /// keep the deleted row's cached `encoded_system_fields` (the non-nil cache
+  /// is what lets the #1085 gate protect it). Without the snapshot/re-attach,
+  /// `performCreateMany` would insert a fresh row with a nil blob.
   @Test("replace preserves the cached system fields on the re-created same-id leg")
   func replacePreservesCachedSystemFieldsForReusedLegId() async throws {
     let fixture = try await seedPlaceholderThenReplaceWithToken()
@@ -183,9 +177,10 @@ struct ReplacePreservesCacheEchoLossTests {
   /// dirty-path guard (`needs_push == 1`) that protects the traced flows no
   /// longer applies.
   ///
-  /// RED today: nil cache → gate fails open → the stale placeholder echo (qty
-  /// 1) clobbers the token (qty 200). GREEN once `replace` preserves the blob:
-  /// the placeholder echo's date is `<=` the cached date → rejected.
+  /// With the cache preserved, the placeholder echo's date is `<=` the cached
+  /// date and the gate rejects it, so the token (qty 200) survives. A nil
+  /// cache would let the gate fail open and the stale echo (qty 1) would
+  /// clobber the token.
   @Test("token leg survives a stale placeholder echo after an automation replace")
   func tokenLegSurvivesStalePlaceholderEchoAfterReplace() async throws {
     let fixture = try await seedPlaceholderThenReplaceWithToken()

--- a/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
+++ b/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
@@ -150,6 +150,58 @@ struct TransactionHookUpdateDeleteTests {
     #expect(deletedIds == originalIds)
   }
 
+  @Test("replace reusing ids suppresses their deletes; only the removed leg is deleted")
+  func transactionReplaceReusingIdsSuppressesDeletes() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = HookCapture()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      instrumentResolver: registry,
+      instrumentRegistrar: registry,
+      onRecordChanged: makeChangedHook(capture),
+      onRecordDeleted: makeDeletedHook(capture))
+
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Trade",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -100, type: .transfer),
+          makeContractTestLeg(accountId: accountId, quantity: 100, type: .transfer),
+        ]))
+    try await drainHookHops()
+    capture.changed.removeAll()
+    capture.deleted.removeAll()
+
+    // Rewrite under the SAME header id, reusing leg[0]'s id verbatim, dropping
+    // leg[1] (genuinely removed), and adding one fresh leg. Models a same-id
+    // rewrite through `replace`.
+    let freshLeg = makeContractTestLeg(accountId: accountId, quantity: 50, type: .transfer)
+    let rebuilt = Transaction(
+      id: txn.id, date: txn.date, payee: "Rewritten",
+      legs: [txn.legs[0], freshLeg])
+    _ = try await txnRepo.replace(deletingIds: [txn.id], creating: [rebuilt])
+    try await drainHookHops()
+
+    // Header id is reused → change, never delete.
+    let txnChanges = capture.changed.filter { $0.recordType == TransactionRow.recordType }
+    #expect(txnChanges.map(\.id) == [txn.id])
+    let txnDeletes = capture.deleted.filter { $0.recordType == TransactionRow.recordType }
+    #expect(txnDeletes.isEmpty)
+
+    // Reused leg[0] + fresh leg → changes; the reused leg is NOT deleted.
+    let legChanges = Set(
+      capture.changed.filter { $0.recordType == TransactionLegRow.recordType }.map(\.id))
+    #expect(legChanges == Set([txn.legs[0].id, freshLeg.id]))
+    // Only the genuinely-removed leg[1] fans out a delete.
+    let legDeletes = Set(
+      capture.deleted.filter { $0.recordType == TransactionLegRow.recordType }.map(\.id))
+    #expect(legDeletes == Set([txn.legs[1].id]))
+  }
+
   @Test("delete(id:) emits TransactionRecord delete plus per-leg LegRecord deletes")
   func transactionDeleteEmitsLegRecordType() async throws {
     let database = try ProfileDatabase.openInMemory()


### PR DESCRIPTION
## Summary

Follow-up to **#1085** — closes a confirmed residual data-loss path on the automation/migration write path that the #1085 modification-date gate did not protect.

**The gap.** The #1085 clean-path gate rejects a stale echo by comparing the incoming record's `modificationDate` to the row's cached one — but it *fails open when the cached date is nil* (correct for genuine first-syncs). Automation leg edits (`addLeg`/`updateLeg`/`removeLeg`) went through `AutomationService.save()` → `transactions.replace(deletingIds:creating:)`, a delete-then-insert that re-creates the leg under the **same** `CKRecord.ID` but **nulls** its `encoded_system_fields` (unlike the in-place `update`, which re-attaches the blob). It also self-queued a `.deleteRecord`+`.saveRecord` for the same id, whose conflict/`unknownItem` handling re-nulls the cache. So an edited leg could reach a **clean (`needs_push=0`) + nil-cache** state, where a stale placeholder echo passes the gate (fail-open) and clobbers the token leg back to the `AUD qty-1` placeholder — `needs_push=0, cache=T_create`. This is the exact signature seen in the crypto-migration STEP-3 live run (46 legs lost). The #1085 in-process tests missed it because they seed a non-nil cache and drive the in-place `update` path, not `replace`.

## Fix (no change to the gate's fail-open — that's load-bearing for new-record inserts)

- **Fix #1:** route the three automation leg verbs' `save()` through the cache-preserving in-place `transactions.update` (diff-by-id; preserves each surviving/edited leg's `encoded_system_fields`; deletes only genuinely-removed legs; no self-delete churn). Verified parity with `replace` (still registers non-fiat leg instruments).
- **Fix #2:** harden `replace` itself for the remaining same-id callers (transfer merge/split, which carry fee-leg ids verbatim): snapshot deleted rows' `encoded_system_fields` **per record type** (separate header + leg maps — no cross-attach) and re-attach to re-created same-id rows; suppress the self-queued `.deleteRecord` for ids re-created in the same `replace` (genuinely-removed ids still emit a delete). Snapshot+delete+recreate is one transaction (atomic rollback verified).

A deliberately-rejected Fix #3 (making the gate reject on nil-cache) is **not** shipped: a brand-new incoming record has no local row → is clean with no cached date → *must* fail-open to be inserted; rejecting would drop every new peer/refetched record. The gate's fail-open is untouched.

## Tests

`ReplacePreservesCacheEchoLossTests` (same-id `replace` preserves the cache; token survives a stale placeholder echo — both RED without the fix, GREEN with it, driving the real `replace` + `applyRemoteChanges` paths), `AutomationLegEditSyncIdentityTests` (the automation `updateLeg` verb keeps the leg's sync identity), `TransactionReplaceRollbackTests` (atomic rollback on create- and delete-phase failure), `TransactionHookUpdateDeleteTests` (reused-id `.deleteRecord` suppression + genuine-removal still deletes). Full macOS suite green (3977), format-check clean, zero warnings.

Deferred fast-follow (nicety, not required): a warning-only tripwire for any *future* cache-nulling write that leaves an existing row with a nil cache (needs a per-record-type row-exists query threaded through the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
