### PR TITLE
Cache-null tripwire (log-only) + correct misleading cachedSystemFields comment

### DIFF
--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+CurrentRecordInTransaction.swift
@@ -88,20 +88,14 @@ extension ProfileDataSyncHandler {
     buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
   }
 
-  /// Reads the row's currently-cached `encodedSystemFields` blob **inside**
-  /// the caller's active `database`. The outer `Optional` is whether a row
-  /// exists (and the type is known); the inner is the nullable blob. Used
-  /// by the upload-ack path to learn whether the row has ever round-tripped
-  /// (non-`nil` blob) before deciding whether clearing `needs_push` is safe
-  /// (issue #1081 follow-up). Returns `nil` for a missing row or an unknown
-  /// record type; the caller treats that conservatively (no clear).
-  /// Reads each saved record's CURRENTLY-cached `encodedSystemFields`
-  /// keyed by `<recordType>|<uuid>`, so `handleSentRecordZoneChanges` can
-  /// snapshot the pre-ack cache before `updateSystemFieldsForSaved`
-  /// overwrites it. Only rows that exist are recorded (storing their
-  /// nullable cached blob); a missing row is left absent so the ack-clear
-  /// treats it conservatively (no clear). Errors are logged and the record
-  /// is omitted (issue #1081 follow-up).
+  /// Reads each saved record's currently-cached `encodedSystemFields` keyed by
+  /// `<recordType>|<uuid>`, so `handleSentRecordZoneChanges` can snapshot the
+  /// pre-ack cache before `updateSystemFieldsForSaved` overwrites it. Records
+  /// each id whose `cachedSystemFields` lookup resolves, storing its nullable
+  /// cached blob; the ack-clear then treats a nil blob conservatively (no
+  /// clear), so an id whose row is absent or never round-tripped is handled
+  /// the same safe way. A read error is logged and the whole batch is omitted
+  /// (issue #1081 follow-up).
   nonisolated func preAckCachedSystemFields(
     _ savedRecords: [CKRecord]
   ) -> [String: Data?] {
@@ -153,6 +147,19 @@ extension ProfileDataSyncHandler {
     return result
   }
 
+  /// Reads a row's currently-cached `encodedSystemFields` blob inside the
+  /// active `database`, dispatched by record type.
+  ///
+  /// Returns `Data??`. The outer optional is `.none` ONLY when the record type
+  /// is unknown to both dispatch halves — it does NOT indicate row existence.
+  /// The per-type lookups use optional chaining
+  /// (`fetchRowSync(...)?.encodedSystemFields`), which flattens a missing row
+  /// and a present row with a nil blob to the same `.some(.none)`, so the
+  /// outer `.some` cannot tell them apart. Callers that only need "is there a
+  /// decodable blob" (a `.some(.some)`) — `cachedModificationDates`,
+  /// `preAckCachedSystemFields` — are unaffected; a caller that must
+  /// distinguish a genuinely missing row should use `currentCKRecord`
+  /// (issue #1090).
   nonisolated func cachedSystemFields(
     recordType: String, id: UUID, in database: Database
   ) throws -> Data?? {
@@ -165,8 +172,10 @@ extension ProfileDataSyncHandler {
   }
 
   /// Reference-data side of the `cachedSystemFields` dispatch. Outer
-  /// `.none` = "not this half's record type"; the inner double-optional is
-  /// the row-exists / nullable-blob result.
+  /// `.none` = "not this half's record type". The inner double-optional does
+  /// NOT distinguish a missing row from a present row with a nil blob —
+  /// optional chaining collapses both to `.some(.none)` (see
+  /// `cachedSystemFields`).
   nonisolated private func cachedSystemFieldsReference(
     recordType: String, id: UUID, in database: Database
   ) throws -> (Data??)? {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ModificationDateGate.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ModificationDateGate.swift
@@ -83,13 +83,23 @@ extension ProfileDataSyncHandler {
   ///
   /// The explicit row-exists guard (`currentCKRecord` returning non-nil) is
   /// what keeps it from firing on a normal new-record insert, whose row does
-  /// not yet exist locally.
+  /// not yet exist locally. A read failure is logged and the check is skipped
+  /// rather than propagated, so a database error never interrupts the apply.
   nonisolated func warnOnExistingRowsWithNilCache(
     recordType: String, ids: [UUID], cachedDates: [UUID: Date], in database: Database
   ) {
-    let suspect =
-      (try? existingRowsWithNilCache(
-        recordType: recordType, ids: ids, cachedDates: cachedDates, in: database)) ?? []
+    let suspect: [UUID]
+    do {
+      suspect = try existingRowsWithNilCache(
+        recordType: recordType, ids: ids, cachedDates: cachedDates, in: database)
+    } catch {
+      logger.error(
+        """
+        clean-apply tripwire: existence check failed for \
+        \(recordType, privacy: .public): \(error.localizedDescription, privacy: .public)
+        """)
+      return
+    }
     for id in suspect {
       logger.error(
         """
@@ -104,8 +114,8 @@ extension ProfileDataSyncHandler {
   /// (the nil-cache regression). An id with no local row — a genuine new
   /// record — is excluded. Pure (no logging) so it can be asserted directly.
   ///
-  /// Existence is tested via `currentCKRecord`, NOT `cachedSystemFields`: the
-  /// latter is built with optional chaining (`fetchRowSync(...)?.encoded…`),
+  /// Existence is tested via `currentCKRecord` rather than `cachedSystemFields`:
+  /// the latter is built with optional chaining (`fetchRowSync(...)?.encoded…`),
   /// which collapses "row absent" and "row present with a nil blob" into the
   /// same value — so its outer optional cannot tell them apart.
   /// `currentCKRecord` returns `nil` only for a genuinely missing row.

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ModificationDateGate.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ModificationDateGate.swift
@@ -68,7 +68,57 @@ extension ProfileDataSyncHandler {
     let cleanIds = deduped.compactMap { $0.recordID.uuid }
     let cachedDates = try cachedModificationDates(
       recordType: recordType, ids: cleanIds, in: database)
+    warnOnExistingRowsWithNilCache(
+      recordType: recordType, ids: cleanIds, cachedDates: cachedDates, in: database)
     return Self.applicableAfterDateGate(deduped, cachedDates: cachedDates)
+  }
+
+  /// Regression tripwire (issue #1090). Logs loudly when a CLEAN incoming
+  /// record's local row EXISTS but caches no `modificationDate` — i.e. some
+  /// write nulled the row's `encoded_system_fields`. That is the exact state
+  /// in which the gate's deliberate nil-cache fail-open lets a stale self-echo
+  /// clobber the row. The record still applies (fail-open is preserved — it is
+  /// required so a genuine first-time peer record inserts); this only surfaces
+  /// the condition so any future cache-nulling write path is caught at runtime.
+  ///
+  /// The explicit row-exists guard (`currentCKRecord` returning non-nil) is
+  /// what keeps it from firing on a normal new-record insert, whose row does
+  /// not yet exist locally.
+  nonisolated func warnOnExistingRowsWithNilCache(
+    recordType: String, ids: [UUID], cachedDates: [UUID: Date], in database: Database
+  ) {
+    let suspect =
+      (try? existingRowsWithNilCache(
+        recordType: recordType, ids: ids, cachedDates: cachedDates, in: database)) ?? []
+    for id in suspect {
+      logger.error(
+        """
+        clean-apply tripwire: existing \(recordType, privacy: .public) row \
+        \(id.uuidString, privacy: .public) has a nil cached system-fields blob — \
+        a write nulled the cache; a stale echo could clobber it (issue #1090)
+        """)
+    }
+  }
+
+  /// The `ids` whose local row EXISTS yet carries no cached `modificationDate`
+  /// (the nil-cache regression). An id with no local row — a genuine new
+  /// record — is excluded. Pure (no logging) so it can be asserted directly.
+  ///
+  /// Existence is tested via `currentCKRecord`, NOT `cachedSystemFields`: the
+  /// latter is built with optional chaining (`fetchRowSync(...)?.encoded…`),
+  /// which collapses "row absent" and "row present with a nil blob" into the
+  /// same value — so its outer optional cannot tell them apart.
+  /// `currentCKRecord` returns `nil` only for a genuinely missing row.
+  nonisolated func existingRowsWithNilCache(
+    recordType: String, ids: [UUID], cachedDates: [UUID: Date], in database: Database
+  ) throws -> [UUID] {
+    var suspect: [UUID] = []
+    for id in ids where cachedDates[id] == nil {
+      if try currentCKRecord(recordType: recordType, id: id, in: database) != nil {
+        suspect.append(id)
+      }
+    }
+    return suspect
   }
 
   /// Filters the clean records by the modification-date gate, returning only

--- a/MoolahTests/Sync/ModificationDateGateTests.swift
+++ b/MoolahTests/Sync/ModificationDateGateTests.swift
@@ -139,4 +139,40 @@ struct ModificationDateGateTests {
 
     #expect(try await quantity(harness, id: id) == 500)
   }
+
+  /// The #1090 tripwire detector flags an existing local row whose cache was
+  /// nulled (absent from the gate's `cachedDates`) — but NOT a genuine new
+  /// record (no local row) and NOT a row carrying a valid cached date. Driven
+  /// through the real `cachedModificationDates` the gate computes, so it also
+  /// guards that a brand-new incoming record (no local row) never trips it.
+  @Test("tripwire flags an existing nil-cache row, not a new record or a cached row")
+  func tripwireDetectsExistingNilCacheRows() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+    // (a) existing row whose cache was nulled (no system-fields blob).
+    let nilCacheId = UUID()
+    try await ProfileDataSyncHandlerTestSupport.seed(into: harness.database) { database in
+      try ProfileDataSyncHandlerTestSupport.transactionLegRow(
+        id: nilCacheId, transactionId: UUID(), accountId: nil, quantity: 1
+      ).insert(database)
+    }
+    // (b) existing row carrying a valid cached date.
+    let cachedId = try await seedCleanLeg(harness, quantity: 5, cachedDate: Self.tOlder)
+    // (c) no local row — a genuine new record.
+    let newRecordId = UUID()
+
+    let handler = harness.handler
+    let ids = [nilCacheId, cachedId, newRecordId]
+    // Run on the writer connection, as `applicableCleanSaves` does in the apply
+    // path, so the cached-date read sees the committed seed writes.
+    let suspect = try await harness.database.write { database -> [UUID] in
+      let cachedDates = try handler.cachedModificationDates(
+        recordType: TransactionLegRow.recordType, ids: ids, in: database)
+      return try handler.existingRowsWithNilCache(
+        recordType: TransactionLegRow.recordType, ids: ids,
+        cachedDates: cachedDates, in: database)
+    }
+    #expect(suspect == [nilCacheId])
+  }
 }

--- a/MoolahTests/Sync/ModificationDateGateTests.swift
+++ b/MoolahTests/Sync/ModificationDateGateTests.swift
@@ -141,10 +141,8 @@ struct ModificationDateGateTests {
   }
 
   /// The #1090 tripwire detector flags an existing local row whose cache was
-  /// nulled (absent from the gate's `cachedDates`) — but NOT a genuine new
-  /// record (no local row) and NOT a row carrying a valid cached date. Driven
-  /// through the real `cachedModificationDates` the gate computes, so it also
-  /// guards that a brand-new incoming record (no local row) never trips it.
+  /// nulled (absent from the gate's `cachedDates`) — but not a genuine new
+  /// record (no local row) and not a row carrying a valid cached date.
   @Test("tripwire flags an existing nil-cache row, not a new record or a cached row")
   func tripwireDetectsExistingNilCacheRows() async throws {
     let harness = try await MainActor.run {


### PR DESCRIPTION
Follow-up to the #1085 modification-date gate / #1090 cache-preservation fix (landed in #1093). **Log-only — no behaviour change to the apply path.**

## Tripwire
Adds a warning-only regression tripwire to the clean-apply gate
(`ProfileDataSyncHandler+ModificationDateGate.swift`): `applicableCleanSaves`
now logs loudly when an incoming clean record's local row **exists** but the
gate found **no cached `modificationDate`** — i.e. some write nulled the row's
`encoded_system_fields`, the exact state in which the gate's (intentional)
nil-cache fail-open lets a stale self-echo clobber the row.

- The record still applies — the fail-open is fully preserved (it is required
  so a genuine first-time peer/refetch record inserts). This is **not** the
  reject variant.
- It only surfaces the condition so any *future* cache-nulling write path is
  caught at runtime. The two known paths (automation leg edits → `replace`)
  are already closed by #1093.
- `existingRowsWithNilCache` is split out as a pure, unit-tested detector;
  `warnOnExistingRowsWithNilCache` does the logging and never propagates a read
  failure (logs it, skips — apply is never interrupted).

## Existence check: `currentCKRecord`, not `cachedSystemFields`
The detector tests row existence via `currentCKRecord(...) != nil`, **not**
`cachedSystemFields`. The latter is built with optional chaining
(`fetchRowSync(...)?.encodedSystemFields`), which collapses "row absent" and
"row present with a nil blob" into the same `.some(.none)` — so its outer
optional can't tell them apart. Using it would have fired the tripwire on
**every** normal new-record insert.

## Comment correction
The same optional-chaining collapse made `cachedSystemFields`' doc comment
("the outer optional is whether a row exists") misleading. This corrects the
doc on `cachedSystemFields` / `cachedSystemFieldsReference` / 
`preAckCachedSystemFields` to state the real semantics. The existing callers
only need "is there a decodable blob", so their behaviour is and was correct —
only the comments change.

## Tests
- `tripwireDetectsExistingNilCacheRows` — an existing nil-cache row is flagged;
  a brand-new record (no local row) and a row with a cached date are not.

Full macOS suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)