### PR TITLE
fix(sync): durable deletion-journal replay (#1090 PR-B)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -1,18 +1,15 @@
 @preconcurrency import CloudKit
 import Foundation
+import GRDB
 
-// Start-time replay of the durable deletion journal (issue #1090, PR-B). A
-// deletion recorded in `deletion_journal` (PR-A) survives engine-down timing
-// and a sync-state reset; on the next engine start this re-enqueues each
-// intent as a `.deleteRecord` so the deletion reliably reaches CloudKit instead
-// of being lost with the in-memory pending state.
-//
-// This file holds the PURE record-id resolution (sentinel zone → real zone),
-// which is the load-bearing, independently-testable core. The async start-time
+// Start-time replay of the durable deletion journal (issue #1090). A deletion
+// recorded in the `deletion_journal` table survives engine-down timing and a
+// sync-state reset (it lives in GRDB, not the engine's pending state); on the
+// next engine start this re-enqueues each intent as a `.deleteRecord` so the
+// deletion reliably reaches CloudKit instead of being lost with the in-memory
+// pending state. Resolution (sentinel zone → real zone) and the async
 // orchestration (iterate the profile-index DB + each live profile's DB, enqueue
-// onto the engine, clear-on-confirm) lands alongside its dedicated adversary
-// pass — replay is where deletions actually fire, so it is the highest-risk
-// surface and is paced separately.
+// onto the engine, clear-on-confirm) both live here.
 
 extension SyncCoordinator {
   /// Resolves journal entries read from ONE per-profile data DB to the
@@ -49,4 +46,208 @@ extension SyncCoordinator {
       return CKRecord.ID(recordName: entry.recordName, zoneID: indexZoneID)
     }
   }
+}
+
+// MARK: - Start-time replay orchestration
+
+@MainActor
+extension SyncCoordinator {
+  /// Replays every durable deletion intent (issue #1090) onto the live engine.
+  /// Called once in `completeStart`'s `zoneSetupTask`, after
+  /// `reconcilePendingAgainstLiveProfiles` (issue #1091). No-op when the engine
+  /// is not yet installed.
+  func replayDeletionJournal() async {
+    guard let syncEngine else { return }
+    await replayDeletionJournal(into: syncEngine.state)
+  }
+
+  /// Reads the deletion journal from the profile-index DB and every live
+  /// profile's DB, resolves each entry's real CloudKit zone (the `@profile-data`
+  /// sentinel → `profile-<id>`, index entries already carry `profile-index`),
+  /// and re-enqueues each as a `.deleteRecord`. Each enqueued id is tracked in
+  /// `replayedDeletionsInFlight` so `clearConfirmedReplayedDeletions` can retire
+  /// its journal row once the delete is acked. Keying the resolved set by
+  /// `CKRecord.ID` also collapses any duplicate intent to one enqueue.
+  ///
+  /// `state` is a seam: production passes `syncEngine.state`; tests pass an
+  /// in-memory ``PendingChangeStore`` (a fresh empty store models the
+  /// post-reset pending queue, proving the deletion survived the reset).
+  ///
+  /// HARD RULE: every re-issued deletion comes from a positive journal row —
+  /// nothing is ever inferred from a record being absent locally.
+  func replayDeletionJournal(into state: any PendingChangeStore) async {
+    var resolved: [CKRecord.ID: ReplayedDeletionRef] = [:]
+
+    let indexEntries = await readDeletionJournal(in: containerManager.profileIndexDatabase)
+    for id in Self.indexZoneDeletionReplayIDs(
+      indexEntries, indexZoneID: profileIndexHandler.zoneID)
+    {
+      resolved[id] = ReplayedDeletionRef(
+        origin: .index,
+        journalZoneName: DeletionJournal.profileIndexZoneName,
+        recordName: id.recordName)
+    }
+
+    for profileId in await containerManager.allProfileIds() {
+      let database: DatabaseQueue
+      do {
+        database = try containerManager.database(for: profileId)
+      } catch {
+        logger.error(
+          "Deletion-journal replay: cannot open DB for profile \(profileId, privacy: .public): \(error, privacy: .public) — skipping its journal"
+        )
+        continue
+      }
+      let entries = await readDeletionJournal(in: database)
+      let dataZoneID = CKRecordZone.ID(
+        zoneName: DeletionJournal.dataZoneName(for: profileId),
+        ownerName: CKCurrentUserDefaultName)
+      for id in Self.dataZoneDeletionReplayIDs(entries, dataZoneID: dataZoneID) {
+        resolved[id] = ReplayedDeletionRef(
+          origin: .profileData(profileId),
+          journalZoneName: DeletionJournal.profileDataSentinelZone,
+          recordName: id.recordName)
+      }
+    }
+
+    // The coordinator may have been stopped while the journal reads were in
+    // flight — don't mutate state / enqueue onto a torn-down engine.
+    guard !Task.isCancelled, !resolved.isEmpty else { return }
+    for (id, ref) in resolved {
+      replayedDeletionsInFlight[id] = ref
+    }
+    state.add(pendingRecordZoneChanges: resolved.keys.map { .deleteRecord($0) })
+    logger.warning(
+      "Deletion-journal replay: re-enqueued \(resolved.count, privacy: .public) durable deletion(s)"
+    )
+    refreshPendingUploadsMirror()
+  }
+
+  /// Retires journal rows for replayed deletions whose `.deleteRecord` has left
+  /// the pending queue — the only signal CloudKit gives for a successful delete
+  /// (`SentRecordZoneChanges` never reports `savedDeletes`). An `.unknownItem`
+  /// failed-delete also leaves the queue, so this covers "server already lacks
+  /// the record" too. Imperfect clearing is harmless (a redundant `.deleteRecord`
+  /// next start, never data loss); the harmful re-create case is handled by the
+  /// in-transaction clear that the repo's create write performs instead.
+  /// Idempotent.
+  func clearConfirmedReplayedDeletions() async {
+    guard let syncEngine else { return }
+    await clearConfirmedReplayedDeletions(against: syncEngine.state)
+  }
+
+  /// Seam-driven core of clear-on-confirm. A tracked replayed deletion whose id
+  /// is no longer a pending `.deleteRecord` is treated as sent → its journal row
+  /// is cleared and it is dropped from `replayedDeletionsInFlight`. Only entries
+  /// the replay itself enqueued this session are considered, so an unrelated
+  /// absence can never clear a row.
+  func clearConfirmedReplayedDeletions(against state: any PendingChangeStore) async {
+    guard !replayedDeletionsInFlight.isEmpty else { return }
+    let confirmed = Self.confirmedReplayedDeletions(
+      replayedDeletionsInFlight, pending: state.pendingRecordZoneChanges)
+    guard !confirmed.isEmpty else { return }
+    await clearJournalRows(for: confirmed)
+    // Only retire the in-flight tracking once the journal writes have run (and
+    // not after a stop cancelled them) — re-tracking on the next start is safe,
+    // dropping the tracking while a row lingers is not.
+    guard !Task.isCancelled else { return }
+    for id in confirmed.keys {
+      replayedDeletionsInFlight.removeValue(forKey: id)
+    }
+  }
+
+  /// The subset of `inFlight` whose `.deleteRecord` is no longer in `pending` —
+  /// treated as confirmed sent (CloudKit gives no positive delete ack, only the
+  /// change leaving the queue). Pure + `nonisolated static` so the confirm rule
+  /// is unit-testable without a live engine.
+  nonisolated static func confirmedReplayedDeletions(
+    _ inFlight: [CKRecord.ID: ReplayedDeletionRef],
+    pending: [CKSyncEngine.PendingRecordZoneChange]
+  ) -> [CKRecord.ID: ReplayedDeletionRef] {
+    var stillPendingDeletes: Set<CKRecord.ID> = []
+    for case .deleteRecord(let id) in pending {
+      stillPendingDeletes.insert(id)
+    }
+    return inFlight.filter { !stillPendingDeletes.contains($0.key) }
+  }
+
+  /// Clears the journal rows for the confirmed deletions, routing each to its
+  /// owning DB (the profile-index DB for index entries, each profile's data DB
+  /// for data entries). Best-effort per DB — a DB that won't open leaves its
+  /// rows to replay (idempotently) next start.
+  private func clearJournalRows(
+    for confirmed: [CKRecord.ID: ReplayedDeletionRef]
+  ) async {
+    var indexKeys: [(zoneName: String, recordName: String)] = []
+    var dataKeysByProfile: [UUID: [(zoneName: String, recordName: String)]] = [:]
+    for ref in confirmed.values {
+      switch ref.origin {
+      case .index:
+        indexKeys.append((ref.journalZoneName, ref.recordName))
+      case .profileData(let profileId):
+        dataKeysByProfile[profileId, default: []].append((ref.journalZoneName, ref.recordName))
+      }
+    }
+
+    if !indexKeys.isEmpty {
+      await clearDeletionJournal(indexKeys, in: containerManager.profileIndexDatabase)
+    }
+    for (profileId, keys) in dataKeysByProfile {
+      guard !Task.isCancelled else { return }
+      let database: DatabaseQueue
+      do {
+        database = try containerManager.database(for: profileId)
+      } catch {
+        logger.error(
+          "Clear-on-confirm: cannot open DB for profile \(profileId, privacy: .public): \(error, privacy: .public) — leaving its journal rows for the next start"
+        )
+        continue
+      }
+      await clearDeletionJournal(keys, in: database)
+    }
+  }
+
+  /// Reads every deletion-journal row in `database` off the MainActor, returning
+  /// `[]` on any read error (a transient failure must degrade to "replay nothing
+  /// from this DB this start", never throw out of startup).
+  private func readDeletionJournal(in database: DatabaseQueue) async -> [DeletionJournalRow] {
+    do {
+      return try await database.read { try DeletionJournal.allEntries(in: $0) }
+    } catch {
+      logger.error(
+        "Deletion-journal read failed: \(error, privacy: .public) — replaying nothing from this DB")
+      return []
+    }
+  }
+
+  /// Clears the given journal rows in `database` off the MainActor. Best-effort:
+  /// a failed clear only costs a redundant (idempotent) replay next start.
+  private func clearDeletionJournal(
+    _ keys: [(zoneName: String, recordName: String)], in database: DatabaseQueue
+  ) async {
+    do {
+      try await database.write { try DeletionJournal.clear(keys, in: $0) }
+    } catch {
+      logger.error(
+        "Clear-on-confirm journal write failed: \(error, privacy: .public) — rows will replay (idempotent) next start"
+      )
+    }
+  }
+}
+
+/// Where a replayed deletion's journal row lives, so the clear-on-confirm sweep
+/// can delete the right row once its `.deleteRecord` is acked (issue #1090).
+/// `journalZoneName` is the value stored IN the row — the `@profile-data`
+/// sentinel for per-profile data entries, the real `profile-index` for index
+/// entries — NOT the resolved CloudKit zone.
+struct ReplayedDeletionRef: Sendable, Equatable {
+  let origin: ReplayedDeletionOrigin
+  let journalZoneName: String
+  let recordName: String
+}
+
+/// Which database a replayed deletion's journal row lives in.
+enum ReplayedDeletionOrigin: Sendable, Equatable {
+  case index
+  case profileData(UUID)
 }

--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -1,0 +1,52 @@
+@preconcurrency import CloudKit
+import Foundation
+
+// Start-time replay of the durable deletion journal (issue #1090, PR-B). A
+// deletion recorded in `deletion_journal` (PR-A) survives engine-down timing
+// and a sync-state reset; on the next engine start this re-enqueues each
+// intent as a `.deleteRecord` so the deletion reliably reaches CloudKit instead
+// of being lost with the in-memory pending state.
+//
+// This file holds the PURE record-id resolution (sentinel zone → real zone),
+// which is the load-bearing, independently-testable core. The async start-time
+// orchestration (iterate the profile-index DB + each live profile's DB, enqueue
+// onto the engine, clear-on-confirm) lands alongside its dedicated adversary
+// pass — replay is where deletions actually fire, so it is the highest-risk
+// surface and is paced separately.
+
+extension SyncCoordinator {
+  /// Resolves journal entries read from ONE per-profile data DB to the
+  /// `CKRecord.ID`s to re-enqueue as `.deleteRecord`. Every per-profile data
+  /// entry carries the sentinel zone (`@profile-data`, Option B); the real
+  /// zone (`profile-<id>`) is implicit in which DB the entry lives in, so it is
+  /// supplied here as `dataZoneID` and applied to each record name.
+  ///
+  /// A non-sentinel entry in a per-profile DB is unexpected (the index zone
+  /// lives in its own DB) and is skipped rather than replayed into the wrong
+  /// zone — resolution never guesses.
+  ///
+  /// Pure + `nonisolated static` so the sentinel→real-zone mapping is unit
+  /// tested without a live `CKSyncEngine`.
+  nonisolated static func dataZoneDeletionReplayIDs(
+    _ entries: [DeletionJournalRow], dataZoneID: CKRecordZone.ID
+  ) -> [CKRecord.ID] {
+    entries.compactMap { entry in
+      guard entry.zoneName == DeletionJournal.profileDataSentinelZone else { return nil }
+      return CKRecord.ID(recordName: entry.recordName, zoneID: dataZoneID)
+    }
+  }
+
+  /// Resolves journal entries read from the profile-index DB to the
+  /// `CKRecord.ID`s to re-enqueue. Index entries carry the real
+  /// `profile-index` zone name already, so resolution is a direct map onto the
+  /// supplied `indexZoneID`; a stray sentinel entry (which has no meaning in
+  /// the index DB) is skipped.
+  nonisolated static func indexZoneDeletionReplayIDs(
+    _ entries: [DeletionJournalRow], indexZoneID: CKRecordZone.ID
+  ) -> [CKRecord.ID] {
+    entries.compactMap { entry in
+      guard entry.zoneName == DeletionJournal.profileIndexZoneName else { return nil }
+      return CKRecord.ID(recordName: entry.recordName, zoneID: indexZoneID)
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -160,6 +160,16 @@ extension SyncCoordinator {
   /// treated as confirmed sent (CloudKit gives no positive delete ack, only the
   /// change leaving the queue). Pure + `nonisolated static` so the confirm rule
   /// is unit-testable without a live engine.
+  ///
+  /// "Left pending" covers one non-success case: a `zoneNotFound` /
+  /// `userDeletedZone` failure removes the delete from the engine state and
+  /// stashes it in `pendingZoneCreation` (not re-added to pending), so it reads
+  /// as confirmed here and the journal row is cleared before any re-send. That is
+  /// safe — a zone-absent error on a *delete* means the whole zone is gone
+  /// server-side, so the record cannot exist and there is nothing to resurrect on
+  /// a future reset. Retryable failures, by contrast, are re-added to pending by
+  /// `SyncErrorRecovery.requeueFailures` (which runs inside the awaited send,
+  /// before this check), so they stay tracked and are NOT cleared.
   nonisolated static func confirmedReplayedDeletions(
     _ inFlight: [CKRecord.ID: ReplayedDeletionRef],
     pending: [CKSyncEngine.PendingRecordZoneChange]

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -172,59 +172,10 @@ extension SyncCoordinator {
 
     let shouldBackfillUnsynced = !isFirstLaunch
     let runFirstLaunchQueue = isFirstLaunch
-    // Eagerly create the profile-index zone and all known profile-data zones,
-    // then send if needed. Reactive creation in `handleSentRecordZoneChanges`
-    // remains as a fallback per SYNC_GUIDE Rule 3.
-    //
-    // Profile id enumeration moved inside the Task because
-    // `containerManager.allProfileIds()` is now async (it must not block
-    // the main thread on the GRDB queue).
     zoneSetupTask = Task {
-      // Start-time reconciliation (issue #1091): purge pending orphaned by a
-      // profile deleted before the engine existed — see
-      // `reconcilePendingAgainstLiveProfiles()`. It fetches its OWN live set via
-      // the throwing path — must NOT use `profileIds` below (`allProfileIds()`
-      // swallows errors to `[]`).
-      await self.reconcilePendingAgainstLiveProfiles()
-
-      // On first launch (migration or truly first launch), queue all existing records
-      if runFirstLaunchQueue {
-        await self.queueAllExistingRecordsForAllZones()
-      }
-      let profileIds = await self.containerManager.allProfileIds()
-      await self.ensureZoneExists(self.profileIndexHandler.zoneID)
-      for profileId in profileIds {
-        let zoneID = CKRecordZone.ID(
-          zoneName: "profile-\(profileId.uuidString)",
-          ownerName: CKCurrentUserDefaultName)
-        await self.ensureZoneExists(zoneID)
-      }
-      // After zones are confirmed, backfill any records that never got queued for upload
-      // (e.g. data imported by migration on a build that predated the migration→sync fix,
-      // or a previous run that crashed between the local write and the sync-engine
-      // queue). Skipped on first launch because `queueAllExistingRecordsForAllZones`
-      // has already queued everything.
-      if shouldBackfillUnsynced {
-        _ = await self.queueUnsyncedRecordsForAllProfiles()
-      }
-      // Shared-registry self-heal — re-queues any `instrument` row in
-      // the profile-index DB whose `encoded_system_fields` is NULL.
-      // Closes the gap between "union runner committed" and "engine
-      // state file persisted" by catching first-launch rows that
-      // never made it into the pending list. Cheap and idempotent.
-      //
-      // The previous per-profile-zone instrument backfill (which
-      // queued auto-inserted stock/crypto rows for upload to each
-      // `profile-<UUID>` zone) is decommissioned: every instrument
-      // upload routes through the shared registry to the profile-index
-      // zone. The DEBUG trap in `ProfileDataSyncHandler.recordToSave`
-      // now refuses any residual per-profile-zone `InstrumentRecord`
-      // upload, so the self-heal lives entirely on the shared side.
-      _ = self.queueUnsyncedSharedInstruments()
-      if self.hasPendingChanges {
-        self.logger.info("Zones ready — sending pending changes")
-        await self.sendChanges()
-      }
+      await self.runZoneSetup(
+        runFirstLaunchQueue: runFirstLaunchQueue,
+        shouldBackfillUnsynced: shouldBackfillUnsynced)
     }
 
     // Initial iCloud availability probe. Skip when entitlements are missing
@@ -243,6 +194,68 @@ extension SyncCoordinator {
           )
         }
       }
+    }
+  }
+
+  /// The async body of `zoneSetupTask`: start-time reconciliation + deletion
+  /// replay, eager zone creation, the unsynced backfill, then a send. Eagerly
+  /// creates the profile-index zone and all known profile-data zones (reactive
+  /// creation in `handleSentRecordZoneChanges` remains a fallback per SYNC_GUIDE
+  /// Rule 3). `Task.isCancelled` is checked after the journal scan and before
+  /// the send so a `stop()` mid-setup doesn't act on a torn-down engine.
+  private func runZoneSetup(
+    runFirstLaunchQueue: Bool, shouldBackfillUnsynced: Bool
+  ) async {
+    // Start-time reconciliation (issue #1091): purge pending orphaned by a
+    // profile deleted before the engine existed — see
+    // `reconcilePendingAgainstLiveProfiles()`. It fetches its OWN live set via
+    // the throwing path — must NOT use `allProfileIds()` below (which swallows
+    // errors to `[]`).
+    await reconcilePendingAgainstLiveProfiles()
+
+    // Durable deletion-journal replay (issue #1090): re-issue every journaled
+    // deletion as a `.deleteRecord` so a deletion survives an engine-down
+    // window or a sync-state reset. Runs after reconciliation (issue #1091) —
+    // the two act on disjoint zones (reconcile purges dead-profile DATA pending;
+    // replay re-issues index `ProfileRecord` + live-profile data deletions), so
+    // the order is conflict-free. See `SyncCoordinator+DeletionReplay`.
+    await replayDeletionJournal()
+    guard !Task.isCancelled else { return }
+
+    // On first launch (migration or truly first launch), queue all existing records.
+    if runFirstLaunchQueue {
+      await queueAllExistingRecordsForAllZones()
+    }
+    let profileIds = await containerManager.allProfileIds()
+    await ensureZoneExists(profileIndexHandler.zoneID)
+    for profileId in profileIds {
+      let zoneID = CKRecordZone.ID(
+        zoneName: "profile-\(profileId.uuidString)",
+        ownerName: CKCurrentUserDefaultName)
+      await ensureZoneExists(zoneID)
+    }
+    // After zones are confirmed, backfill any records that never got queued for
+    // upload (e.g. data imported by migration on a build that predated the
+    // migration→sync fix, or a previous run that crashed between the local write
+    // and the sync-engine queue). Skipped on first launch because
+    // `queueAllExistingRecordsForAllZones` has already queued everything.
+    if shouldBackfillUnsynced {
+      _ = await queueUnsyncedRecordsForAllProfiles()
+    }
+    // Shared-registry self-heal — re-queues any `instrument` row in the
+    // profile-index DB whose `encoded_system_fields` is NULL. Closes the gap
+    // between "union runner committed" and "engine state file persisted" by
+    // catching first-launch rows that never made it into the pending list.
+    // Cheap and idempotent. (The decommissioned per-profile-zone instrument
+    // backfill is gone: every instrument upload routes through the shared
+    // registry to the profile-index zone, and the DEBUG trap in
+    // `ProfileDataSyncHandler.recordToSave` refuses any residual per-profile
+    // `InstrumentRecord` upload.)
+    _ = queueUnsyncedSharedInstruments()
+    guard !Task.isCancelled else { return }
+    if hasPendingChanges {
+      logger.info("Zones ready — sending pending changes")
+      await sendChanges()
     }
   }
 
@@ -291,35 +304,8 @@ extension SyncCoordinator {
     syncEngine.map { !$0.state.pendingRecordZoneChanges.isEmpty } ?? false
   }
 
-  /// Removes any pending change whose recordName is a bare UUID (no `|`
-  /// separator and parses as a UUID). Such entries can only have been
-  /// persisted by a build that predated the `<recordType>|<UUID>` prefix
-  /// (issue #416). Post-prefix they collide with their prefixed counterparts
-  /// during batch build — both pass the `Set<CKRecord.ID>` dedup (different
-  /// recordNames) but resolve to the same UUID and the same local row,
-  /// so the same `CKRecord` instance gets appended to `recordsToSave` twice
-  /// and CloudKit rejects the entire batch with `.invalidArguments`
-  /// ("You can't save the same record twice").
-  ///
-  /// Instrument records use raw string IDs (`"AUD"`, `"ASX:BHP"`) which
-  /// don't parse as UUIDs, so they are correctly excluded by this check.
-  private func purgeStaleBareUUIDPendingChanges() {
-    guard let syncEngine else { return }
-    let stale = syncEngine.state.pendingRecordZoneChanges.filter { change in
-      let recordName: String
-      switch change {
-      case .saveRecord(let id): recordName = id.recordName
-      case .deleteRecord(let id): recordName = id.recordName
-      @unknown default: return false
-      }
-      return !recordName.contains("|") && UUID(uuidString: recordName) != nil
-    }
-    guard !stale.isEmpty else { return }
-    logger.warning(
-      "Purging \(stale.count, privacy: .public) stale bare-UUID pending changes left over from pre-prefixing CKSyncEngine state"
-    )
-    syncEngine.state.remove(pendingRecordZoneChanges: stale)
-  }
+  // `purgeStaleBareUUIDPendingChanges()` (issue #416 cleanup) lives in
+  // `SyncCoordinator+StalePendingPurge.swift`.
 
   // The four `queueSave` / `queueDeletion` overloads live in
   // `SyncCoordinator+QueueChanges.swift`.
@@ -331,6 +317,10 @@ extension SyncCoordinator {
     } catch {
       logger.error("Failed to send changes: \(error, privacy: .public)")
     }
+    // Clear-on-confirm (issue #1090): retire the journal row of any
+    // replayed deletion whose `.deleteRecord` left the queue during this send
+    // (CloudKit's only success signal for a delete), so it does not re-replay.
+    await clearConfirmedReplayedDeletions()
   }
 
   func fetchChanges() async {

--- a/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
@@ -15,15 +15,35 @@ extension SyncCoordinator {
   // `queueAllExistingRecordsForAllZones` / `queueUnsyncedRecordsForAllProfiles`
   // inside `completeStart`.
   func queueSave(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(
-      recordType: recordType, uuid: id, zoneID: zoneID)
-    syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
-    refreshPendingUploadsMirror()
+    enqueueSave(CKRecord.ID(recordType: recordType, uuid: id, zoneID: zoneID))
   }
 
   func queueSave(recordName: String, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
-    syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    enqueueSave(CKRecord.ID(recordName: recordName, zoneID: zoneID))
+  }
+
+  /// Adds a `.saveRecord` to the live engine, no-op until the engine is
+  /// installed (the documented start-window behaviour — anything persisted
+  /// before then is re-queued by the start-time backfill).
+  private func enqueueSave(_ recordID: CKRecord.ID) {
+    guard let syncEngine else { return }
+    applySave(recordID, to: syncEngine.state)
+  }
+
+  /// Shared core of the save path + the create-hook hardening (issue #1090):
+  /// BEFORE adding the save, drop any pending `.deleteRecord` for the same id,
+  /// and drop it from `replayedDeletionsInFlight`. A re-created (or undeleted)
+  /// record must not be killed by a replayed/in-flight deletion that is still
+  /// sitting in the queue — `add(.saveRecord)` does NOT supersede a coexisting
+  /// `.deleteRecord`, so the removal is explicit. (The repo's create write
+  /// already cleared the journal row in-transaction; this clears the in-memory
+  /// pending side.)
+  ///
+  /// `state` is a seam so the hardening is unit-testable without a live engine.
+  func applySave(_ recordID: CKRecord.ID, to state: any PendingChangeStore) {
+    state.remove(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+    replayedDeletionsInFlight.removeValue(forKey: recordID)
+    state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
     refreshPendingUploadsMirror()
   }
 
@@ -58,10 +78,8 @@ extension SyncCoordinator {
     guard !candidates.isEmpty else { return [] }
     var pendingDeleteIds: Set<CKRecord.ID> = []
     pendingDeleteIds.reserveCapacity(pendingChanges.count)
-    for change in pendingChanges {
-      if case .deleteRecord(let id) = change {
-        pendingDeleteIds.insert(id)
-      }
+    for case .deleteRecord(let id) in pendingChanges {
+      pendingDeleteIds.insert(id)
     }
     if pendingDeleteIds.isEmpty { return candidates }
     return candidates.filter { !pendingDeleteIds.contains($0) }

--- a/Backends/CloudKit/Sync/SyncCoordinator+StalePendingPurge.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+StalePendingPurge.swift
@@ -1,0 +1,37 @@
+@preconcurrency import CloudKit
+import Foundation
+
+// Start-time purge of stale pre-prefixing (issue #416) pending changes for
+// `SyncCoordinator`. Called from `completeStart` in `+Lifecycle.swift`.
+@MainActor
+extension SyncCoordinator {
+  /// Removes any pending change whose recordName is a bare UUID (no `|`
+  /// separator and parses as a UUID). Such entries can only have been
+  /// persisted by a build that predated the `<recordType>|<UUID>` prefix
+  /// (issue #416). Post-prefix they collide with their prefixed counterparts
+  /// during batch build — both pass the `Set<CKRecord.ID>` dedup (different
+  /// recordNames) but resolve to the same UUID and the same local row,
+  /// so the same `CKRecord` instance gets appended to `recordsToSave` twice
+  /// and CloudKit rejects the entire batch with `.invalidArguments`
+  /// ("You can't save the same record twice").
+  ///
+  /// Instrument records use raw string IDs (`"AUD"`, `"ASX:BHP"`) which
+  /// don't parse as UUIDs, so they are correctly excluded by this check.
+  func purgeStaleBareUUIDPendingChanges() {
+    guard let syncEngine else { return }
+    let stale = syncEngine.state.pendingRecordZoneChanges.filter { change in
+      let recordName: String
+      switch change {
+      case .saveRecord(let id): recordName = id.recordName
+      case .deleteRecord(let id): recordName = id.recordName
+      @unknown default: return false
+      }
+      return !recordName.contains("|") && UUID(uuidString: recordName) != nil
+    }
+    guard !stale.isEmpty else { return }
+    logger.warning(
+      "Purging \(stale.count, privacy: .public) stale bare-UUID pending changes left over from pre-prefixing CKSyncEngine state"
+    )
+    syncEngine.state.remove(pendingRecordZoneChanges: stale)
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -233,6 +233,15 @@ final class SyncCoordinator {
   /// database layer again. See `ProfileGRDBRepositories`.
   var cachedGRDBRepositories: [UUID: ProfileGRDBRepositories] = [:]
 
+  /// Journal-backed deletions the start-time replay re-enqueued this session
+  /// that have not yet been confirmed sent (issue #1090, PR-B). Keyed by the
+  /// pending-change `CKRecord.ID`. `clearConfirmedReplayedDeletions` clears a
+  /// row's journal entry once its `.deleteRecord` leaves the pending queue (the
+  /// only signal CloudKit gives for a successful delete), so a confirmed
+  /// deletion does not re-replay on every subsequent start. A `.saveRecord` for
+  /// the same id (a re-create) also drops its entry here — see `applySave`.
+  var replayedDeletionsInFlight: [CKRecord.ID: ReplayedDeletionRef] = [:]
+
   /// Zones with pending zone creation — records in these zones are skipped in nextRecordZoneChangeBatch.
   var pendingZoneCreation: [CKRecordZone.ID: [CKSyncEngine.PendingRecordZoneChange]] = [:]
 

--- a/MoolahTests/Sync/DeletionReplayResolutionTests.swift
+++ b/MoolahTests/Sync/DeletionReplayResolutionTests.swift
@@ -1,0 +1,68 @@
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins the sentinel→real-zone resolution at the heart of the #1090 deletion
+/// replay (PR-B): a per-profile data journal entry stores the `@profile-data`
+/// sentinel and MUST resolve to that profile's real `profile-<id>` zone at
+/// replay; an index entry resolves to the `profile-index` zone; mismatched
+/// entries are never replayed into the wrong zone.
+@Suite("Deletion replay — sentinel→real-zone resolution")
+struct DeletionReplayResolutionTests {
+  private let profileId = UUID()
+
+  private func dataZoneID() -> CKRecordZone.ID {
+    CKRecordZone.ID(
+      zoneName: DeletionJournal.dataZoneName(for: profileId),
+      ownerName: CKCurrentUserDefaultName)
+  }
+
+  private func entry(zone: String, recordName: String) -> DeletionJournalRow {
+    DeletionJournalRow(
+      zoneName: zone, recordName: recordName, recordType: "AccountRecord",
+      queuedAt: 1_700_000_000)
+  }
+
+  @Test("data-zone replay maps sentinel entries onto the real profile-<id> zone")
+  func dataZoneResolvesSentinelToRealZone() async throws {
+    let zone = dataZoneID()
+    let ids = SyncCoordinator.dataZoneDeletionReplayIDs(
+      [
+        entry(zone: DeletionJournal.profileDataSentinelZone, recordName: "AccountRecord|1"),
+        entry(zone: DeletionJournal.profileDataSentinelZone, recordName: "AccountRecord|2"),
+      ],
+      dataZoneID: zone)
+    #expect(ids.count == 2)
+    #expect(ids.allSatisfy { $0.zoneID == zone })
+    #expect(Set(ids.map(\.recordName)) == ["AccountRecord|1", "AccountRecord|2"])
+    // Never the literal sentinel string as a zone.
+    #expect(ids.allSatisfy { $0.zoneID.zoneName != DeletionJournal.profileDataSentinelZone })
+  }
+
+  @Test("data-zone replay skips a non-sentinel entry (never replays into the wrong zone)")
+  func dataZoneSkipsNonSentinel() async throws {
+    let ids = SyncCoordinator.dataZoneDeletionReplayIDs(
+      [
+        entry(zone: DeletionJournal.profileIndexZoneName, recordName: "ProfileRecord|9"),
+        entry(zone: "profile-\(UUID().uuidString)", recordName: "AccountRecord|3"),
+      ],
+      dataZoneID: dataZoneID())
+    #expect(ids.isEmpty)
+  }
+
+  @Test("index-zone replay maps index entries onto the profile-index zone, skipping sentinels")
+  func indexZoneResolvesIndexEntries() async throws {
+    let indexZone = CKRecordZone.ID(
+      zoneName: DeletionJournal.profileIndexZoneName, ownerName: CKCurrentUserDefaultName)
+    let ids = SyncCoordinator.indexZoneDeletionReplayIDs(
+      [
+        entry(zone: DeletionJournal.profileIndexZoneName, recordName: "ProfileRecord|7"),
+        entry(zone: DeletionJournal.profileDataSentinelZone, recordName: "AccountRecord|4"),
+      ],
+      indexZoneID: indexZone)
+    #expect(ids.map(\.recordName) == ["ProfileRecord|7"])
+    #expect(ids.first?.zoneID == indexZone)
+  }
+}

--- a/MoolahTests/Sync/DeletionReplayTests.swift
+++ b/MoolahTests/Sync/DeletionReplayTests.swift
@@ -1,0 +1,250 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// End-to-end tests for the durable deletion-journal REPLAY (issue #1090).
+///
+/// The write side journals every synced deletion durably (in GRDB, not the
+/// CKSyncEngine state blob) inside the same write that removes the local row.
+/// This is the read side: on engine start the coordinator REPLAYS each journal
+/// entry as a `.deleteRecord`, so a deletion reliably reaches CloudKit even
+/// after an engine-down window or a sync-state reset wiped the in-memory pending
+/// queue. The replay re-issues ONLY from a positive recorded intent — never
+/// inferred from a record being absent locally.
+///
+/// `CKSyncEngine.State` has no constructible test instance, so these drive the
+/// coordinator's replay / clear seams against an in-memory ``PendingChangeStore``
+/// double (the same seam the #1088 drain tests use) — a fresh empty store models
+/// the post-reset pending queue. The journal itself is written through the REAL
+/// GRDB repositories, so the delete→journal and recreate→clear contracts are
+/// exercised end to end.
+@Suite("Deletion-journal replay (#1090)")
+@MainActor
+struct DeletionReplayTests {
+
+  // MARK: - Fixture
+
+  private struct Fixture {
+    let manager: ProfileContainerManager
+    let coordinator: SyncCoordinator
+    let profileId: UUID
+    let dataZoneID: CKRecordZone.ID
+    let categories: GRDBCategoryRepository
+  }
+
+  /// A coordinator over an in-memory container with one registered profile and
+  /// a real GRDB category repository wired to that profile's data DB.
+  private static func makeFixture() async throws -> Fixture {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(id: profileId, label: "Replay", currencyCode: "AUD"))
+    let database = try manager.database(for: profileId)
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: DeletionJournal.dataZoneName(for: profileId),
+      ownerName: CKCurrentUserDefaultName)
+    return Fixture(
+      manager: manager,
+      coordinator: coordinator,
+      profileId: profileId,
+      dataZoneID: dataZoneID,
+      categories: GRDBCategoryRepository(database: database))
+  }
+
+  private static func deleteRecordIDs(
+    _ changes: [CKSyncEngine.PendingRecordZoneChange]
+  ) -> Set<CKRecord.ID> {
+    Set(
+      changes.compactMap { change in
+        if case .deleteRecord(let id) = change { return id }
+        return nil
+      })
+  }
+
+  // MARK: - 1. Delete survives an engine-down / state reset → replayed
+
+  @Test(
+    "a journaled deletion survives a state reset and replays as a .deleteRecord — never inferred from absence"
+  )
+  func journaledDeletionSurvivesResetAndReplays() async throws {
+    let fixture = try await Self.makeFixture()
+
+    // A live category that is NEVER deleted — it must NOT be replayed (the hard
+    // rule: replay only from positive journaled intent, never from absence).
+    let live = try await fixture.categories.create(Moolah.Category(name: "Live"))
+    // A category we delete while the engine is down — its deletion is journaled
+    // durably in GRDB by the repo's in-transaction journal write.
+    let doomed = try await fixture.categories.create(Moolah.Category(name: "Doomed"))
+    try await fixture.categories.delete(id: doomed.id, withReplacement: nil)
+
+    // The pending queue was wiped by the reset → start from an empty store.
+    let store = InMemoryPendingChangeStore()
+    await fixture.coordinator.replayDeletionJournal(into: store)
+
+    let deletes = Self.deleteRecordIDs(store.pendingRecordZoneChanges)
+    #expect(
+      deletes.contains(
+        CKRecord.ID(
+          recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: fixture.dataZoneID)))
+    #expect(
+      !deletes.contains(
+        CKRecord.ID(
+          recordType: CategoryRow.recordType, uuid: live.id, zoneID: fixture.dataZoneID)))
+    // Exactly the one journaled deletion, resolved onto the real profile-<id>
+    // zone (never the @profile-data sentinel).
+    #expect(deletes.count == 1)
+    #expect(deletes.allSatisfy { $0.zoneID == fixture.dataZoneID })
+  }
+
+  // MARK: - 2. Clear-on-recreate before replay → no spurious delete
+
+  @Test(
+    "delete-then-recreate the same id before restart leaves NO deletion to replay (the recreate cleared the journal)"
+  )
+  func recreateBeforeReplayClearsTheJournaledDeletion() async throws {
+    let fixture = try await Self.makeFixture()
+
+    let id = UUID()
+    _ = try await fixture.categories.create(Moolah.Category(id: id, name: "First"))
+    try await fixture.categories.delete(id: id, withReplacement: nil)
+    // Re-create the SAME id (undo / restore / UUID reuse). The repo's create
+    // clears the stale deletion intent in the same write.
+    _ = try await fixture.categories.create(Moolah.Category(id: id, name: "Reborn"))
+
+    let store = InMemoryPendingChangeStore()
+    await fixture.coordinator.replayDeletionJournal(into: store)
+
+    // No `.deleteRecord` — the live, re-created record must survive replay.
+    #expect(Self.deleteRecordIDs(store.pendingRecordZoneChanges).isEmpty)
+  }
+
+  // MARK: - 3. Empty-shell resurrection closed (profile deleted while engine nil)
+
+  @Test(
+    "a profile deleted while the engine was down replays its profile-index ProfileRecord deletion (no empty-shell resurrection)"
+  )
+  func deletedProfileReplaysIndexRecordDeletion() async throws {
+    let fixture = try await Self.makeFixture()
+    let indexZoneID = fixture.coordinator.profileIndexHandler.zoneID
+
+    // Delete the profile through the real index repository: its ProfileRecord
+    // deletion is journaled in the profile-index DB (which outlives the
+    // per-profile data DB teardown).
+    _ = try await fixture.manager.profileIndexRepository.delete(id: fixture.profileId)
+
+    let store = InMemoryPendingChangeStore()
+    await fixture.coordinator.replayDeletionJournal(into: store)
+
+    let expected = CKRecord.ID(
+      recordType: ProfileRow.recordType, uuid: fixture.profileId, zoneID: indexZoneID)
+    let deletes = Self.deleteRecordIDs(store.pendingRecordZoneChanges)
+    #expect(deletes.contains(expected))
+    #expect(deletes.allSatisfy { $0.zoneID == indexZoneID })
+  }
+
+  // MARK: - 4. Clear-on-confirm → no infinite re-replay across restarts
+
+  @Test(
+    "a replayed delete the engine acks is removed from the journal — it does not re-replay on the next start"
+  )
+  func confirmedDeletionIsClearedFromJournal() async throws {
+    let fixture = try await Self.makeFixture()
+    let doomed = try await fixture.categories.create(Moolah.Category(name: "Doomed"))
+    try await fixture.categories.delete(id: doomed.id, withReplacement: nil)
+
+    // Start: replay enqueues the delete.
+    let store = InMemoryPendingChangeStore()
+    await fixture.coordinator.replayDeletionJournal(into: store)
+    let deleteID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: fixture.dataZoneID)
+    #expect(Self.deleteRecordIDs(store.pendingRecordZoneChanges).contains(deleteID))
+
+    // The engine sends the delete successfully → it leaves the pending queue.
+    store.remove(pendingRecordZoneChanges: [.deleteRecord(deleteID)])
+    await fixture.coordinator.clearConfirmedReplayedDeletions(against: store)
+
+    // Next start: a fresh replay finds nothing — the journal row was cleared,
+    // so the delete does not re-fire forever.
+    let nextStore = InMemoryPendingChangeStore()
+    await fixture.coordinator.replayDeletionJournal(into: nextStore)
+    #expect(Self.deleteRecordIDs(nextStore.pendingRecordZoneChanges).isEmpty)
+  }
+
+  // MARK: - 5. Coexistence with #1091 start-time reconciliation
+
+  @Test(
+    "replay and dead-profile reconciliation coexist: each acts on its own zone, no double-queue, no cross-purge"
+  )
+  func replayCoexistsWithReconciliation() async throws {
+    let fixture = try await Self.makeFixture()
+
+    // A LIVE profile's journaled data deletion — replay must re-issue it, and
+    // reconciliation (which only purges DEAD profiles' zones) must leave it be.
+    let doomed = try await fixture.categories.create(Moolah.Category(name: "Doomed"))
+    try await fixture.categories.delete(id: doomed.id, withReplacement: nil)
+    let liveDeleteID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: fixture.dataZoneID)
+
+    // An orphaned pending save for a DEAD profile (never registered) — exactly
+    // what start-time reconciliation purges.
+    let deadProfileId = UUID()
+    let deadZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(deadProfileId.uuidString)", ownerName: CKCurrentUserDefaultName)
+    let orphanSaveID = CKRecord.ID(
+      recordType: AccountRow.recordType, uuid: UUID(), zoneID: deadZoneID)
+    let orphanSave = CKSyncEngine.PendingRecordZoneChange.saveRecord(orphanSaveID)
+
+    let store = InMemoryPendingChangeStore([orphanSave])
+
+    // zoneSetupTask order: reconcile first, then replay. Reconcile's core is the
+    // tested-pure `pendingToPurge`; the live set has only `fixture.profileId`.
+    let liveIds: Set<UUID> = [fixture.profileId]
+    store.remove(
+      pendingRecordZoneChanges:
+        SyncCoordinator.pendingToPurge(store.pendingRecordZoneChanges, liveIds: liveIds))
+    await fixture.coordinator.replayDeletionJournal(into: store)
+
+    // The dead profile's orphan save was purged; the live profile's deletion was
+    // replayed exactly once; nothing for the dead profile was re-queued.
+    #expect(
+      !store.pendingRecordZoneChanges.contains { change in
+        if case .saveRecord(let id) = change { return id == orphanSaveID }
+        return false
+      })
+    let deletes = Self.deleteRecordIDs(store.pendingRecordZoneChanges)
+    #expect(deletes == [liveDeleteID])
+    #expect(!deletes.contains { $0.zoneID == deadZoneID })
+  }
+
+  // MARK: - 6. Create-hook hardening: a (re)created record drops a stale pending delete
+
+  @Test(
+    "queuing a save drops any in-flight .deleteRecord for the same id (a recreated record is never killed by a stale delete)"
+  )
+  func savingARecordDropsStalePendingDelete() async throws {
+    let fixture = try await Self.makeFixture()
+    let id = UUID()
+    let recordID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: id, zoneID: fixture.dataZoneID)
+
+    // A replayed/in-flight delete is sitting in the queue.
+    let store = InMemoryPendingChangeStore([.deleteRecord(recordID)])
+    // The record is (re)created → its save must supersede the stale delete.
+    fixture.coordinator.applySave(recordID, to: store)
+
+    #expect(
+      store.pendingRecordZoneChanges.contains { change in
+        if case .saveRecord(let saved) = change { return saved == recordID }
+        return false
+      })
+    #expect(
+      !store.pendingRecordZoneChanges.contains { change in
+        if case .deleteRecord(let deleted) = change { return deleted == recordID }
+        return false
+      })
+  }
+}


### PR DESCRIPTION
## What

PR-B of #1090: the **firing side** of the durable deletion journal, built on the already-merged resolver core. At engine start the coordinator now **REPLAYS** every durable deletion-journal row as a `.deleteRecord`, so a deletion survives an engine-down window or a sync-state reset instead of being lost with the in-memory pending queue. This closes the **delete-survives-reset** gap and the **empty-shell-resurrection** class.

**Replays ONLY from a positive journal row — never inferred from a record being absent locally** (absence is ambiguous; it could be a peer's brand-new record this device hasn't fetched).

## Mechanism

1. **Replay (what + from where).** `replayDeletionJournal(into:)` reads the `deletion_journal` table from the profile-index DB **and every live profile's DB**, resolves each entry's real CloudKit zone, and enqueues one `.deleteRecord` per entry (keyed by `CKRecord.ID`, so duplicate intents collapse to one). Wired into `completeStart`'s `zoneSetupTask` right after `reconcilePendingAgainstLiveProfiles` (#1091).
2. **Sentinel → zone resolution.** Per-profile data rows store the `@profile-data` sentinel zone; the real `profile-<id>` zone is resolved from the owning DB at replay. Index rows (`ProfileRecord`) already carry the real `profile-index` zone. (Existing `dataZoneDeletionReplayIDs` / `indexZoneDeletionReplayIDs` resolver core.)
3. **Coexistence with #1091.** Replay runs *after* reconciliation; the two act on **disjoint zones** (reconcile purges dead-profile *data*-zone pending; replay re-issues index `ProfileRecord` + live-profile data deletions), so the order is conflict-free — no double-queue.
4. **Clear-on-confirm.** After each `sendChanges`, any replayed deletion whose `.deleteRecord` left the pending queue — CloudKit's only success signal for a delete (`SentRecordZoneChanges` never reports `savedDeletes`); also covers `.unknownItem` — has its journal row retired, so a confirmed deletion does not re-replay on every subsequent start. Only entries *this session's replay* enqueued are considered, so an unrelated absence can never clear a row.
5. **Create-hook hardening.** The save path (`applySave`, now shared by both `queueSave` overloads) drops any pending `.deleteRecord` for the same id **before** adding the save. `add(.saveRecord)` does NOT supersede a coexisting `.deleteRecord`, so a re-created/undeleted record can't be killed by a stale replayed/in-flight deletion still in the queue. (The repo's create write already cleared the journal row in-transaction; this clears the in-memory pending side.)

## Tests (TDD, red-first)

Six e2e tests in `DeletionReplayTests.swift`, each verified **failing with the firing code stubbed** before implementation:

1. A journaled deletion **survives a state reset** → replayed as `.deleteRecord` (and a never-deleted live record is **not** queued — the no-infer-from-absence lock).
2. **Clear-on-recreate before replay** — delete→recreate same id → no spurious `.deleteRecord`.
3. **Empty-shell resurrection closed** — a profile deleted while the engine was down replays its `ProfileRecord` deletion.
4. **Clear-on-confirm** — an acked replayed delete is removed from the journal → no infinite re-replay across restarts.
5. **Coexists with #1091** reconciliation — each acts on its own zone, no double-queue, no cross-purge.
6. **Create-hook hardening** — queuing a save drops a stale in-flight `.deleteRecord` for the same id.

The journal is driven through the **real GRDB repositories** (delete→journal, recreate→clear); the engine is the `PendingChangeStore` seam (`CKSyncEngine.State` has no constructible test instance).

## Also

- Extracted `runZoneSetup` and `purgeStaleBareUUIDPendingChanges` out of `+Lifecycle` to keep it within its length budget.
- Added `Task.isCancelled` guards around the new start-time suspension points so a `stop()` mid-setup doesn't act on a torn-down engine.
- Ran `code-review` + `concurrency-review`; applied all findings (do/catch error logging, `for case`, dict-not-tuple, cancellation guards, removed PR-archaeology comment labels).

## Verification

- All 6 e2e + resolver tests green; **full macOS suite green**.
- `format-check` clean; build is warning-free (`SWIFT_TREAT_WARNINGS_AS_ERRORS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1090.
