### PR TITLE
feat(sync): safe already-bloated-state recovery — self-heal on launch (#1090 / #12)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+BloatRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+BloatRecovery.swift
@@ -48,6 +48,17 @@ extension SyncCoordinator {
   /// UserDefaults key for the consecutive-recovery counter.
   static let bloatRecoveryAttemptCountKey = "com.moolah.sync.bloatRecoveryAttemptCount"
 
+  /// Durable "recovery incomplete" marker key — set when a recovery had to fail
+  /// closed (suppress-all) and may have dropped peer-only records the engine's
+  /// change token has since advanced past. Forces a fresh recovery (regardless
+  /// of state size) on the next launch to re-deliver them.
+  static let recoveryIncompleteMarkerKey = "com.moolah.sync.recoveryIncomplete"
+
+  /// How many times to re-read the journal before giving up and failing closed
+  /// — a transient GRDB read error usually clears on a retry, yielding a precise
+  /// shield with no drops at all.
+  static let recoverySnapshotReadAttempts = 3
+
   // MARK: - Off-actor engine construction + gate
 
   /// Off-actor: reads the persisted sync state, applies the byte-size gate, and
@@ -66,6 +77,7 @@ extension SyncCoordinator {
     stateFileURL: URL,
     delegate: any CKSyncEngineDelegate & Sendable,
     allowRecovery: Bool,
+    forceRecovery: Bool,
     bloatThreshold: Int
   ) async -> PreparedEngine {
     // A missing file is the normal first launch; a genuine read error is logged
@@ -88,7 +100,10 @@ extension SyncCoordinator {
     )
 
     let outcome = bloatGateOutcome(
-      stateByteCount: data?.count, allowRecovery: allowRecovery, threshold: bloatThreshold)
+      stateByteCount: data?.count,
+      allowRecovery: allowRecovery,
+      forceRecovery: forceRecovery,
+      threshold: bloatThreshold)
     // `.recovered` drops the bloated blob → `nil` state → instant init,
     // `isFirstLaunch = true`. `.healthy` / `.bloatedButSkipped` decode and pass
     // the existing state through (off-main init absorbs any stall).
@@ -102,7 +117,10 @@ extension SyncCoordinator {
     return PreparedEngine(
       engine: CKSyncEngine(configuration),
       isFirstLaunch: savedState == nil,
-      recoveryOutcome: outcome)
+      recoveryOutcome: outcome,
+      // Forced (marker-driven) recoveries must NOT count against the normal
+      // size-recovery ceiling — they're a separate, self-clearing mechanism.
+      recoveryWasForced: forceRecovery && outcome == .recovered)
   }
 
   /// Decodes the persisted state, logging (not swallowing) a corrupt /
@@ -123,12 +141,15 @@ extension SyncCoordinator {
   // MARK: - Gate decision (pure)
 
   /// Classifies the persisted state from its byte size + whether recovery is
-  /// currently allowed. `nil` byteCount (no state file) is `.healthy`. Pure +
-  /// `nonisolated static` so the gate is unit-tested without touching disk or a
-  /// live engine.
+  /// allowed / forced. `forceRecovery` (the durable "recovery incomplete"
+  /// marker) wins regardless of size — a prior fail-closed recovery may have
+  /// dropped peer-only records the engine's token has advanced past, and only a
+  /// fresh nil-reset re-delivers them. Otherwise `nil` byteCount (no state file)
+  /// or a below-threshold size is `.healthy`. Pure + `nonisolated static`.
   nonisolated static func bloatGateOutcome(
-    stateByteCount: Int?, allowRecovery: Bool, threshold: Int
+    stateByteCount: Int?, allowRecovery: Bool, forceRecovery: Bool, threshold: Int
   ) -> BloatGateOutcome {
+    if forceRecovery { return .recovered }
     guard let byteCount = stateByteCount, byteCount > threshold else { return .healthy }
     return allowRecovery ? .recovered : .bloatedButSkipped
   }
@@ -163,17 +184,48 @@ extension SyncCoordinator {
     return recoveryAttemptCount < Self.bloatRecoveryAttemptCeiling
   }
 
+  /// `true` while a prior recovery failed closed: a fresh recovery is forced on
+  /// this launch (regardless of state size, and bypassing the size-recovery
+  /// ceiling) to re-deliver any peer-only record dropped under suppress-all.
+  /// Gated on entitlements + iCloud-not-known-unavailable like `isRecoveryAllowed`.
+  var isRecoveryForced: Bool {
+    guard isCloudKitAvailable, recoveryIncomplete else { return false }
+    if case .unavailable = iCloudAvailability { return false }
+    return true
+  }
+
+  /// The durable "recovery incomplete" marker (UserDefaults).
+  var recoveryIncomplete: Bool {
+    userDefaults.bool(forKey: Self.recoveryIncompleteMarkerKey)
+  }
+
+  /// Sets the marker so the next launch forces a fresh recovery — survives the
+  /// attempt-ceiling reset (a separate key) so a healthy launch can't swallow it.
+  func markRecoveryIncomplete() {
+    userDefaults.set(true, forKey: Self.recoveryIncompleteMarkerKey)
+  }
+
+  /// Clears the marker once a recovery completed WITHOUT failing closed — the
+  /// forced refetch re-delivered and applied any stranded peer record.
+  func clearRecoveryIncomplete() {
+    userDefaults.removeObject(forKey: Self.recoveryIncompleteMarkerKey)
+  }
+
   // MARK: - Outcome handling (called from completeStart)
 
-  /// Applies the byte-size gate outcome at start: a recovery bumps the attempt
-  /// count and arms the tombstone shield; a healthy launch re-arms the ceiling;
-  /// a skipped-but-bloated launch warns (the existing state is running as-is).
-  func applyRecoveryOutcome(_ outcome: BloatGateOutcome) {
+  /// Applies the byte-size gate outcome at start: a recovery arms the tombstone
+  /// shield (and, unless it was marker-FORCED, bumps the size-recovery ceiling);
+  /// a healthy launch re-arms the ceiling; a skipped-but-bloated launch warns
+  /// (the existing state runs as-is). A healthy launch does NOT touch the
+  /// recovery-incomplete marker — only a clean recovery clears it.
+  func applyRecoveryOutcome(_ outcome: BloatGateOutcome, wasForced: Bool) {
     switch outcome {
     case .recovered:
-      incrementRecoveryAttemptCount()
+      if !wasForced {
+        incrementRecoveryAttemptCount()
+      }
       logger.warning(
-        "Bloated sync state recovered: rebuilt the engine with empty state (consecutive recovery #\(self.recoveryAttemptCount, privacy: .public) of \(Self.bloatRecoveryAttemptCeiling, privacy: .public))"
+        "Bloated sync state recovered (\(wasForced ? "forced re-recovery" : "size-gated", privacy: .public)): rebuilt the engine with empty state"
       )
       armRecoveryShield()
     case .healthy:
@@ -195,6 +247,7 @@ extension SyncCoordinator {
     isRecoveryShieldActive = true
     recoveryFetchDidSettle = false
     recoveryShieldSuppressAll = false
+    recoveryReplayDidRun = false
     // Cancel any in-flight snapshot from a prior arm before replacing it, so an
     // abandoned build can't resume and overwrite the new snapshot.
     recoverySnapshotTask?.cancel()
@@ -205,23 +258,45 @@ extension SyncCoordinator {
 
   /// Builds `recoveringDeletions` = the union of every journal deletion id
   /// (index DB + each live profile DB), resolved to its real CloudKit zone.
-  ///
-  /// Fail-closed: if a journal read failed the snapshot is INCOMPLETE, so the
-  /// shield can't know which ids to protect → `recoveryShieldSuppressAll` makes
-  /// the apply path drop ALL fetched saves for the session (the forced refetch
-  /// would otherwise resurrect every un-propagated deletion). If the reads all
-  /// succeeded and the journals are empty there is nothing to shield, so the
-  /// shield deactivates immediately.
+  /// Retries a failed read a few times first (a transient GRDB error usually
+  /// clears, yielding a precise shield with no drops), then hands the result to
+  /// `applyRecoverySnapshot`.
   private func buildRecoveryDeletionSnapshot() async {
-    let (resolved, readFailed) = await resolveAllJournalDeletions()
-    // `stop()` (or a re-arm) may have cancelled us during the journal reads and
-    // already cleared the shield state — don't resurrect it with a stale set.
-    guard !Task.isCancelled else { return }
+    var resolved: [CKRecord.ID: ReplayedDeletionRef] = [:]
+    var readFailed = true
+    for attempt in 0..<Self.recoverySnapshotReadAttempts {
+      if attempt > 0 {
+        try? await Task.sleep(for: .milliseconds(100))
+      }
+      guard !Task.isCancelled else { return }
+      let result = await resolveAllJournalDeletions()
+      guard !Task.isCancelled else { return }
+      resolved = result.resolved
+      readFailed = result.readFailed
+      if !readFailed { break }
+      logger.error(
+        "Recovery shield: journal read attempt \(attempt + 1, privacy: .public) of \(Self.recoverySnapshotReadAttempts, privacy: .public) failed"
+      )
+    }
+    applyRecoverySnapshot(resolved: resolved, readFailed: readFailed)
+  }
+
+  /// Installs the resolved snapshot. Fail-closed on `readFailed`: the snapshot is
+  /// INCOMPLETE, so `recoveryShieldSuppressAll` makes the apply path drop ALL
+  /// fetched saves this session (the forced refetch would otherwise resurrect an
+  /// un-enumerable deletion) and a durable marker forces a fresh recovery next
+  /// launch (the engine advances its token past dropped saves, so a peer-only
+  /// record dropped here would otherwise be permanently missing). Reads-OK +
+  /// empty journals ⇒ nothing to shield ⇒ deactivate.
+  func applyRecoverySnapshot(
+    resolved: [CKRecord.ID: ReplayedDeletionRef], readFailed: Bool
+  ) {
     recoveringDeletions = Set(resolved.keys)
     recoveryShieldSuppressAll = readFailed
     if readFailed {
+      markRecoveryIncomplete()
       logger.error(
-        "Recovery shield: journal read failed — failing closed, suppressing ALL fetched saves this recovery session to avoid resurrecting un-propagated deletions"
+        "Recovery shield: journal read failed after \(Self.recoverySnapshotReadAttempts, privacy: .public) attempts — failing closed (suppressing ALL fetched saves) and marking recovery incomplete to force a fresh recovery next launch"
       )
     } else if recoveringDeletions.isEmpty {
       isRecoveryShieldActive = false
@@ -270,14 +345,23 @@ extension SyncCoordinator {
   /// Called from `clearConfirmedReplayedDeletions` and `endFetchingChanges`.
   func releaseRecoveryShieldIfSettled() {
     guard isRecoveryShieldActive,
+      recoveryReplayDidRun,
       replayedDeletionsInFlight.isEmpty,
       recoveryFetchDidSettle,
       !isFetchingChanges
     else { return }
+    // A recovery that never failed closed has now applied the full refetch
+    // cleanly — clear the durable marker so we don't force another recovery. A
+    // suppress-all session leaves the marker set (it may have dropped peer-only
+    // records) so the next launch re-recovers.
+    if !recoveryShieldSuppressAll {
+      clearRecoveryIncomplete()
+    }
     isRecoveryShieldActive = false
     recoveringDeletions = []
     recoveryShieldSuppressAll = false
     recoveryFetchDidSettle = false
+    recoveryReplayDidRun = false
     recoverySnapshotTask = nil
     logger.info(
       "Recovery shield released — deletions confirmed and the post-recovery refetch has settled")

--- a/Backends/CloudKit/Sync/SyncCoordinator+BloatRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+BloatRecovery.swift
@@ -13,6 +13,25 @@ import OSLog
 // its tombstone cleared, so the replayed `.deleteRecord` wins. Save-completeness
 // comes from `isFirstLaunch = true` → `queueAllExistingRecordsForAllZones`.
 
+/// Classification of the persisted sync-state file by the start-time byte-size
+/// gate (issue #1090 / #12).
+enum BloatGateOutcome: Sendable, Equatable {
+  /// State is absent or below the bloat threshold — the engine starts from it
+  /// normally and the recovery attempt count is re-armed (reset to 0).
+  case healthy
+  /// State exceeded the threshold and recovery was allowed — the engine was
+  /// rebuilt with `nil` state (instant init) and self-heals on launch.
+  case recovered
+  /// State exceeded the threshold but recovery was NOT allowed (attempt ceiling
+  /// reached, or iCloud known-unavailable) — the existing state is passed
+  /// through (off-main init absorbs the stall) and a warning is logged.
+  case bloatedButSkipped
+}
+
+// Instance members are `@MainActor` (the shield state they mutate is
+// MainActor-isolated); the `nonisolated static` members (the off-actor
+// `prepareEngine` + the pure gate / partition helpers) keep their isolation.
+@MainActor
 extension SyncCoordinator {
   /// State-file byte size above which the persisted state is treated as
   /// pathological and recovered. A healthy state is KB–low-MB; the wedge that
@@ -174,6 +193,8 @@ extension SyncCoordinator {
   /// post-init fetch. Idempotent within a start.
   func armRecoveryShield() {
     isRecoveryShieldActive = true
+    recoveryFetchDidSettle = false
+    recoveryShieldSuppressAll = false
     // Cancel any in-flight snapshot from a prior arm before replacing it, so an
     // abandoned build can't resume and overwrite the new snapshot.
     recoverySnapshotTask?.cancel()
@@ -183,16 +204,26 @@ extension SyncCoordinator {
   }
 
   /// Builds `recoveringDeletions` = the union of every journal deletion id
-  /// (index DB + each live profile DB), resolved to its real CloudKit zone. If
-  /// the journals are empty there is nothing to shield, so the shield
-  /// deactivates immediately.
+  /// (index DB + each live profile DB), resolved to its real CloudKit zone.
+  ///
+  /// Fail-closed: if a journal read failed the snapshot is INCOMPLETE, so the
+  /// shield can't know which ids to protect → `recoveryShieldSuppressAll` makes
+  /// the apply path drop ALL fetched saves for the session (the forced refetch
+  /// would otherwise resurrect every un-propagated deletion). If the reads all
+  /// succeeded and the journals are empty there is nothing to shield, so the
+  /// shield deactivates immediately.
   private func buildRecoveryDeletionSnapshot() async {
-    let resolved = await resolveAllJournalDeletions()
+    let (resolved, readFailed) = await resolveAllJournalDeletions()
     // `stop()` (or a re-arm) may have cancelled us during the journal reads and
     // already cleared the shield state — don't resurrect it with a stale set.
     guard !Task.isCancelled else { return }
     recoveringDeletions = Set(resolved.keys)
-    if recoveringDeletions.isEmpty {
+    recoveryShieldSuppressAll = readFailed
+    if readFailed {
+      logger.error(
+        "Recovery shield: journal read failed — failing closed, suppressing ALL fetched saves this recovery session to avoid resurrecting un-propagated deletions"
+      )
+    } else if recoveringDeletions.isEmpty {
       isRecoveryShieldActive = false
     } else {
       logger.warning(
@@ -201,29 +232,55 @@ extension SyncCoordinator {
     }
   }
 
-  /// The active shield id-set for the apply path. Awaits the snapshot build so a
-  /// fetched change that arrives before the snapshot is ready is still shielded
-  /// (race-free). Returns `[]` when no recovery is in progress.
-  func activeRecoveryShield() async -> Set<CKRecord.ID> {
-    guard isRecoveryShieldActive else { return [] }
+  #if DEBUG
+    /// Test seam: observe the built shield id-set, awaiting the snapshot build
+    /// (race-free). The production apply path uses `recoveryShieldedSaves`, which
+    /// additionally models the fail-closed suppress-all mode. Guarded by
+    /// `#if DEBUG` so it is not part of the shipping API surface.
+    func activeRecoveryShield() async -> Set<CKRecord.ID> {
+      guard isRecoveryShieldActive else { return [] }
+      await recoverySnapshotTask?.value
+      guard !Task.isCancelled, isRecoveryShieldActive else { return [] }
+      return recoveringDeletions
+    }
+  #endif
+
+  /// The apply-path entry point: partitions fetched saves into those to apply
+  /// and those the recovery shield suppresses. Awaits the snapshot build
+  /// (race-free vs the forced refetch). Outside recovery everything applies;
+  /// under a read-failed (fail-closed) recovery EVERYTHING is suppressed.
+  func recoveryShieldedSaves(
+    _ saved: [CKRecord]
+  ) async -> (toApply: [CKRecord], suppressed: [CKRecord]) {
+    guard isRecoveryShieldActive else { return (saved, []) }
     await recoverySnapshotTask?.value
-    // Re-check after the suspension: `stop()` may have deactivated the shield
-    // (and cleared `recoveringDeletions`) while we were awaiting the build.
-    guard isRecoveryShieldActive else { return [] }
-    return recoveringDeletions
+    // Re-check after the suspension: `stop()` may have deactivated the shield,
+    // or the apply task may have been cancelled, while we awaited the build.
+    guard !Task.isCancelled, isRecoveryShieldActive else { return (saved, []) }
+    if recoveryShieldSuppressAll { return ([], saved) }
+    return Self.partitionShieldedSaves(saved, shield: recoveringDeletions)
   }
 
-  /// Releases the whole shield once every recovered deletion has been confirmed
-  /// sent (`replayedDeletionsInFlight` emptied by clear-on-confirm) — the
-  /// recovery session has settled, so a later legitimate peer re-create of a
-  /// (formerly) shielded id upserts normally again. Called from
-  /// `clearConfirmedReplayedDeletions`.
+  /// Releases the whole shield only once the recovery session has fully settled:
+  /// every recovered deletion confirmed sent (`replayedDeletionsInFlight`
+  /// emptied) AND a full fetch session has completed since arming AND we are not
+  /// mid-fetch. The shield MUST outlive the forced token-less refetch —
+  /// releasing on delete-confirm alone would let a still-draining refetch
+  /// re-deliver (and resurrect) a record whose `.deleteRecord` just propagated.
+  /// Called from `clearConfirmedReplayedDeletions` and `endFetchingChanges`.
   func releaseRecoveryShieldIfSettled() {
-    guard isRecoveryShieldActive, replayedDeletionsInFlight.isEmpty else { return }
+    guard isRecoveryShieldActive,
+      replayedDeletionsInFlight.isEmpty,
+      recoveryFetchDidSettle,
+      !isFetchingChanges
+    else { return }
     isRecoveryShieldActive = false
     recoveringDeletions = []
+    recoveryShieldSuppressAll = false
+    recoveryFetchDidSettle = false
     recoverySnapshotTask = nil
-    logger.info("Recovery shield released — all recovered deletions confirmed")
+    logger.info(
+      "Recovery shield released — deletions confirmed and the post-recovery refetch has settled")
   }
 
   /// Partitions fetched saved records into those to apply and those the shield

--- a/Backends/CloudKit/Sync/SyncCoordinator+BloatRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+BloatRecovery.swift
@@ -1,0 +1,247 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import OSLog
+
+// Safe already-bloated-state recovery (issue #1090 / #12). A persisted
+// CKSyncEngine state so large it would stall `CKSyncEngine.init` is detected by
+// a byte-size gate and the engine is rebuilt with `nil` state (instant init),
+// self-healing on launch with no manual `syncstate` deletion. The reset is made
+// delete-safe by the #1090 journal replay PLUS a recovery-scoped tombstone
+// shield (below): the token-less full refetch the reset forces re-delivers any
+// record deleted-but-un-propagated, and the shield stops it being re-inserted /
+// its tombstone cleared, so the replayed `.deleteRecord` wins. Save-completeness
+// comes from `isFirstLaunch = true` → `queueAllExistingRecordsForAllZones`.
+
+extension SyncCoordinator {
+  /// State-file byte size above which the persisted state is treated as
+  /// pathological and recovered. A healthy state is KB–low-MB; the wedge that
+  /// motivated this was 42.5 MB. 24 MB cleanly separates the two, and a
+  /// false-positive recovery is data-safe (it costs only a one-time refetch).
+  static let bloatRecoveryByteThreshold = 24 * 1024 * 1024
+
+  /// Maximum consecutive recoveries before degrading to warning-only. A state
+  /// that re-bloats on every launch (real data exceeds the gate, or a deeper
+  /// bug) must not loop forever losing tokens; any healthy launch re-arms the
+  /// count (see `resetRecoveryAttemptCount`).
+  static let bloatRecoveryAttemptCeiling = 3
+
+  /// UserDefaults key for the consecutive-recovery counter.
+  static let bloatRecoveryAttemptCountKey = "com.moolah.sync.bloatRecoveryAttemptCount"
+
+  // MARK: - Off-actor engine construction + gate
+
+  /// Off-actor: reads the persisted sync state, applies the byte-size gate, and
+  /// constructs the `CKSyncEngine`. The body's heavy synchronous work
+  /// (`NSKeyedUnarchiver` inside `CKSyncEngine.init`) must not run on the main
+  /// thread — the `nonisolated async` hop from the `@MainActor`-originating
+  /// `Task {}` in `start()` is sufficient on the current toolchain (verified
+  /// empirically, issue #565: `Thread.isMainThread == false` at entry, a
+  /// different OS TID from the surrounding `@MainActor` `completeStart`).
+  /// `Task.detached` is not required.
+  ///
+  /// `allowRecovery` (entitlements / account / attempt ceiling) is computed on
+  /// the MainActor by `start()` and passed in; this method owns only the byte
+  /// measurement and the `nil`-state rebuild on `.recovered`.
+  nonisolated static func prepareEngine(
+    stateFileURL: URL,
+    delegate: any CKSyncEngineDelegate & Sendable,
+    allowRecovery: Bool,
+    bloatThreshold: Int
+  ) async -> PreparedEngine {
+    // A missing file is the normal first launch; a genuine read error is logged
+    // (it degrades to an empty-state / full-refetch start, the safe fallback).
+    let data: Data?
+    do {
+      data = try Data(contentsOf: stateFileURL)
+    } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+      data = nil
+    } catch {
+      offActorLogger.error(
+        "Failed to read persisted sync-state file: \(error, privacy: .public) — starting from empty state"
+      )
+      data = nil
+    }
+    // Observe-only size logging on every launch (issue #1090 / #12) — feeds
+    // threshold calibration even when the gate never fires.
+    offActorLogger.info(
+      "Persisted sync-state size: \(data?.count ?? 0, privacy: .public) bytes (threshold \(bloatThreshold, privacy: .public))"
+    )
+
+    let outcome = bloatGateOutcome(
+      stateByteCount: data?.count, allowRecovery: allowRecovery, threshold: bloatThreshold)
+    // `.recovered` drops the bloated blob → `nil` state → instant init,
+    // `isFirstLaunch = true`. `.healthy` / `.bloatedButSkipped` decode and pass
+    // the existing state through (off-main init absorbs any stall).
+    let savedState: CKSyncEngine.State.Serialization? =
+      outcome == .recovered ? nil : Self.decodeState(data)
+    let configuration = CKSyncEngine.Configuration(
+      database: CloudKitContainer.app.privateCloudDatabase,
+      stateSerialization: savedState,
+      delegate: delegate
+    )
+    return PreparedEngine(
+      engine: CKSyncEngine(configuration),
+      isFirstLaunch: savedState == nil,
+      recoveryOutcome: outcome)
+  }
+
+  /// Decodes the persisted state, logging (not swallowing) a corrupt /
+  /// schema-incompatible blob. A decode failure degrades to `nil` → an
+  /// empty-state, full-refetch start (safe), but the operator gets a signal.
+  nonisolated private static func decodeState(_ data: Data?) -> CKSyncEngine.State.Serialization? {
+    guard let data else { return nil }
+    do {
+      return try JSONDecoder().decode(CKSyncEngine.State.Serialization.self, from: data)
+    } catch {
+      offActorLogger.error(
+        "Persisted sync state failed to decode: \(error, privacy: .public) — starting from empty state"
+      )
+      return nil
+    }
+  }
+
+  // MARK: - Gate decision (pure)
+
+  /// Classifies the persisted state from its byte size + whether recovery is
+  /// currently allowed. `nil` byteCount (no state file) is `.healthy`. Pure +
+  /// `nonisolated static` so the gate is unit-tested without touching disk or a
+  /// live engine.
+  nonisolated static func bloatGateOutcome(
+    stateByteCount: Int?, allowRecovery: Bool, threshold: Int
+  ) -> BloatGateOutcome {
+    guard let byteCount = stateByteCount, byteCount > threshold else { return .healthy }
+    return allowRecovery ? .recovered : .bloatedButSkipped
+  }
+
+  // MARK: - Attempt counter (re-armable ceiling)
+
+  /// Consecutive recoveries recorded so far (0 when none / re-armed).
+  var recoveryAttemptCount: Int {
+    userDefaults.integer(forKey: Self.bloatRecoveryAttemptCountKey)
+  }
+
+  /// Records one more consecutive recovery.
+  func incrementRecoveryAttemptCount() {
+    userDefaults.set(recoveryAttemptCount + 1, forKey: Self.bloatRecoveryAttemptCountKey)
+  }
+
+  /// Re-arms the ceiling — called on any launch that observes a healthy state,
+  /// so a legitimately-re-bloated install months later can self-heal again.
+  func resetRecoveryAttemptCount() {
+    userDefaults.removeObject(forKey: Self.bloatRecoveryAttemptCountKey)
+  }
+
+  /// Whether a bloated state may be recovered right now: entitlements present,
+  /// iCloud not *known* unavailable, and the consecutive-recovery ceiling not
+  /// yet reached. The async account-status probe has not run at
+  /// `prepareEngine` time, so `.unknown` counts as "not known-unavailable"
+  /// (recovery is data-safe regardless of account state; this only avoids
+  /// churning a refetch during a *known* sign-out / restricted account).
+  var isRecoveryAllowed: Bool {
+    guard isCloudKitAvailable else { return false }
+    if case .unavailable = iCloudAvailability { return false }
+    return recoveryAttemptCount < Self.bloatRecoveryAttemptCeiling
+  }
+
+  // MARK: - Outcome handling (called from completeStart)
+
+  /// Applies the byte-size gate outcome at start: a recovery bumps the attempt
+  /// count and arms the tombstone shield; a healthy launch re-arms the ceiling;
+  /// a skipped-but-bloated launch warns (the existing state is running as-is).
+  func applyRecoveryOutcome(_ outcome: BloatGateOutcome) {
+    switch outcome {
+    case .recovered:
+      incrementRecoveryAttemptCount()
+      logger.warning(
+        "Bloated sync state recovered: rebuilt the engine with empty state (consecutive recovery #\(self.recoveryAttemptCount, privacy: .public) of \(Self.bloatRecoveryAttemptCeiling, privacy: .public))"
+      )
+      armRecoveryShield()
+    case .healthy:
+      resetRecoveryAttemptCount()
+    case .bloatedButSkipped:
+      logger.warning(
+        "Sync state exceeds the bloat threshold but recovery was skipped (attempt ceiling reached or iCloud unavailable) — running with the existing state"
+      )
+    }
+  }
+
+  // MARK: - Recovery-scoped tombstone shield
+
+  /// Arms the shield for a recovery session: spawns the snapshot build BEFORE
+  /// the engine is installed, so the apply path always observes an in-flight (or
+  /// finished) `recoverySnapshotTask` and never races the engine's automatic
+  /// post-init fetch. Idempotent within a start.
+  func armRecoveryShield() {
+    isRecoveryShieldActive = true
+    // Cancel any in-flight snapshot from a prior arm before replacing it, so an
+    // abandoned build can't resume and overwrite the new snapshot.
+    recoverySnapshotTask?.cancel()
+    recoverySnapshotTask = Task { [weak self] in
+      await self?.buildRecoveryDeletionSnapshot()
+    }
+  }
+
+  /// Builds `recoveringDeletions` = the union of every journal deletion id
+  /// (index DB + each live profile DB), resolved to its real CloudKit zone. If
+  /// the journals are empty there is nothing to shield, so the shield
+  /// deactivates immediately.
+  private func buildRecoveryDeletionSnapshot() async {
+    let resolved = await resolveAllJournalDeletions()
+    // `stop()` (or a re-arm) may have cancelled us during the journal reads and
+    // already cleared the shield state — don't resurrect it with a stale set.
+    guard !Task.isCancelled else { return }
+    recoveringDeletions = Set(resolved.keys)
+    if recoveringDeletions.isEmpty {
+      isRecoveryShieldActive = false
+    } else {
+      logger.warning(
+        "Recovery shield armed for \(self.recoveringDeletions.count, privacy: .public) un-propagated deletion(s)"
+      )
+    }
+  }
+
+  /// The active shield id-set for the apply path. Awaits the snapshot build so a
+  /// fetched change that arrives before the snapshot is ready is still shielded
+  /// (race-free). Returns `[]` when no recovery is in progress.
+  func activeRecoveryShield() async -> Set<CKRecord.ID> {
+    guard isRecoveryShieldActive else { return [] }
+    await recoverySnapshotTask?.value
+    // Re-check after the suspension: `stop()` may have deactivated the shield
+    // (and cleared `recoveringDeletions`) while we were awaiting the build.
+    guard isRecoveryShieldActive else { return [] }
+    return recoveringDeletions
+  }
+
+  /// Releases the whole shield once every recovered deletion has been confirmed
+  /// sent (`replayedDeletionsInFlight` emptied by clear-on-confirm) — the
+  /// recovery session has settled, so a later legitimate peer re-create of a
+  /// (formerly) shielded id upserts normally again. Called from
+  /// `clearConfirmedReplayedDeletions`.
+  func releaseRecoveryShieldIfSettled() {
+    guard isRecoveryShieldActive, replayedDeletionsInFlight.isEmpty else { return }
+    isRecoveryShieldActive = false
+    recoveringDeletions = []
+    recoverySnapshotTask = nil
+    logger.info("Recovery shield released — all recovered deletions confirmed")
+  }
+
+  /// Partitions fetched saved records into those to apply and those the shield
+  /// suppresses (a re-delivered deleted-but-un-propagated record). Pure +
+  /// `nonisolated static` so the filter is unit-tested without a live engine.
+  nonisolated static func partitionShieldedSaves(
+    _ saved: [CKRecord], shield: Set<CKRecord.ID>
+  ) -> (toApply: [CKRecord], suppressed: [CKRecord]) {
+    guard !shield.isEmpty else { return (saved, []) }
+    var toApply: [CKRecord] = []
+    var suppressed: [CKRecord] = []
+    for record in saved {
+      if shield.contains(record.recordID) {
+        suppressed.append(record)
+      } else {
+        toApply.append(record)
+      }
+    }
+    return (toApply, suppressed)
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -76,6 +76,27 @@ extension SyncCoordinator {
   /// HARD RULE: every re-issued deletion comes from a positive journal row —
   /// nothing is ever inferred from a record being absent locally.
   func replayDeletionJournal(into state: any PendingChangeStore) async {
+    let resolved = await resolveAllJournalDeletions()
+    // The coordinator may have been stopped while the journal reads were in
+    // flight — don't mutate state / enqueue onto a torn-down engine.
+    guard !Task.isCancelled, !resolved.isEmpty else { return }
+    for (id, ref) in resolved {
+      replayedDeletionsInFlight[id] = ref
+    }
+    state.add(pendingRecordZoneChanges: resolved.keys.map { .deleteRecord($0) })
+    logger.warning(
+      "Deletion-journal replay: re-enqueued \(resolved.count, privacy: .public) durable deletion(s)"
+    )
+    refreshPendingUploadsMirror()
+  }
+
+  /// Reads the deletion journal from the profile-index DB and every live
+  /// profile's DB and resolves each row to its real CloudKit `CKRecord.ID`
+  /// (sentinel `@profile-data` → `profile-<id>`; index rows already carry
+  /// `profile-index`). Shared by the start-time replay and the recovery
+  /// tombstone-shield snapshot (issue #1090 / #12). Keyed by `CKRecord.ID` so a
+  /// duplicate intent collapses to one entry.
+  func resolveAllJournalDeletions() async -> [CKRecord.ID: ReplayedDeletionRef] {
     var resolved: [CKRecord.ID: ReplayedDeletionRef] = [:]
 
     let indexEntries = await readDeletionJournal(in: containerManager.profileIndexDatabase)
@@ -94,7 +115,7 @@ extension SyncCoordinator {
         database = try containerManager.database(for: profileId)
       } catch {
         logger.error(
-          "Deletion-journal replay: cannot open DB for profile \(profileId, privacy: .public): \(error, privacy: .public) — skipping its journal"
+          "Deletion-journal resolve: cannot open DB for profile \(profileId, privacy: .public): \(error, privacy: .public) — skipping its journal"
         )
         continue
       }
@@ -109,18 +130,7 @@ extension SyncCoordinator {
           recordName: id.recordName)
       }
     }
-
-    // The coordinator may have been stopped while the journal reads were in
-    // flight — don't mutate state / enqueue onto a torn-down engine.
-    guard !Task.isCancelled, !resolved.isEmpty else { return }
-    for (id, ref) in resolved {
-      replayedDeletionsInFlight[id] = ref
-    }
-    state.add(pendingRecordZoneChanges: resolved.keys.map { .deleteRecord($0) })
-    logger.warning(
-      "Deletion-journal replay: re-enqueued \(resolved.count, privacy: .public) durable deletion(s)"
-    )
-    refreshPendingUploadsMirror()
+    return resolved
   }
 
   /// Retires journal rows for replayed deletions whose `.deleteRecord` has left
@@ -154,6 +164,10 @@ extension SyncCoordinator {
     for id in confirmed.keys {
       replayedDeletionsInFlight.removeValue(forKey: id)
     }
+    // A recovery session settles once its replayed deletions are all confirmed
+    // (issue #1090 / #12) — release the tombstone shield so later incoming
+    // records upsert normally again.
+    releaseRecoveryShieldIfSettled()
   }
 
   /// The subset of `inFlight` whose `.deleteRecord` is no longer in `pending` —

--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -76,7 +76,7 @@ extension SyncCoordinator {
   /// HARD RULE: every re-issued deletion comes from a positive journal row —
   /// nothing is ever inferred from a record being absent locally.
   func replayDeletionJournal(into state: any PendingChangeStore) async {
-    let resolved = await resolveAllJournalDeletions()
+    let resolved = await resolveAllJournalDeletions().resolved
     // The coordinator may have been stopped while the journal reads were in
     // flight — don't mutate state / enqueue onto a torn-down engine.
     guard !Task.isCancelled, !resolved.isEmpty else { return }
@@ -96,41 +96,54 @@ extension SyncCoordinator {
   /// `profile-index`). Shared by the start-time replay and the recovery
   /// tombstone-shield snapshot (issue #1090 / #12). Keyed by `CKRecord.ID` so a
   /// duplicate intent collapses to one entry.
-  func resolveAllJournalDeletions() async -> [CKRecord.ID: ReplayedDeletionRef] {
+  ///
+  /// `readFailed` is `true` when ANY journal read (or DB open) failed: the
+  /// resolved set is then INCOMPLETE. The replay tolerates that (the missed rows
+  /// replay next start), but the recovery shield must fail closed — see
+  /// `buildRecoveryDeletionSnapshot`.
+  func resolveAllJournalDeletions()
+    async -> (resolved: [CKRecord.ID: ReplayedDeletionRef], readFailed: Bool)
+  {
     var resolved: [CKRecord.ID: ReplayedDeletionRef] = [:]
+    var readFailed = false
 
-    let indexEntries = await readDeletionJournal(in: containerManager.profileIndexDatabase)
-    for id in Self.indexZoneDeletionReplayIDs(
-      indexEntries, indexZoneID: profileIndexHandler.zoneID)
-    {
-      resolved[id] = ReplayedDeletionRef(
-        origin: .index,
-        journalZoneName: DeletionJournal.profileIndexZoneName,
-        recordName: id.recordName)
+    do {
+      let indexEntries = try await readDeletionJournal(in: containerManager.profileIndexDatabase)
+      for id in Self.indexZoneDeletionReplayIDs(
+        indexEntries, indexZoneID: profileIndexHandler.zoneID)
+      {
+        resolved[id] = ReplayedDeletionRef(
+          origin: .index,
+          journalZoneName: DeletionJournal.profileIndexZoneName,
+          recordName: id.recordName)
+      }
+    } catch {
+      logger.error(
+        "Deletion-journal resolve: index DB read failed: \(error, privacy: .public)")
+      readFailed = true
     }
 
     for profileId in await containerManager.allProfileIds() {
-      let database: DatabaseQueue
       do {
-        database = try containerManager.database(for: profileId)
+        let database = try containerManager.database(for: profileId)
+        let entries = try await readDeletionJournal(in: database)
+        let dataZoneID = CKRecordZone.ID(
+          zoneName: DeletionJournal.dataZoneName(for: profileId),
+          ownerName: CKCurrentUserDefaultName)
+        for id in Self.dataZoneDeletionReplayIDs(entries, dataZoneID: dataZoneID) {
+          resolved[id] = ReplayedDeletionRef(
+            origin: .profileData(profileId),
+            journalZoneName: DeletionJournal.profileDataSentinelZone,
+            recordName: id.recordName)
+        }
       } catch {
         logger.error(
-          "Deletion-journal resolve: cannot open DB for profile \(profileId, privacy: .public): \(error, privacy: .public) — skipping its journal"
+          "Deletion-journal resolve: read failed for profile \(profileId, privacy: .public): \(error, privacy: .public)"
         )
-        continue
-      }
-      let entries = await readDeletionJournal(in: database)
-      let dataZoneID = CKRecordZone.ID(
-        zoneName: DeletionJournal.dataZoneName(for: profileId),
-        ownerName: CKCurrentUserDefaultName)
-      for id in Self.dataZoneDeletionReplayIDs(entries, dataZoneID: dataZoneID) {
-        resolved[id] = ReplayedDeletionRef(
-          origin: .profileData(profileId),
-          journalZoneName: DeletionJournal.profileDataSentinelZone,
-          recordName: id.recordName)
+        readFailed = true
       }
     }
-    return resolved
+    return (resolved, readFailed)
   }
 
   /// Retires journal rows for replayed deletions whose `.deleteRecord` has left
@@ -231,17 +244,13 @@ extension SyncCoordinator {
     }
   }
 
-  /// Reads every deletion-journal row in `database` off the MainActor, returning
-  /// `[]` on any read error (a transient failure must degrade to "replay nothing
-  /// from this DB this start", never throw out of startup).
-  private func readDeletionJournal(in database: DatabaseQueue) async -> [DeletionJournalRow] {
-    do {
-      return try await database.read { try DeletionJournal.allEntries(in: $0) }
-    } catch {
-      logger.error(
-        "Deletion-journal read failed: \(error, privacy: .public) — replaying nothing from this DB")
-      return []
-    }
+  /// Reads every deletion-journal row in `database` off the MainActor. Throws on
+  /// a read error so the caller can tell "no tombstones" (`[]`) from "could not
+  /// read" — the recovery shield must fail closed on the latter rather than
+  /// proceed with an incomplete snapshot.
+  private func readDeletionJournal(in database: DatabaseQueue) async throws -> [DeletionJournalRow]
+  {
+    try await database.read { try DeletionJournal.allEntries(in: $0) }
   }
 
   /// Clears the given journal rows in `database` off the MainActor. Best-effort:

--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -79,15 +79,21 @@ extension SyncCoordinator {
     let resolved = await resolveAllJournalDeletions().resolved
     // The coordinator may have been stopped while the journal reads were in
     // flight — don't mutate state / enqueue onto a torn-down engine.
-    guard !Task.isCancelled, !resolved.isEmpty else { return }
-    for (id, ref) in resolved {
-      replayedDeletionsInFlight[id] = ref
+    guard !Task.isCancelled else { return }
+    if !resolved.isEmpty {
+      for (id, ref) in resolved {
+        replayedDeletionsInFlight[id] = ref
+      }
+      state.add(pendingRecordZoneChanges: resolved.keys.map { .deleteRecord($0) })
+      logger.warning(
+        "Deletion-journal replay: re-enqueued \(resolved.count, privacy: .public) durable deletion(s)"
+      )
+      refreshPendingUploadsMirror()
     }
-    state.add(pendingRecordZoneChanges: resolved.keys.map { .deleteRecord($0) })
-    logger.warning(
-      "Deletion-journal replay: re-enqueued \(resolved.count, privacy: .public) durable deletion(s)"
-    )
-    refreshPendingUploadsMirror()
+    // Mark that replay has run this start — half of the recovery-shield release
+    // condition, so a fetch settling before replay can't release it early
+    // (issue #1090 / #12).
+    recoveryReplayDidRun = true
   }
 
   /// Reads the deletion journal from the profile-index DB and every live

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -101,12 +101,14 @@ extension SyncCoordinator {
     // ceiling); capture it here and pass it into the off-main `prepareEngine`,
     // which owns the byte-size measurement (issue #1090 / #12).
     let allowRecovery = self.isRecoveryAllowed
+    let forceRecovery = self.isRecoveryForced
     let bloatThreshold = Self.bloatRecoveryByteThreshold
     startTask = Task { [weak self] in
       let prepared = await Self.prepareEngine(
         stateFileURL: stateURL,
         delegate: delegate,
         allowRecovery: allowRecovery,
+        forceRecovery: forceRecovery,
         bloatThreshold: bloatThreshold)
       // `stop()` cancels `startTask` — if that races with prepareEngine, drop
       // the prepared engine. `delegate` strongly captures `self`, so the
@@ -132,7 +134,7 @@ extension SyncCoordinator {
     // Handle the byte-size gate outcome (issue #1090 / #12) BEFORE installing the
     // engine, so a `.recovered` launch arms the tombstone shield before the
     // engine's automatic post-init fetch can deliver a re-fetched record.
-    applyRecoveryOutcome(prepared.recoveryOutcome)
+    applyRecoveryOutcome(prepared.recoveryOutcome, wasForced: prepared.recoveryWasForced)
 
     syncEngine = prepared.engine
     isFirstLaunch = prepared.isFirstLaunch
@@ -264,6 +266,7 @@ extension SyncCoordinator {
     recoveringDeletions = []
     recoveryFetchDidSettle = false
     recoveryShieldSuppressAll = false
+    recoveryReplayDidRun = false
     fetchChangesTask?.cancel()
     fetchChangesTask = nil
     cancelRefetchTasks()

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -262,6 +262,8 @@ extension SyncCoordinator {
     recoverySnapshotTask = nil
     isRecoveryShieldActive = false
     recoveringDeletions = []
+    recoveryFetchDidSettle = false
+    recoveryShieldSuppressAll = false
     fetchChangesTask?.cancel()
     fetchChangesTask = nil
     cancelRefetchTasks()
@@ -369,6 +371,14 @@ extension SyncCoordinator {
     }
     fetchSessionTouchedIndexZone = false
     progress.endReceiving(now: Date())
+    // A full fetch session has completed — the forced post-recovery refetch (if
+    // any) has now delivered everything. Record that and try to release the
+    // recovery shield (issue #1090 / #12): it must outlive the refetch, not just
+    // the delete-send. `isFetchingChanges` is already false here.
+    if isRecoveryShieldActive {
+      recoveryFetchDidSettle = true
+      releaseRecoveryShieldIfSettled()
+    }
   }
 
   /// Fires the index-observer callbacks if the profile-index zone changed

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -97,8 +97,17 @@ extension SyncCoordinator {
     // engine object is back on the main actor.
     let stateURL = self.stateFileURL
     let delegate: any CKSyncEngineDelegate & Sendable = self
+    // Recovery eligibility is MainActor state (entitlements, account, attempt
+    // ceiling); capture it here and pass it into the off-main `prepareEngine`,
+    // which owns the byte-size measurement (issue #1090 / #12).
+    let allowRecovery = self.isRecoveryAllowed
+    let bloatThreshold = Self.bloatRecoveryByteThreshold
     startTask = Task { [weak self] in
-      let prepared = await Self.prepareEngine(stateFileURL: stateURL, delegate: delegate)
+      let prepared = await Self.prepareEngine(
+        stateFileURL: stateURL,
+        delegate: delegate,
+        allowRecovery: allowRecovery,
+        bloatThreshold: bloatThreshold)
       // `stop()` cancels `startTask` — if that races with prepareEngine, drop
       // the prepared engine. `delegate` strongly captures `self`, so the
       // `guard let self` alone would still succeed after a stop.
@@ -107,32 +116,8 @@ extension SyncCoordinator {
     }
   }
 
-  /// Off-actor: reads sync state from disk and constructs the `CKSyncEngine`.
-  ///
-  /// The body's heavy synchronous work (`NSKeyedUnarchiver` inside
-  /// `CKSyncEngine.init`) must not run on the main thread. The
-  /// `nonisolated async` hop from the `@MainActor`-originating `Task {}`
-  /// in `start()` is sufficient on the current toolchain — verified
-  /// empirically (issue #565) by logging `Thread.isMainThread` at entry
-  /// and observing `false`, plus a different OS TID from the surrounding
-  /// `@MainActor` `completeStart`. `Task.detached` is not required here.
-  nonisolated static func prepareEngine(
-    stateFileURL: URL,
-    delegate: any CKSyncEngineDelegate & Sendable
-  ) async -> PreparedEngine {
-    let data = try? Data(contentsOf: stateFileURL)
-    let savedState = data.flatMap {
-      try? JSONDecoder().decode(CKSyncEngine.State.Serialization.self, from: $0)
-    }
-    let configuration = CKSyncEngine.Configuration(
-      database: CloudKitContainer.app.privateCloudDatabase,
-      stateSerialization: savedState,
-      delegate: delegate
-    )
-    return PreparedEngine(
-      engine: CKSyncEngine(configuration),
-      isFirstLaunch: savedState == nil)
-  }
+  // `prepareEngine` (off-actor engine construction + the #1090/#12 byte-size
+  // gate) lives in `SyncCoordinator+BloatRecovery.swift`.
 
   /// Back-on-MainActor half of `start()`: installs the engine and kicks off
   /// zone setup. Separate from `start()` so the heavy init can run off-actor.
@@ -143,6 +128,11 @@ extension SyncCoordinator {
       os_signpost(.end, log: Signposts.sync, name: "coordinatorStart", signpostID: signpostID)
       startTask = nil
     }
+
+    // Handle the byte-size gate outcome (issue #1090 / #12) BEFORE installing the
+    // engine, so a `.recovered` launch arms the tombstone shield before the
+    // engine's automatic post-init fetch can deliver a re-fetched record.
+    applyRecoveryOutcome(prepared.recoveryOutcome)
 
     syncEngine = prepared.engine
     isFirstLaunch = prepared.isFirstLaunch
@@ -268,6 +258,10 @@ extension SyncCoordinator {
     zoneSetupTask = nil
     availabilityProbeTask?.cancel()
     availabilityProbeTask = nil
+    recoverySnapshotTask?.cancel()
+    recoverySnapshotTask = nil
+    isRecoveryShieldActive = false
+    recoveringDeletions = []
     fetchChangesTask?.cancel()
     fetchChangesTask = nil
     cancelRefetchTasks()

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -107,8 +107,7 @@ extension SyncCoordinator {
     // Recovery tombstone shield (issue #1090 / #12) — suppress a re-delivered
     // deleted ProfileRecord so the token-less refetch can't resurrect an
     // empty-shell profile mid-recovery. See `applyFetchedProfileDataChanges`.
-    let shield = await activeRecoveryShield()
-    let (toApply, suppressed) = Self.partitionShieldedSaves(saved, shield: shield)
+    let (toApply, suppressed) = await recoveryShieldedSaves(saved)
     if !suppressed.isEmpty {
       logger.warning(
         "Recovery shield suppressed \(suppressed.count, privacy: .public) re-delivered index deletion(s)"
@@ -178,11 +177,10 @@ extension SyncCoordinator {
     // locally whose `.deleteRecord` never propagated. Drop those saves so the
     // replayed deletion wins on both the local row and the server — the per-repo
     // D1-b journal clear runs per-upserted-row, so suppressing the upsert also
-    // skips the clear. `activeRecoveryShield()` awaits the snapshot build, so
-    // there is no race with the engine's automatic post-init fetch; it is `[]`
-    // (no filtering) outside recovery.
-    let shield = await activeRecoveryShield()
-    let (toApply, suppressed) = Self.partitionShieldedSaves(saved, shield: shield)
+    // skips the clear. `recoveryShieldedSaves` awaits the snapshot build, so
+    // there is no race with the engine's automatic post-init fetch; it returns
+    // everything unfiltered outside recovery.
+    let (toApply, suppressed) = await recoveryShieldedSaves(saved)
     if !suppressed.isEmpty {
       logger.warning(
         "Recovery shield suppressed \(suppressed.count, privacy: .public) re-delivered deletion(s) for profile \(profileId, privacy: .public)"

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -104,12 +104,22 @@ extension SyncCoordinator {
     deleted: [(CKRecord.ID, String)]
   ) async {
     let deletedIDs = deleted.map(\.0)
+    // Recovery tombstone shield (issue #1090 / #12) — suppress a re-delivered
+    // deleted ProfileRecord so the token-less refetch can't resurrect an
+    // empty-shell profile mid-recovery. See `applyFetchedProfileDataChanges`.
+    let shield = await activeRecoveryShield()
+    let (toApply, suppressed) = Self.partitionShieldedSaves(saved, shield: shield)
+    if !suppressed.isEmpty {
+      logger.warning(
+        "Recovery shield suppressed \(suppressed.count, privacy: .public) re-delivered index deletion(s)"
+      )
+    }
     // Index upsert is fast (few records), run off-main. The single-device
     // echo race is guarded transactionally inside the handler's apply
     // write via the `needs_push` flag (issue #1081), so no main-actor
     // pre-snapshot is needed.
     let indexResult = profileIndexHandler.applyRemoteChanges(
-      saved: saved, deleted: deletedIDs)
+      saved: toApply, deleted: deletedIDs)
     switch indexResult {
     case .success:
       await MainActor.run {
@@ -163,8 +173,24 @@ extension SyncCoordinator {
       }
     guard let handler else { return }
 
+    // Recovery tombstone shield (issue #1090 / #12): during a bloated-state
+    // recovery, the token-less full refetch re-delivers any record deleted
+    // locally whose `.deleteRecord` never propagated. Drop those saves so the
+    // replayed deletion wins on both the local row and the server — the per-repo
+    // D1-b journal clear runs per-upserted-row, so suppressing the upsert also
+    // skips the clear. `activeRecoveryShield()` awaits the snapshot build, so
+    // there is no race with the engine's automatic post-init fetch; it is `[]`
+    // (no filtering) outside recovery.
+    let shield = await activeRecoveryShield()
+    let (toApply, suppressed) = Self.partitionShieldedSaves(saved, shield: shield)
+    if !suppressed.isEmpty {
+      logger.warning(
+        "Recovery shield suppressed \(suppressed.count, privacy: .public) re-delivered deletion(s) for profile \(profileId, privacy: .public)"
+      )
+    }
+
     // Filter pre-extracted system fields to this zone (off-main)
-    let savedNames = Set(saved.map { $0.recordID.recordName })
+    let savedNames = Set(toApply.map { $0.recordID.recordName })
     let zonePreExtracted = preExtractedSystemFields.filter { recordName, _ in
       savedNames.contains(recordName)
     }
@@ -174,11 +200,11 @@ extension SyncCoordinator {
     // path. The deduper hook below uses this set to scope its sweep to
     // legs the fetch could plausibly have introduced duplicates for —
     // bounded work even when an unrelated zone push arrived.
-    let touchedExternalIds = Self.extractTouchedExternalIds(saved: saved)
+    let touchedExternalIds = Self.extractTouchedExternalIds(saved: toApply)
 
     // Heavy upsert/delete/save runs off-main via nonisolated method
     let result = handler.applyRemoteChanges(
-      saved: saved, deleted: deleted, preExtractedSystemFields: zonePreExtracted)
+      saved: toApply, deleted: deleted, preExtractedSystemFields: zonePreExtracted)
 
     switch result {
     case .success:

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -54,6 +54,26 @@ final class SyncCoordinator {
   struct PreparedEngine: @unchecked Sendable {
     let engine: CKSyncEngine
     let isFirstLaunch: Bool
+    /// How the start-time byte-size gate classified the persisted state (issue
+    /// #1090 / #12). `.recovered` means the bloated state was dropped and the
+    /// engine rebuilt with `nil` state; `completeStart` arms the recovery
+    /// tombstone shield and bumps the attempt count on it.
+    let recoveryOutcome: BloatGateOutcome
+  }
+
+  /// Classification of the persisted sync-state file by the start-time
+  /// byte-size gate (issue #1090 / #12).
+  enum BloatGateOutcome: Sendable, Equatable {
+    /// State is absent or below the bloat threshold — the engine starts from it
+    /// normally and the recovery attempt count is re-armed (reset to 0).
+    case healthy
+    /// State exceeded the threshold and recovery was allowed — the engine was
+    /// rebuilt with `nil` state (instant init) and self-heals on launch.
+    case recovered
+    /// State exceeded the threshold but recovery was NOT allowed (attempt
+    /// ceiling reached, or iCloud known-unavailable) — the existing state is
+    /// passed through (off-main init absorbs the stall) and a warning is logged.
+    case bloatedButSkipped
   }
 
   // MARK: - Index Observer
@@ -157,6 +177,11 @@ final class SyncCoordinator {
 
   let logger = Logger(subsystem: "com.moolah.app", category: "SyncCoordinator")
 
+  /// The same logger for the `nonisolated static` off-actor paths (e.g.
+  /// `prepareEngine`) that cannot reach the `@MainActor` instance `logger`.
+  nonisolated static let offActorLogger = Logger(
+    subsystem: "com.moolah.app", category: "SyncCoordinator")
+
   var syncEngine: CKSyncEngine?
 
   var isRunning = false
@@ -234,13 +259,34 @@ final class SyncCoordinator {
   var cachedGRDBRepositories: [UUID: ProfileGRDBRepositories] = [:]
 
   /// Journal-backed deletions the start-time replay re-enqueued this session
-  /// that have not yet been confirmed sent (issue #1090, PR-B). Keyed by the
+  /// that have not yet been confirmed sent (issue #1090). Keyed by the
   /// pending-change `CKRecord.ID`. `clearConfirmedReplayedDeletions` clears a
   /// row's journal entry once its `.deleteRecord` leaves the pending queue (the
   /// only signal CloudKit gives for a successful delete), so a confirmed
   /// deletion does not re-replay on every subsequent start. A `.saveRecord` for
   /// the same id (a re-create) also drops its entry here — see `applySave`.
   var replayedDeletionsInFlight: [CKRecord.ID: ReplayedDeletionRef] = [:]
+
+  /// `true` for the duration of a bloated-state recovery session (issue #1090 /
+  /// #12), from when `completeStart` arms the shield until every recovered
+  /// deletion is confirmed sent. While active, the fetched-change apply path
+  /// suppresses any re-delivered record whose id is in `recoveringDeletions`
+  /// (see `SyncCoordinator+BloatRecovery`).
+  var isRecoveryShieldActive = false
+
+  /// The recovery-scoped tombstone shield: the union of every journal deletion
+  /// id captured at recovery start. While `isRecoveryShieldActive`, the
+  /// token-less full refetch must NOT re-insert (or clear the tombstone of) any
+  /// record in this set — the replayed `.deleteRecord` wins on both the local
+  /// row and the server copy. Built off-main by `recoverySnapshotTask`; the
+  /// apply path awaits that task before reading this, so there is no race with
+  /// the engine's automatic post-init fetch.
+  var recoveringDeletions: Set<CKRecord.ID> = []
+
+  /// Builds `recoveringDeletions` from the journals at recovery start. Held so
+  /// the apply path can `await` it (race-free) before consulting the shield, and
+  /// so `stop()` can cancel it.
+  var recoverySnapshotTask: Task<Void, Never>?
 
   /// Zones with pending zone creation — records in these zones are skipped in nextRecordZoneChangeBatch.
   var pendingZoneCreation: [CKRecordZone.ID: [CKSyncEngine.PendingRecordZoneChange]] = [:]

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -61,21 +61,6 @@ final class SyncCoordinator {
     let recoveryOutcome: BloatGateOutcome
   }
 
-  /// Classification of the persisted sync-state file by the start-time
-  /// byte-size gate (issue #1090 / #12).
-  enum BloatGateOutcome: Sendable, Equatable {
-    /// State is absent or below the bloat threshold — the engine starts from it
-    /// normally and the recovery attempt count is re-armed (reset to 0).
-    case healthy
-    /// State exceeded the threshold and recovery was allowed — the engine was
-    /// rebuilt with `nil` state (instant init) and self-heals on launch.
-    case recovered
-    /// State exceeded the threshold but recovery was NOT allowed (attempt
-    /// ceiling reached, or iCloud known-unavailable) — the existing state is
-    /// passed through (off-main init absorbs the stall) and a warning is logged.
-    case bloatedButSkipped
-  }
-
   // MARK: - Index Observer
 
   private struct IndexObserver {
@@ -177,8 +162,8 @@ final class SyncCoordinator {
 
   let logger = Logger(subsystem: "com.moolah.app", category: "SyncCoordinator")
 
-  /// The same logger for the `nonisolated static` off-actor paths (e.g.
-  /// `prepareEngine`) that cannot reach the `@MainActor` instance `logger`.
+  /// Logger for `nonisolated static` off-actor paths (e.g. `prepareEngine`) that
+  /// can't reach the `@MainActor` instance `logger`.
   nonisolated static let offActorLogger = Logger(
     subsystem: "com.moolah.app", category: "SyncCoordinator")
 
@@ -267,20 +252,27 @@ final class SyncCoordinator {
   /// the same id (a re-create) also drops its entry here — see `applySave`.
   var replayedDeletionsInFlight: [CKRecord.ID: ReplayedDeletionRef] = [:]
 
-  /// `true` for the duration of a bloated-state recovery session (issue #1090 /
-  /// #12), from when `completeStart` arms the shield until every recovered
-  /// deletion is confirmed sent. While active, the fetched-change apply path
-  /// suppresses any re-delivered record whose id is in `recoveringDeletions`
-  /// (see `SyncCoordinator+BloatRecovery`).
+  // Bloated-state recovery shield (issue #1090 / #12) — see
+  // `SyncCoordinator+BloatRecovery`. Releases only once every recovered deletion
+  // is confirmed AND the forced refetch has settled.
+
+  /// `true` while the recovery tombstone shield is suppressing re-delivered
+  /// deletions in the apply path.
   var isRecoveryShieldActive = false
 
-  /// The recovery-scoped tombstone shield: the union of every journal deletion
-  /// id captured at recovery start. While `isRecoveryShieldActive`, the
-  /// token-less full refetch must NOT re-insert (or clear the tombstone of) any
-  /// record in this set — the replayed `.deleteRecord` wins on both the local
-  /// row and the server copy. Built off-main by `recoverySnapshotTask`; the
-  /// apply path awaits that task before reading this, so there is no race with
-  /// the engine's automatic post-init fetch.
+  /// `true` once a full fetch session has completed since arming — one half of
+  /// the release condition. Set in `endFetchingChanges`.
+  var recoveryFetchDidSettle = false
+
+  /// Fail-closed: a journal read failed building the snapshot, so the apply path
+  /// suppresses ALL fetched saves this session rather than resurrect an
+  /// un-enumerable deletion (legitimate peer data defers one fetch).
+  var recoveryShieldSuppressAll = false
+
+  /// The union of every journal deletion id captured at recovery start. While
+  /// the shield is active the forced refetch must NOT re-insert (or clear the
+  /// tombstone of) these — the replayed `.deleteRecord` wins. Built off-main by
+  /// `recoverySnapshotTask`; the apply path awaits that task (race-free).
   var recoveringDeletions: Set<CKRecord.ID> = []
 
   /// Builds `recoveringDeletions` from the journals at recovery start. Held so

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -59,6 +59,10 @@ final class SyncCoordinator {
     /// engine rebuilt with `nil` state; `completeStart` arms the recovery
     /// tombstone shield and bumps the attempt count on it.
     let recoveryOutcome: BloatGateOutcome
+    /// `true` when the recovery was forced by the durable "recovery incomplete"
+    /// marker (not the size gate) — it must NOT count against the size-recovery
+    /// ceiling.
+    let recoveryWasForced: Bool
   }
 
   // MARK: - Index Observer
@@ -266,8 +270,16 @@ final class SyncCoordinator {
 
   /// Fail-closed: a journal read failed building the snapshot, so the apply path
   /// suppresses ALL fetched saves this session rather than resurrect an
-  /// un-enumerable deletion (legitimate peer data defers one fetch).
+  /// un-enumerable deletion. Because the engine advances its change token past
+  /// dropped saves, a durable "recovery incomplete" marker forces a fresh
+  /// recovery next launch to re-deliver any stranded peer-only record.
   var recoveryShieldSuppressAll = false
+
+  /// `true` once `replayDeletionJournal` has run this start — the other half of
+  /// the release condition. Without it a fetch settling in the window before
+  /// replay enqueues the deletions (when `replayedDeletionsInFlight` is still
+  /// empty) could release the shield early. Reset by `armRecoveryShield` / `stop`.
+  var recoveryReplayDidRun = false
 
   /// The union of every journal deletion id captured at recovery start. While
   /// the shield is active the forced refetch must NOT re-insert (or clear the

--- a/MoolahTests/Sync/BloatRecoveryMarkerTests.swift
+++ b/MoolahTests/Sync/BloatRecoveryMarkerTests.swift
@@ -1,0 +1,131 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// The fail-closed / stranded-peer-record recovery path and the release-timing
+/// guards for bloated-state recovery (issue #1090 / #12). Shares fixtures with
+/// `BloatStateRecoveryTests` via `BloatRecoveryTestSupport`.
+@Suite("Bloated-state recovery — fail-closed + release timing (#1090 / #12)")
+@MainActor
+struct BloatRecoveryMarkerTests {
+  private typealias Support = BloatRecoveryTestSupport
+
+  // MARK: - Fail-closed on a journal-read failure during arming
+
+  @Test("a read-failed shield suppresses ALL fetched saves (fail-closed), not just snapshot ids")
+  func failClosedShieldSuppressesEverything() async throws {
+    let (coordinator, _) = try Support.makeCoordinator()
+    // Simulate the snapshot-build read-failure outcome directly.
+    coordinator.isRecoveryShieldActive = true
+    coordinator.recoveryShieldSuppressAll = true
+
+    let zone = CKRecordZone.ID(zoneName: "profile-x", ownerName: CKCurrentUserDefaultName)
+    let anyRecord = CKRecord(
+      recordType: CategoryRow.recordType,
+      recordID: CKRecord.ID(recordType: CategoryRow.recordType, uuid: UUID(), zoneID: zone))
+    let (toApply, suppressed) = await coordinator.recoveryShieldedSaves([anyRecord])
+    #expect(toApply.isEmpty)
+    #expect(suppressed.count == 1)
+  }
+
+  // MARK: - Stranded-peer-record recovery (the adversary's IMPORTANT)
+
+  @Test(
+    "a fail-closed snapshot marks recovery incomplete, which forces a fresh recovery next launch regardless of size"
+  )
+  func failClosedMarksAndForcesNextRecovery() async throws {
+    let (coordinator, _) = try Support.makeCoordinator()
+    #expect(!coordinator.recoveryIncomplete)
+    #expect(!coordinator.isRecoveryForced)
+
+    // A read-failed snapshot (the engine has advanced its token past the saves we
+    // had to drop) sets the durable marker and fails closed. Set the active flag
+    // directly rather than via `armRecoveryShield`, whose async snapshot task
+    // would race this synchronous `applyRecoverySnapshot`.
+    coordinator.isRecoveryShieldActive = true
+    coordinator.applyRecoverySnapshot(resolved: [:], readFailed: true)
+    #expect(coordinator.recoveryShieldSuppressAll)
+    #expect(coordinator.recoveryIncomplete)
+    #expect(coordinator.isRecoveryForced)
+
+    // Next launch: the marker forces recovery even though the state is now small
+    // (healthy size) and the size-ceiling is exhausted — only a fresh nil-reset
+    // re-delivers the dropped peer record.
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: 1024,
+        allowRecovery: false,
+        forceRecovery: coordinator.isRecoveryForced,
+        threshold: Support.threshold) == .recovered)
+  }
+
+  @Test("a forced recovery does NOT count against the size-recovery ceiling")
+  func forcedRecoveryDoesNotIncrementCeiling() throws {
+    let (coordinator, _) = try Support.makeCoordinator()
+    coordinator.applyRecoveryOutcome(.recovered, wasForced: true)
+    #expect(coordinator.recoveryAttemptCount == 0)
+    coordinator.applyRecoveryOutcome(.recovered, wasForced: false)
+    #expect(coordinator.recoveryAttemptCount == 1)
+  }
+
+  @Test("a healthy launch re-arms the ceiling but does NOT clear the recovery-incomplete marker")
+  func healthyLaunchKeepsTheIncompleteMarker() throws {
+    let (coordinator, _) = try Support.makeCoordinator()
+    coordinator.markRecoveryIncomplete()
+    coordinator.applyRecoveryOutcome(.healthy, wasForced: false)
+    #expect(coordinator.recoveryAttemptCount == 0)
+    #expect(coordinator.recoveryIncomplete)  // survives — still forces next launch
+  }
+
+  @Test("a clean recovery clears the marker on settle; a suppress-all recovery leaves it set")
+  func markerClearedOnCleanSettleButKeptOnSuppressAll() async throws {
+    // Clean recovery → marker cleared on release.
+    let clean = try await Support.makeShieldFixture()
+    clean.coordinator.markRecoveryIncomplete()
+    clean.coordinator.armRecoveryShield()
+    _ = await clean.coordinator.activeRecoveryShield()  // let the snapshot build
+    let cleanStore = InMemoryPendingChangeStore()
+    await clean.coordinator.replayDeletionJournal(into: cleanStore)
+    cleanStore.remove(pendingRecordZoneChanges: [.deleteRecord(clean.doomedID)])
+    await clean.coordinator.clearConfirmedReplayedDeletions(against: cleanStore)
+    Support.settleFetchSession(clean.coordinator)
+    #expect(!clean.coordinator.isRecoveryShieldActive)
+    #expect(!clean.coordinator.recoveryIncomplete)  // cleared
+
+    // Suppress-all recovery → marker stays set so the next launch re-recovers.
+    let (failed, _) = try Support.makeCoordinator()
+    failed.markRecoveryIncomplete()
+    failed.isRecoveryShieldActive = true
+    failed.applyRecoverySnapshot(resolved: [:], readFailed: true)  // fail closed
+    failed.recoveryReplayDidRun = true
+    Support.settleFetchSession(failed)  // refetch settles; no deletes in flight
+    #expect(!failed.isRecoveryShieldActive)  // released (nothing pending)
+    #expect(failed.recoveryIncomplete)  // but the marker survives
+  }
+
+  // MARK: - Release guard is not timing-dependent (the MINOR)
+
+  @Test("a fetch settling BEFORE replay runs does not release the shield early")
+  func fetchSettlingBeforeReplayDoesNotRelease() async throws {
+    let fixture = try await Support.makeShieldFixture()
+    let coordinator = fixture.coordinator
+    coordinator.armRecoveryShield()
+    _ = await coordinator.activeRecoveryShield()  // build the snapshot
+
+    // A fetch settles before replay has enqueued the deletions —
+    // `replayedDeletionsInFlight` is still empty, but replay has NOT run, so the
+    // shield must NOT release (else the in-flight refetch could resurrect).
+    Support.settleFetchSession(coordinator)
+    #expect(coordinator.isRecoveryShieldActive)
+    #expect(await Support.suppresses(fixture.doomedID, coordinator))
+
+    let store = InMemoryPendingChangeStore()
+    await coordinator.replayDeletionJournal(into: store)
+    store.remove(pendingRecordZoneChanges: [.deleteRecord(fixture.doomedID)])
+    await coordinator.clearConfirmedReplayedDeletions(against: store)
+    #expect(!coordinator.isRecoveryShieldActive)
+  }
+}

--- a/MoolahTests/Sync/BloatRecoveryTestSupport.swift
+++ b/MoolahTests/Sync/BloatRecoveryTestSupport.swift
@@ -1,0 +1,68 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Shared fixtures for the bloated-state recovery suites (issue #1090 / #12).
+/// Split across two `@Suite` files to stay within the test-file length budget;
+/// the helpers live here so both share one definition.
+@MainActor
+enum BloatRecoveryTestSupport {
+  static let threshold = SyncCoordinator.bloatRecoveryByteThreshold
+
+  static func makeDefaults() throws -> UserDefaults {
+    try #require(UserDefaults(suiteName: "bloat-recovery-test-\(UUID().uuidString)"))
+  }
+
+  static func makeCoordinator(
+    iCloud: ICloudAvailability = .available,
+    isCloudKitAvailable: Bool = true
+  ) throws -> (coordinator: SyncCoordinator, manager: ProfileContainerManager) {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      userDefaults: try makeDefaults(),
+      isCloudKitAvailable: isCloudKitAvailable)
+    coordinator.iCloudAvailability = iCloud
+    return (coordinator, manager)
+  }
+
+  /// A coordinator + a profile with one locally-deleted-but-un-propagated
+  /// category whose tombstone is journaled, plus the resolved `CKRecord.ID`.
+  struct ShieldFixture {
+    let coordinator: SyncCoordinator
+    let doomedID: CKRecord.ID
+  }
+
+  static func makeShieldFixture() async throws -> ShieldFixture {
+    let (coordinator, manager) = try makeCoordinator()
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
+    let categories = GRDBCategoryRepository(database: try manager.database(for: profileId))
+    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
+    try await categories.delete(id: doomed.id, withReplacement: nil)
+    let doomedID = CKRecord.ID(
+      recordType: CategoryRow.recordType,
+      uuid: doomed.id,
+      zoneID: CKRecordZone.ID(
+        zoneName: DeletionJournal.dataZoneName(for: profileId),
+        ownerName: CKCurrentUserDefaultName))
+    return ShieldFixture(coordinator: coordinator, doomedID: doomedID)
+  }
+
+  /// Drives a complete fetch session (begin → end) so the forced post-recovery
+  /// refetch is considered "settled".
+  static func settleFetchSession(_ coordinator: SyncCoordinator) {
+    coordinator.beginFetchingChanges()
+    coordinator.endFetchingChanges()
+  }
+
+  /// Whether the recovery shield suppresses a fetched save for `id`.
+  static func suppresses(_ id: CKRecord.ID, _ coordinator: SyncCoordinator) async -> Bool {
+    let record = CKRecord(recordType: CategoryRow.recordType, recordID: id)
+    return await coordinator.recoveryShieldedSaves([record]).toApply.isEmpty
+  }
+}

--- a/MoolahTests/Sync/BloatStateRecoveryTests.swift
+++ b/MoolahTests/Sync/BloatStateRecoveryTests.swift
@@ -209,4 +209,66 @@ struct BloatStateRecoveryTests {
     #expect(coordinator.recoveringDeletions.isEmpty)
     #expect(await coordinator.activeRecoveryShield().isEmpty)
   }
+
+  // MARK: - Refetch-resurrection closed in BOTH orderings (the CRITICAL hazard)
+
+  @Test(
+    "the deleted record is suppressed whether the refetch arrives before OR after replay; after the deletion settles a peer re-create applies again"
+  )
+  func refetchDoesNotResurrectInEitherOrdering() async throws {
+    let (coordinator, manager) = try Self.makeCoordinator()
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
+    let database = try manager.database(for: profileId)
+    let categories = GRDBCategoryRepository(database: database)
+    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
+    try await categories.delete(id: doomed.id, withReplacement: nil)
+
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: DeletionJournal.dataZoneName(for: profileId),
+      ownerName: CKCurrentUserDefaultName)
+    let doomedID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: dataZoneID)
+    let redelivered = CKRecord(recordType: CategoryRow.recordType, recordID: doomedID)
+
+    coordinator.armRecoveryShield()
+
+    // ORDERING A — refetch BEFORE replay. The shield snapshot is built from the
+    // journal at recovery start, independent of replay, so the re-delivered
+    // record is suppressed even though no `.deleteRecord` has been enqueued yet.
+    let shieldBeforeReplay = await coordinator.activeRecoveryShield()
+    #expect(
+      SyncCoordinator.partitionShieldedSaves([redelivered], shield: shieldBeforeReplay)
+        .toApply.isEmpty)
+
+    // Now replay enqueues the deletion.
+    let store = InMemoryPendingChangeStore()
+    await coordinator.replayDeletionJournal(into: store)
+
+    // ORDERING B — refetch AFTER replay. Still suppressed (the shield holds for
+    // the whole recovery session until the deletion is confirmed).
+    let shieldAfterReplay = await coordinator.activeRecoveryShield()
+    #expect(
+      SyncCoordinator.partitionShieldedSaves([redelivered], shield: shieldAfterReplay)
+        .toApply.isEmpty)
+
+    // The server-side resurrection is closed separately: replay enqueued the
+    // `.deleteRecord` for the same id, so CloudKit deletes the server copy.
+    #expect(
+      store.pendingRecordZoneChanges.contains { change in
+        if case .deleteRecord(let id) = change { return id == doomedID }
+        return false
+      })
+
+    // Once the deletion is confirmed sent the session settles and the shield
+    // releases — a genuine later peer re-create of that id now applies normally
+    // (the shield is recovery-scoped, not a permanent veto).
+    store.remove(pendingRecordZoneChanges: [.deleteRecord(doomedID)])
+    await coordinator.clearConfirmedReplayedDeletions(against: store)
+    let releasedShield = await coordinator.activeRecoveryShield()
+    #expect(
+      SyncCoordinator.partitionShieldedSaves([redelivered], shield: releasedShield)
+        .toApply.map(\.recordID) == [doomedID])
+  }
 }

--- a/MoolahTests/Sync/BloatStateRecoveryTests.swift
+++ b/MoolahTests/Sync/BloatStateRecoveryTests.swift
@@ -5,32 +5,15 @@ import Testing
 
 @testable import Moolah
 
-/// Tests for safe already-bloated-state recovery (issue #1090 / #12): the
-/// byte-size gate, the re-armable attempt ceiling, and the recovery-scoped
-/// tombstone shield that keeps the token-less post-reset refetch from
-/// resurrecting a deleted-but-un-propagated record.
+/// Safe already-bloated-state recovery (issue #1090 / #12): the byte-size gate,
+/// the re-armable attempt ceiling, and the recovery-scoped tombstone shield that
+/// keeps the token-less post-reset refetch from resurrecting a deleted-but-
+/// un-propagated record. The marker / fail-closed / release-timing cases live in
+/// `BloatRecoveryMarkerTests`.
 @Suite("Bloated-state recovery (#1090 / #12)")
 @MainActor
 struct BloatStateRecoveryTests {
-
-  private static func makeDefaults() throws -> UserDefaults {
-    try #require(UserDefaults(suiteName: "bloat-recovery-test-\(UUID().uuidString)"))
-  }
-
-  private static func makeCoordinator(
-    iCloud: ICloudAvailability = .available,
-    isCloudKitAvailable: Bool = true
-  ) throws -> (coordinator: SyncCoordinator, manager: ProfileContainerManager) {
-    let manager = try ProfileContainerManager.forTesting()
-    let coordinator = SyncCoordinator(
-      containerManager: manager,
-      userDefaults: try makeDefaults(),
-      isCloudKitAvailable: isCloudKitAvailable)
-    coordinator.iCloudAvailability = iCloud
-    return (coordinator, manager)
-  }
-
-  private static let threshold = SyncCoordinator.bloatRecoveryByteThreshold
+  private typealias Support = BloatRecoveryTestSupport
 
   // MARK: - Gate decision (pure)
 
@@ -39,63 +22,68 @@ struct BloatStateRecoveryTests {
   func gateClassifiesBySizeAndPermission() {
     #expect(
       SyncCoordinator.bloatGateOutcome(
-        stateByteCount: Self.threshold + 1, allowRecovery: true, threshold: Self.threshold)
+        stateByteCount: Support.threshold + 1, allowRecovery: true, forceRecovery: false,
+        threshold: Support.threshold)
         == .recovered)
     #expect(
       SyncCoordinator.bloatGateOutcome(
-        stateByteCount: Self.threshold + 1, allowRecovery: false, threshold: Self.threshold)
+        stateByteCount: Support.threshold + 1, allowRecovery: false, forceRecovery: false,
+        threshold: Support.threshold)
         == .bloatedButSkipped)
+    // boundary: == threshold is NOT bloated
     #expect(
       SyncCoordinator.bloatGateOutcome(
-        stateByteCount: Self.threshold, allowRecovery: true, threshold: Self.threshold)
-        == .healthy)  // boundary: == threshold is NOT bloated
+        stateByteCount: Support.threshold, allowRecovery: true, forceRecovery: false,
+        threshold: Support.threshold) == .healthy)
     #expect(
       SyncCoordinator.bloatGateOutcome(
-        stateByteCount: 1024, allowRecovery: true, threshold: Self.threshold) == .healthy)
+        stateByteCount: 1024, allowRecovery: true, forceRecovery: false,
+        threshold: Support.threshold) == .healthy)
     // No state file (first launch) is healthy, never recovered.
     #expect(
       SyncCoordinator.bloatGateOutcome(
-        stateByteCount: nil, allowRecovery: true, threshold: Self.threshold) == .healthy)
+        stateByteCount: nil, allowRecovery: true, forceRecovery: false,
+        threshold: Support.threshold) == .healthy)
   }
 
   // MARK: - Attempt ceiling (re-armable)
 
   @Test("attempt ceiling: recover increments; a healthy launch re-arms; N consecutive stop firing")
   func attemptCeilingIsReArmable() throws {
-    let (coordinator, _) = try Self.makeCoordinator()
+    let (coordinator, _) = try Support.makeCoordinator()
     #expect(coordinator.recoveryAttemptCount == 0)
     #expect(coordinator.isRecoveryAllowed)
 
-    // Recover up to the ceiling.
     for _ in 0..<SyncCoordinator.bloatRecoveryAttemptCeiling {
-      coordinator.applyRecoveryOutcome(.recovered)
+      coordinator.applyRecoveryOutcome(.recovered, wasForced: false)
     }
     #expect(coordinator.recoveryAttemptCount == SyncCoordinator.bloatRecoveryAttemptCeiling)
     // Ceiling reached → no longer allowed → the gate would degrade to skipped.
     #expect(!coordinator.isRecoveryAllowed)
     #expect(
       SyncCoordinator.bloatGateOutcome(
-        stateByteCount: Self.threshold + 1,
+        stateByteCount: Support.threshold + 1,
         allowRecovery: coordinator.isRecoveryAllowed,
-        threshold: Self.threshold) == .bloatedButSkipped)
+        forceRecovery: false,
+        threshold: Support.threshold) == .bloatedButSkipped)
 
     // A healthy launch re-arms the count to 0 → recovery is possible again.
-    coordinator.applyRecoveryOutcome(.healthy)
+    coordinator.applyRecoveryOutcome(.healthy, wasForced: false)
     #expect(coordinator.recoveryAttemptCount == 0)
     #expect(coordinator.isRecoveryAllowed)
   }
 
   @Test("recovery is disallowed when iCloud is known-unavailable or entitlements are missing")
   func recoveryGatedOnAccountAndEntitlements() throws {
-    let (signedOut, _) = try Self.makeCoordinator(iCloud: .unavailable(reason: .notSignedIn))
+    let (signedOut, _) = try Support.makeCoordinator(iCloud: .unavailable(reason: .notSignedIn))
     #expect(!signedOut.isRecoveryAllowed)
 
-    let (noEntitlement, _) = try Self.makeCoordinator(isCloudKitAvailable: false)
+    let (noEntitlement, _) = try Support.makeCoordinator(isCloudKitAvailable: false)
     #expect(!noEntitlement.isRecoveryAllowed)
 
     // `.unknown` (the usual state before the async account probe runs) is NOT
     // treated as known-unavailable — recovery is data-safe regardless.
-    let (unknown, _) = try Self.makeCoordinator(iCloud: .unknown)
+    let (unknown, _) = try Support.makeCoordinator(iCloud: .unknown)
     #expect(unknown.isRecoveryAllowed)
   }
 
@@ -115,7 +103,6 @@ struct BloatStateRecoveryTests {
     #expect(toApply.map(\.recordID) == [freeID])
     #expect(suppressed.map(\.recordID) == [shieldedID])
 
-    // Empty shield → everything applies (the no-recovery fast path).
     let (allApply, none) = SyncCoordinator.partitionShieldedSaves([shielded, free], shield: [])
     #expect(allApply.count == 2)
     #expect(none.isEmpty)
@@ -125,46 +112,29 @@ struct BloatStateRecoveryTests {
 
   @Test("arming the shield snapshots the journal union; the apply path awaits it race-free")
   func armingShieldSnapshotsJournalUnion() async throws {
-    let (coordinator, manager) = try Self.makeCoordinator()
-    let profileId = UUID()
-    try await manager.profileIndexRepository.upsert(
-      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
-    let database = try manager.database(for: profileId)
-    let categories = GRDBCategoryRepository(database: database)
-
-    // A locally-deleted record whose `.deleteRecord` never propagated → its
-    // tombstone is journaled.
-    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
-    try await categories.delete(id: doomed.id, withReplacement: nil)
+    let fixture = try await Support.makeShieldFixture()
+    let coordinator = fixture.coordinator
 
     coordinator.armRecoveryShield()
     #expect(coordinator.isRecoveryShieldActive)
-    // `activeRecoveryShield()` awaits the snapshot build, so even a fetch racing
-    // the arm sees the full set (race-free, both refetch/replay orderings).
     let shield = await coordinator.activeRecoveryShield()
-
-    let dataZoneID = CKRecordZone.ID(
-      zoneName: DeletionJournal.dataZoneName(for: profileId),
-      ownerName: CKCurrentUserDefaultName)
-    let doomedID = CKRecord.ID(
-      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: dataZoneID)
-    #expect(shield.contains(doomedID))
+    #expect(shield.contains(fixture.doomedID))
 
     // A re-delivered save for the deleted record is suppressed (NOT resurrected);
     // an unrelated incoming record is applied (the shield is scoped).
-    let doomedRecord = CKRecord(recordType: CategoryRow.recordType, recordID: doomedID)
+    let doomedRecord = CKRecord(recordType: CategoryRow.recordType, recordID: fixture.doomedID)
     let peerID = CKRecord.ID(
-      recordType: CategoryRow.recordType, uuid: UUID(), zoneID: dataZoneID)
+      recordType: CategoryRow.recordType, uuid: UUID(), zoneID: fixture.doomedID.zoneID)
     let peerRecord = CKRecord(recordType: CategoryRow.recordType, recordID: peerID)
     let (toApply, suppressed) = SyncCoordinator.partitionShieldedSaves(
       [doomedRecord, peerRecord], shield: shield)
-    #expect(suppressed.map(\.recordID) == [doomedID])
+    #expect(suppressed.map(\.recordID) == [fixture.doomedID])
     #expect(toApply.map(\.recordID) == [peerID])
   }
 
   @Test("an empty journal arms no shield (nothing to suppress)")
   func emptyJournalArmsNoShield() async throws {
-    let (coordinator, manager) = try Self.makeCoordinator()
+    let (coordinator, manager) = try Support.makeCoordinator()
     let profileId = UUID()
     try await manager.profileIndexRepository.upsert(
       Profile(id: profileId, label: "Clean", currencyCode: "AUD"))
@@ -176,60 +146,20 @@ struct BloatStateRecoveryTests {
     #expect(!coordinator.isRecoveryShieldActive)  // deactivated — nothing to shield
   }
 
-  // MARK: - Refetch-resurrection closed in BOTH orderings (the CRITICAL hazard)
-
-  /// A coordinator + a profile with one locally-deleted-but-un-propagated
-  /// category whose tombstone is journaled, plus the resolved `CKRecord.ID`.
-  private struct ShieldFixture {
-    let coordinator: SyncCoordinator
-    let doomedID: CKRecord.ID
-  }
-
-  private static func makeShieldFixture() async throws -> ShieldFixture {
-    let (coordinator, manager) = try makeCoordinator()
-    let profileId = UUID()
-    try await manager.profileIndexRepository.upsert(
-      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
-    let categories = GRDBCategoryRepository(database: try manager.database(for: profileId))
-    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
-    try await categories.delete(id: doomed.id, withReplacement: nil)
-    let doomedID = CKRecord.ID(
-      recordType: CategoryRow.recordType,
-      uuid: doomed.id,
-      zoneID: CKRecordZone.ID(
-        zoneName: DeletionJournal.dataZoneName(for: profileId),
-        ownerName: CKCurrentUserDefaultName))
-    return ShieldFixture(coordinator: coordinator, doomedID: doomedID)
-  }
-
-  /// Drives a complete fetch session (begin → end) so the forced post-recovery
-  /// refetch is considered "settled".
-  private static func settleFetchSession(_ coordinator: SyncCoordinator) {
-    coordinator.beginFetchingChanges()
-    coordinator.endFetchingChanges()
-  }
-
-  private static func suppresses(
-    _ id: CKRecord.ID, _ coordinator: SyncCoordinator
-  ) async -> Bool {
-    let record = CKRecord(recordType: CategoryRow.recordType, recordID: id)
-    return await coordinator.recoveryShieldedSaves([record]).toApply.isEmpty
-  }
+  // MARK: - Refetch-resurrection closed in BOTH orderings (pre-settle)
 
   @Test(
     "the deleted record is suppressed whether the refetch arrives before OR after replay (pre-settle, both orderings)"
   )
   func refetchSuppressedInEitherOrderingBeforeSettle() async throws {
-    let fixture = try await Self.makeShieldFixture()
+    let fixture = try await Support.makeShieldFixture()
     let coordinator = fixture.coordinator
     coordinator.armRecoveryShield()
 
-    // ORDERING A — refetch BEFORE replay. The shield snapshot is built from the
-    // journal at recovery start, independent of replay, so the re-delivered
-    // record is suppressed even though no `.deleteRecord` is enqueued yet.
-    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+    // ORDERING A — refetch BEFORE replay. The snapshot is built from the journal
+    // at recovery start, independent of replay, so it's suppressed already.
+    #expect(await Support.suppresses(fixture.doomedID, coordinator))
 
-    // Replay enqueues the deletion (closes the server side).
     let store = InMemoryPendingChangeStore()
     await coordinator.replayDeletionJournal(into: store)
     #expect(
@@ -239,7 +169,7 @@ struct BloatStateRecoveryTests {
       })
 
     // ORDERING B — refetch AFTER replay. Still suppressed.
-    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+    #expect(await Support.suppresses(fixture.doomedID, coordinator))
   }
 
   // MARK: - Shield must OUTLIVE the forced refetch (the Critical regression lock)
@@ -248,7 +178,7 @@ struct BloatStateRecoveryTests {
     "the shield holds after delete-confirm until the post-recovery refetch settles, THEN a peer re-create applies"
   )
   func shieldOutlivesDeleteConfirmUntilRefetchSettles() async throws {
-    let fixture = try await Self.makeShieldFixture()
+    let fixture = try await Support.makeShieldFixture()
     let coordinator = fixture.coordinator
     coordinator.armRecoveryShield()
 
@@ -257,24 +187,22 @@ struct BloatStateRecoveryTests {
 
     // The `.deleteRecord` is confirmed sent — under the OLD (broken) rule the
     // shield would release here. But the forced full refetch may still be
-    // draining, so it MUST stay armed: a still-in-flight re-delivery of the same
-    // id would otherwise be resurrected with no tombstone left.
+    // draining, so it MUST stay armed.
     store.remove(pendingRecordZoneChanges: [.deleteRecord(fixture.doomedID)])
     await coordinator.clearConfirmedReplayedDeletions(against: store)
     #expect(coordinator.isRecoveryShieldActive)
-    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+    #expect(await Support.suppresses(fixture.doomedID, coordinator))
 
-    // Only once a full fetch session has completed does the shield release —
-    // now the server no longer holds the record, so a genuine later peer
-    // re-create of that id applies normally (recovery-scoped, not a veto).
-    Self.settleFetchSession(coordinator)
+    // Only once a full fetch session completes does the shield release — now a
+    // genuine later peer re-create of that id applies normally.
+    Support.settleFetchSession(coordinator)
     #expect(!coordinator.isRecoveryShieldActive)
-    #expect(!(await Self.suppresses(fixture.doomedID, coordinator)))
+    #expect(!(await Support.suppresses(fixture.doomedID, coordinator)))
   }
 
   @Test("the shield also releases when the refetch settles before the delete is confirmed")
   func shieldReleasesWhenRefetchSettlesThenDeleteConfirms() async throws {
-    let fixture = try await Self.makeShieldFixture()
+    let fixture = try await Support.makeShieldFixture()
     let coordinator = fixture.coordinator
     coordinator.armRecoveryShield()
 
@@ -283,33 +211,13 @@ struct BloatStateRecoveryTests {
 
     // Refetch settles FIRST — but the deletion isn't confirmed yet, so the
     // shield must stay armed (the record is still on the server).
-    Self.settleFetchSession(coordinator)
+    Support.settleFetchSession(coordinator)
     #expect(coordinator.isRecoveryShieldActive)
-    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+    #expect(await Support.suppresses(fixture.doomedID, coordinator))
 
-    // Now the delete confirms → both conditions met → released.
     store.remove(pendingRecordZoneChanges: [.deleteRecord(fixture.doomedID)])
     await coordinator.clearConfirmedReplayedDeletions(against: store)
     #expect(!coordinator.isRecoveryShieldActive)
     #expect(coordinator.recoveringDeletions.isEmpty)
-  }
-
-  // MARK: - Fail-closed on a journal-read failure during arming
-
-  @Test("a read-failed shield suppresses ALL fetched saves (fail-closed), not just snapshot ids")
-  func failClosedShieldSuppressesEverything() async throws {
-    let (coordinator, _) = try Self.makeCoordinator()
-    // Simulate the snapshot-build read-failure outcome directly (the apply path
-    // can't enumerate which deletions to protect → it must drop everything).
-    coordinator.isRecoveryShieldActive = true
-    coordinator.recoveryShieldSuppressAll = true
-
-    let zone = CKRecordZone.ID(zoneName: "profile-x", ownerName: CKCurrentUserDefaultName)
-    let anyRecord = CKRecord(
-      recordType: CategoryRow.recordType,
-      recordID: CKRecord.ID(recordType: CategoryRow.recordType, uuid: UUID(), zoneID: zone))
-    let (toApply, suppressed) = await coordinator.recoveryShieldedSaves([anyRecord])
-    #expect(toApply.isEmpty)
-    #expect(suppressed.count == 1)
   }
 }

--- a/MoolahTests/Sync/BloatStateRecoveryTests.swift
+++ b/MoolahTests/Sync/BloatStateRecoveryTests.swift
@@ -1,0 +1,212 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for safe already-bloated-state recovery (issue #1090 / #12): the
+/// byte-size gate, the re-armable attempt ceiling, and the recovery-scoped
+/// tombstone shield that keeps the token-less post-reset refetch from
+/// resurrecting a deleted-but-un-propagated record.
+@Suite("Bloated-state recovery (#1090 / #12)")
+@MainActor
+struct BloatStateRecoveryTests {
+
+  private static func makeDefaults() throws -> UserDefaults {
+    try #require(UserDefaults(suiteName: "bloat-recovery-test-\(UUID().uuidString)"))
+  }
+
+  private static func makeCoordinator(
+    iCloud: ICloudAvailability = .available,
+    isCloudKitAvailable: Bool = true
+  ) throws -> (coordinator: SyncCoordinator, manager: ProfileContainerManager) {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      userDefaults: try makeDefaults(),
+      isCloudKitAvailable: isCloudKitAvailable)
+    coordinator.iCloudAvailability = iCloud
+    return (coordinator, manager)
+  }
+
+  private static let threshold = SyncCoordinator.bloatRecoveryByteThreshold
+
+  // MARK: - Gate decision (pure)
+
+  @Test(
+    "size-gate: oversized + allowed → .recovered; below → .healthy; oversized + !allowed → skipped")
+  func gateClassifiesBySizeAndPermission() {
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: Self.threshold + 1, allowRecovery: true, threshold: Self.threshold)
+        == .recovered)
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: Self.threshold + 1, allowRecovery: false, threshold: Self.threshold)
+        == .bloatedButSkipped)
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: Self.threshold, allowRecovery: true, threshold: Self.threshold)
+        == .healthy)  // boundary: == threshold is NOT bloated
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: 1024, allowRecovery: true, threshold: Self.threshold) == .healthy)
+    // No state file (first launch) is healthy, never recovered.
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: nil, allowRecovery: true, threshold: Self.threshold) == .healthy)
+  }
+
+  // MARK: - Attempt ceiling (re-armable)
+
+  @Test("attempt ceiling: recover increments; a healthy launch re-arms; N consecutive stop firing")
+  func attemptCeilingIsReArmable() throws {
+    let (coordinator, _) = try Self.makeCoordinator()
+    #expect(coordinator.recoveryAttemptCount == 0)
+    #expect(coordinator.isRecoveryAllowed)
+
+    // Recover up to the ceiling.
+    for _ in 0..<SyncCoordinator.bloatRecoveryAttemptCeiling {
+      coordinator.applyRecoveryOutcome(.recovered)
+    }
+    #expect(coordinator.recoveryAttemptCount == SyncCoordinator.bloatRecoveryAttemptCeiling)
+    // Ceiling reached → no longer allowed → the gate would degrade to skipped.
+    #expect(!coordinator.isRecoveryAllowed)
+    #expect(
+      SyncCoordinator.bloatGateOutcome(
+        stateByteCount: Self.threshold + 1,
+        allowRecovery: coordinator.isRecoveryAllowed,
+        threshold: Self.threshold) == .bloatedButSkipped)
+
+    // A healthy launch re-arms the count to 0 → recovery is possible again.
+    coordinator.applyRecoveryOutcome(.healthy)
+    #expect(coordinator.recoveryAttemptCount == 0)
+    #expect(coordinator.isRecoveryAllowed)
+  }
+
+  @Test("recovery is disallowed when iCloud is known-unavailable or entitlements are missing")
+  func recoveryGatedOnAccountAndEntitlements() throws {
+    let (signedOut, _) = try Self.makeCoordinator(iCloud: .unavailable(reason: .notSignedIn))
+    #expect(!signedOut.isRecoveryAllowed)
+
+    let (noEntitlement, _) = try Self.makeCoordinator(isCloudKitAvailable: false)
+    #expect(!noEntitlement.isRecoveryAllowed)
+
+    // `.unknown` (the usual state before the async account probe runs) is NOT
+    // treated as known-unavailable — recovery is data-safe regardless.
+    let (unknown, _) = try Self.makeCoordinator(iCloud: .unknown)
+    #expect(unknown.isRecoveryAllowed)
+  }
+
+  // MARK: - Shield filter (pure)
+
+  @Test(
+    "shield partition: a shielded id is suppressed, others apply; empty shield passes all through")
+  func partitionShieldedSaves() {
+    let zone = CKRecordZone.ID(zoneName: "profile-x", ownerName: CKCurrentUserDefaultName)
+    let shieldedID = CKRecord.ID(recordType: CategoryRow.recordType, uuid: UUID(), zoneID: zone)
+    let freeID = CKRecord.ID(recordType: CategoryRow.recordType, uuid: UUID(), zoneID: zone)
+    let shielded = CKRecord(recordType: CategoryRow.recordType, recordID: shieldedID)
+    let free = CKRecord(recordType: CategoryRow.recordType, recordID: freeID)
+
+    let (toApply, suppressed) = SyncCoordinator.partitionShieldedSaves(
+      [shielded, free], shield: [shieldedID])
+    #expect(toApply.map(\.recordID) == [freeID])
+    #expect(suppressed.map(\.recordID) == [shieldedID])
+
+    // Empty shield → everything applies (the no-recovery fast path).
+    let (allApply, none) = SyncCoordinator.partitionShieldedSaves([shielded, free], shield: [])
+    #expect(allApply.count == 2)
+    #expect(none.isEmpty)
+  }
+
+  // MARK: - Shield snapshot (e2e through real journals)
+
+  @Test("arming the shield snapshots the journal union; the apply path awaits it race-free")
+  func armingShieldSnapshotsJournalUnion() async throws {
+    let (coordinator, manager) = try Self.makeCoordinator()
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
+    let database = try manager.database(for: profileId)
+    let categories = GRDBCategoryRepository(database: database)
+
+    // A locally-deleted record whose `.deleteRecord` never propagated → its
+    // tombstone is journaled.
+    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
+    try await categories.delete(id: doomed.id, withReplacement: nil)
+
+    coordinator.armRecoveryShield()
+    #expect(coordinator.isRecoveryShieldActive)
+    // `activeRecoveryShield()` awaits the snapshot build, so even a fetch racing
+    // the arm sees the full set (race-free, both refetch/replay orderings).
+    let shield = await coordinator.activeRecoveryShield()
+
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: DeletionJournal.dataZoneName(for: profileId),
+      ownerName: CKCurrentUserDefaultName)
+    let doomedID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: dataZoneID)
+    #expect(shield.contains(doomedID))
+
+    // A re-delivered save for the deleted record is suppressed (NOT resurrected);
+    // an unrelated incoming record is applied (the shield is scoped).
+    let doomedRecord = CKRecord(recordType: CategoryRow.recordType, recordID: doomedID)
+    let peerID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: UUID(), zoneID: dataZoneID)
+    let peerRecord = CKRecord(recordType: CategoryRow.recordType, recordID: peerID)
+    let (toApply, suppressed) = SyncCoordinator.partitionShieldedSaves(
+      [doomedRecord, peerRecord], shield: shield)
+    #expect(suppressed.map(\.recordID) == [doomedID])
+    #expect(toApply.map(\.recordID) == [peerID])
+  }
+
+  @Test("an empty journal arms no shield (nothing to suppress)")
+  func emptyJournalArmsNoShield() async throws {
+    let (coordinator, manager) = try Self.makeCoordinator()
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(id: profileId, label: "Clean", currencyCode: "AUD"))
+    _ = try manager.database(for: profileId)
+
+    coordinator.armRecoveryShield()
+    let shield = await coordinator.activeRecoveryShield()
+    #expect(shield.isEmpty)
+    #expect(!coordinator.isRecoveryShieldActive)  // deactivated — nothing to shield
+  }
+
+  // MARK: - Shield release on settle
+
+  @Test("the shield releases once every recovered deletion is confirmed sent")
+  func shieldReleasesWhenRecoverySettles() async throws {
+    let (coordinator, manager) = try Self.makeCoordinator()
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
+    let database = try manager.database(for: profileId)
+    let categories = GRDBCategoryRepository(database: database)
+    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
+    try await categories.delete(id: doomed.id, withReplacement: nil)
+
+    coordinator.armRecoveryShield()
+    _ = await coordinator.activeRecoveryShield()
+    #expect(coordinator.isRecoveryShieldActive)
+
+    // Replay enqueues the deletion; once it is confirmed sent, clear-on-confirm
+    // empties `replayedDeletionsInFlight` and the shield releases.
+    let store = InMemoryPendingChangeStore()
+    await coordinator.replayDeletionJournal(into: store)
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: DeletionJournal.dataZoneName(for: profileId),
+      ownerName: CKCurrentUserDefaultName)
+    let doomedID = CKRecord.ID(
+      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: dataZoneID)
+    store.remove(pendingRecordZoneChanges: [.deleteRecord(doomedID)])
+    await coordinator.clearConfirmedReplayedDeletions(against: store)
+
+    #expect(!coordinator.isRecoveryShieldActive)
+    #expect(coordinator.recoveringDeletions.isEmpty)
+    #expect(await coordinator.activeRecoveryShield().isEmpty)
+  }
+}

--- a/MoolahTests/Sync/BloatStateRecoveryTests.swift
+++ b/MoolahTests/Sync/BloatStateRecoveryTests.swift
@@ -176,99 +176,140 @@ struct BloatStateRecoveryTests {
     #expect(!coordinator.isRecoveryShieldActive)  // deactivated — nothing to shield
   }
 
-  // MARK: - Shield release on settle
-
-  @Test("the shield releases once every recovered deletion is confirmed sent")
-  func shieldReleasesWhenRecoverySettles() async throws {
-    let (coordinator, manager) = try Self.makeCoordinator()
-    let profileId = UUID()
-    try await manager.profileIndexRepository.upsert(
-      Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
-    let database = try manager.database(for: profileId)
-    let categories = GRDBCategoryRepository(database: database)
-    let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
-    try await categories.delete(id: doomed.id, withReplacement: nil)
-
-    coordinator.armRecoveryShield()
-    _ = await coordinator.activeRecoveryShield()
-    #expect(coordinator.isRecoveryShieldActive)
-
-    // Replay enqueues the deletion; once it is confirmed sent, clear-on-confirm
-    // empties `replayedDeletionsInFlight` and the shield releases.
-    let store = InMemoryPendingChangeStore()
-    await coordinator.replayDeletionJournal(into: store)
-    let dataZoneID = CKRecordZone.ID(
-      zoneName: DeletionJournal.dataZoneName(for: profileId),
-      ownerName: CKCurrentUserDefaultName)
-    let doomedID = CKRecord.ID(
-      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: dataZoneID)
-    store.remove(pendingRecordZoneChanges: [.deleteRecord(doomedID)])
-    await coordinator.clearConfirmedReplayedDeletions(against: store)
-
-    #expect(!coordinator.isRecoveryShieldActive)
-    #expect(coordinator.recoveringDeletions.isEmpty)
-    #expect(await coordinator.activeRecoveryShield().isEmpty)
-  }
-
   // MARK: - Refetch-resurrection closed in BOTH orderings (the CRITICAL hazard)
 
-  @Test(
-    "the deleted record is suppressed whether the refetch arrives before OR after replay; after the deletion settles a peer re-create applies again"
-  )
-  func refetchDoesNotResurrectInEitherOrdering() async throws {
-    let (coordinator, manager) = try Self.makeCoordinator()
+  /// A coordinator + a profile with one locally-deleted-but-un-propagated
+  /// category whose tombstone is journaled, plus the resolved `CKRecord.ID`.
+  private struct ShieldFixture {
+    let coordinator: SyncCoordinator
+    let doomedID: CKRecord.ID
+  }
+
+  private static func makeShieldFixture() async throws -> ShieldFixture {
+    let (coordinator, manager) = try makeCoordinator()
     let profileId = UUID()
     try await manager.profileIndexRepository.upsert(
       Profile(id: profileId, label: "Recover", currencyCode: "AUD"))
-    let database = try manager.database(for: profileId)
-    let categories = GRDBCategoryRepository(database: database)
+    let categories = GRDBCategoryRepository(database: try manager.database(for: profileId))
     let doomed = try await categories.create(Moolah.Category(name: "Doomed"))
     try await categories.delete(id: doomed.id, withReplacement: nil)
-
-    let dataZoneID = CKRecordZone.ID(
-      zoneName: DeletionJournal.dataZoneName(for: profileId),
-      ownerName: CKCurrentUserDefaultName)
     let doomedID = CKRecord.ID(
-      recordType: CategoryRow.recordType, uuid: doomed.id, zoneID: dataZoneID)
-    let redelivered = CKRecord(recordType: CategoryRow.recordType, recordID: doomedID)
+      recordType: CategoryRow.recordType,
+      uuid: doomed.id,
+      zoneID: CKRecordZone.ID(
+        zoneName: DeletionJournal.dataZoneName(for: profileId),
+        ownerName: CKCurrentUserDefaultName))
+    return ShieldFixture(coordinator: coordinator, doomedID: doomedID)
+  }
 
+  /// Drives a complete fetch session (begin → end) so the forced post-recovery
+  /// refetch is considered "settled".
+  private static func settleFetchSession(_ coordinator: SyncCoordinator) {
+    coordinator.beginFetchingChanges()
+    coordinator.endFetchingChanges()
+  }
+
+  private static func suppresses(
+    _ id: CKRecord.ID, _ coordinator: SyncCoordinator
+  ) async -> Bool {
+    let record = CKRecord(recordType: CategoryRow.recordType, recordID: id)
+    return await coordinator.recoveryShieldedSaves([record]).toApply.isEmpty
+  }
+
+  @Test(
+    "the deleted record is suppressed whether the refetch arrives before OR after replay (pre-settle, both orderings)"
+  )
+  func refetchSuppressedInEitherOrderingBeforeSettle() async throws {
+    let fixture = try await Self.makeShieldFixture()
+    let coordinator = fixture.coordinator
     coordinator.armRecoveryShield()
 
     // ORDERING A — refetch BEFORE replay. The shield snapshot is built from the
     // journal at recovery start, independent of replay, so the re-delivered
-    // record is suppressed even though no `.deleteRecord` has been enqueued yet.
-    let shieldBeforeReplay = await coordinator.activeRecoveryShield()
-    #expect(
-      SyncCoordinator.partitionShieldedSaves([redelivered], shield: shieldBeforeReplay)
-        .toApply.isEmpty)
+    // record is suppressed even though no `.deleteRecord` is enqueued yet.
+    #expect(await Self.suppresses(fixture.doomedID, coordinator))
 
-    // Now replay enqueues the deletion.
+    // Replay enqueues the deletion (closes the server side).
     let store = InMemoryPendingChangeStore()
     await coordinator.replayDeletionJournal(into: store)
-
-    // ORDERING B — refetch AFTER replay. Still suppressed (the shield holds for
-    // the whole recovery session until the deletion is confirmed).
-    let shieldAfterReplay = await coordinator.activeRecoveryShield()
-    #expect(
-      SyncCoordinator.partitionShieldedSaves([redelivered], shield: shieldAfterReplay)
-        .toApply.isEmpty)
-
-    // The server-side resurrection is closed separately: replay enqueued the
-    // `.deleteRecord` for the same id, so CloudKit deletes the server copy.
     #expect(
       store.pendingRecordZoneChanges.contains { change in
-        if case .deleteRecord(let id) = change { return id == doomedID }
+        if case .deleteRecord(let id) = change { return id == fixture.doomedID }
         return false
       })
 
-    // Once the deletion is confirmed sent the session settles and the shield
-    // releases — a genuine later peer re-create of that id now applies normally
-    // (the shield is recovery-scoped, not a permanent veto).
-    store.remove(pendingRecordZoneChanges: [.deleteRecord(doomedID)])
+    // ORDERING B — refetch AFTER replay. Still suppressed.
+    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+  }
+
+  // MARK: - Shield must OUTLIVE the forced refetch (the Critical regression lock)
+
+  @Test(
+    "the shield holds after delete-confirm until the post-recovery refetch settles, THEN a peer re-create applies"
+  )
+  func shieldOutlivesDeleteConfirmUntilRefetchSettles() async throws {
+    let fixture = try await Self.makeShieldFixture()
+    let coordinator = fixture.coordinator
+    coordinator.armRecoveryShield()
+
+    let store = InMemoryPendingChangeStore()
+    await coordinator.replayDeletionJournal(into: store)
+
+    // The `.deleteRecord` is confirmed sent — under the OLD (broken) rule the
+    // shield would release here. But the forced full refetch may still be
+    // draining, so it MUST stay armed: a still-in-flight re-delivery of the same
+    // id would otherwise be resurrected with no tombstone left.
+    store.remove(pendingRecordZoneChanges: [.deleteRecord(fixture.doomedID)])
     await coordinator.clearConfirmedReplayedDeletions(against: store)
-    let releasedShield = await coordinator.activeRecoveryShield()
-    #expect(
-      SyncCoordinator.partitionShieldedSaves([redelivered], shield: releasedShield)
-        .toApply.map(\.recordID) == [doomedID])
+    #expect(coordinator.isRecoveryShieldActive)
+    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+
+    // Only once a full fetch session has completed does the shield release —
+    // now the server no longer holds the record, so a genuine later peer
+    // re-create of that id applies normally (recovery-scoped, not a veto).
+    Self.settleFetchSession(coordinator)
+    #expect(!coordinator.isRecoveryShieldActive)
+    #expect(!(await Self.suppresses(fixture.doomedID, coordinator)))
+  }
+
+  @Test("the shield also releases when the refetch settles before the delete is confirmed")
+  func shieldReleasesWhenRefetchSettlesThenDeleteConfirms() async throws {
+    let fixture = try await Self.makeShieldFixture()
+    let coordinator = fixture.coordinator
+    coordinator.armRecoveryShield()
+
+    let store = InMemoryPendingChangeStore()
+    await coordinator.replayDeletionJournal(into: store)
+
+    // Refetch settles FIRST — but the deletion isn't confirmed yet, so the
+    // shield must stay armed (the record is still on the server).
+    Self.settleFetchSession(coordinator)
+    #expect(coordinator.isRecoveryShieldActive)
+    #expect(await Self.suppresses(fixture.doomedID, coordinator))
+
+    // Now the delete confirms → both conditions met → released.
+    store.remove(pendingRecordZoneChanges: [.deleteRecord(fixture.doomedID)])
+    await coordinator.clearConfirmedReplayedDeletions(against: store)
+    #expect(!coordinator.isRecoveryShieldActive)
+    #expect(coordinator.recoveringDeletions.isEmpty)
+  }
+
+  // MARK: - Fail-closed on a journal-read failure during arming
+
+  @Test("a read-failed shield suppresses ALL fetched saves (fail-closed), not just snapshot ids")
+  func failClosedShieldSuppressesEverything() async throws {
+    let (coordinator, _) = try Self.makeCoordinator()
+    // Simulate the snapshot-build read-failure outcome directly (the apply path
+    // can't enumerate which deletions to protect → it must drop everything).
+    coordinator.isRecoveryShieldActive = true
+    coordinator.recoveryShieldSuppressAll = true
+
+    let zone = CKRecordZone.ID(zoneName: "profile-x", ownerName: CKCurrentUserDefaultName)
+    let anyRecord = CKRecord(
+      recordType: CategoryRow.recordType,
+      recordID: CKRecord.ID(recordType: CategoryRow.recordType, uuid: UUID(), zoneID: zone))
+    let (toApply, suppressed) = await coordinator.recoveryShieldedSaves([anyRecord])
+    #expect(toApply.isEmpty)
+    #expect(suppressed.count == 1)
   }
 }

--- a/plans/1090-bloated-state-recovery-plan.md
+++ b/plans/1090-bloated-state-recovery-plan.md
@@ -1,0 +1,91 @@
+# Safe bloated-state recovery (self-heal) — #1090 Design 2 / #12
+
+Builds on the merged #1090 deletion journal + replay (PR-B). Size-gates a
+pathological CKSyncEngine state that would stall `CKSyncEngine.init`, rebuilds
+the engine with `nil` state (instant init) → the install self-heals on launch
+with no manual `syncstate` deletion. Made delete-safe by the journal replay +
+a **recovery-scoped tombstone shield**; save-complete via the
+`isFirstLaunch=true` → `queueAllExistingRecordsForAllZones` path.
+
+**Rollout decision (user):** ship ENABLED with `BLOAT_BYTES = 24 MB`, plus
+always-on `Data.count` logging.
+
+## Mechanism
+
+1. **Size-gate (`prepareEngine`).** `start()` computes `allowRecovery` on the
+   MainActor (entitlements present, account not known-unavailable, attempt count
+   < ceiling) and passes it + the threshold into `prepareEngine`. `prepareEngine`
+   always logs `Data.count`; if `allowRecovery && count > BLOAT_BYTES` it builds
+   the engine with `stateSerialization: nil` and returns
+   `recoveryOutcome = .recovered` + `isFirstLaunch = true`. Below threshold →
+   `.healthy`; above but skipped (ceiling/account) → `.bloatedButSkipped`
+   (state passed through; off-main init absorbs the stall; loud warning).
+
+2. **Attempt ceiling + re-arm.** `recoveryAttemptCount` in UserDefaults
+   (pattern: `backfillScanCompleteKeyPrefix`). `completeStart`: `.recovered` →
+   increment; `.healthy` → reset to 0 (re-armable months later); CEILING = 3.
+
+3. **Save-completeness (closes C-1).** `.recovered` ⇒ `isFirstLaunch = true` ⇒
+   `runZoneSetup` runs `queueAllExistingRecordsForAllZones` (→
+   `collectGRDBRecordIDs(.all)`, every row incl. `needs_push=1` edited-after-sync).
+   NOT the `IS NULL` backfill.
+
+4. **Delete-safety (closes C-2, normal).** The merged journal replay re-issues
+   every unconfirmed deletion on the post-reset start.
+
+5. **Recovery-scoped tombstone shield (closes C-2 under the token-less refetch).**
+   On `.recovered`, `completeStart` spawns `recoverySnapshotTask` (set BEFORE the
+   engine is installed) that reads every journal (index + each profile DB),
+   resolves the union of tombstone `CKRecord.ID`s into `recoveringDeletions`. The
+   fetched-change apply path, while the shield is active, **awaits that task**
+   (race-free) and, for any incoming saved record whose id ∈ `recoveringDeletions`,
+   **skips the upsert AND the D1-b journal clear** — so the replayed
+   `.deleteRecord` wins on both local row and server, and a deleted-but-
+   un-propagated record re-delivered by the full refetch is not resurrected. Each
+   id is released from the shield as its `.deleteRecord` is confirmed
+   (clear-on-confirm); the shield deactivates when the set empties. Scoped: a peer
+   re-create of an id NOT in the snapshot upserts + clears normally.
+
+6. **Recovery never wipes the journal.** Recovery resets ONLY engine state
+   (`nil`); it never calls `deleteLocalData`/`clearAll` (those are sign-out /
+   account-switch / zone-purge teardown). Provable by construction.
+
+## Files
+
+- `SyncCoordinator.swift` — state: `recoveringDeletions: Set<CKRecord.ID>`,
+  `recoverySnapshotTask`, `isRecoveryShieldActive`; recovery-count key.
+- `SyncCoordinator+BloatRecovery.swift` (NEW) — `BLOAT_BYTES`, `CEILING`, pure
+  `bloatGateOutcome(...)`, attempt-count helpers, `buildRecoveryDeletionSnapshot`,
+  shield accessors + release, pure `shieldedSaves(_:shield:)`.
+- `SyncCoordinator+Lifecycle.swift` — `start()` gate inputs; `prepareEngine`
+  (params + size log + outcome); `completeStart` outcome handling + arm shield;
+  `runZoneSetup` unchanged (isFirstLaunch already drives save-complete).
+- `SyncCoordinator+DeletionReplay.swift` — extract `resolveAllJournalDeletions`
+  (shared by replay + snapshot); release shield ids in `clearConfirmedReplayedDeletions`.
+- `SyncCoordinator+RecordChanges.swift` — apply-path filter (data + index) via the
+  shield, race-free await.
+- `PreparedEngine` — add `recoveryOutcome`.
+
+## Tests (Design 2) — TDD, red-first
+
+1. **Size-gate** (pure): oversized count + allow → `.recovered`; below → `.healthy`;
+   above + !allow → `.bloatedButSkipped`.
+2. **Attempt-ceiling**: recover→increment; healthy→reset 0; N≥CEILING consecutive
+   above-threshold → `.bloatedButSkipped` (stops firing); re-armable after healthy.
+3. **Save-complete reset (C-1)**: edited-after-sync (`needs_push=1`, blob≠NULL) +
+   never-synced row → recovery → BOTH re-queued.
+4. **Delete-safe reset (C-2)**: journaled deletion replayed; no resurrection.
+5. **Refetch-resurrection CRITICAL (both orderings)**: deleted-but-un-propagated X
+   re-delivered by refetch, refetch-before-replay AND replay-before-refetch →
+   X NOT resurrected locally or server-side, tombstone not prematurely cleared.
+6. **Shield is scoped**: peer re-create of id NOT in snapshot → upserts + clears.
+7. **Shield filter** (pure `shieldedSaves`): partitions saved records by the set.
+8. **End-to-end self-heal**: wedged fixture → recovered → queue drains.
+
+## Open items for the adversary
+
+- BLOAT_BYTES = 24 MB calibration (false-positive = one-time refetch, data-safe).
+- Shield lifetime = until each tombstone's `.deleteRecord` is confirmed (per-id
+  release); apply path awaits the snapshot task (race-free vs the auto-fetch).
+- Account gate at `prepareEngine` time uses entitlements + not-known-unavailable
+  (the async account probe hasn't run yet); recovery is data-safe regardless.


### PR DESCRIPTION
## What

Issue #1090 / #12 — restores the size-gated CKSyncEngine-state reset, now made **data-safe** by the merged #1090 deletion journal + replay. A persisted state so large it would stall `CKSyncEngine.init` is detected by a byte-size gate and the engine is rebuilt with `nil` state (instant init) → **the install self-heals on launch with no manual `syncstate` deletion**.

Rollout (per maintainer): shipped **enabled** with `BLOAT_BYTES = 24 MB`, plus always-on `Data.count` logging for calibration.

## Mechanism

1. **Size gate (`prepareEngine`).** Always logs the persisted-state byte size. `start()` computes recovery eligibility on the MainActor (entitlements present, iCloud not *known*-unavailable, attempt ceiling not reached) and passes it into the off-main `prepareEngine`, which owns the byte measurement. `Data.count > 24 MB && allowed` → rebuild with `nil` state + `isFirstLaunch = true` (`.recovered`); below threshold → `.healthy`; above but disallowed → `.bloatedButSkipped` (existing state passed through; the off-main init absorbs the stall; loud warning).
2. **Re-armable attempt ceiling.** A recovery increments a UserDefaults counter; any **healthy** launch resets it to 0 (CEILING = 3), so a legitimately re-bloated install months later can self-heal again rather than being permanently capped.
3. **Save-completeness — closes adversary C-1.** `.recovered` ⇒ `isFirstLaunch = true` ⇒ `queueAllExistingRecordsForAllZones` (→ `collectGRDBRecordIDs(.all)`, **every** local row incl. `needs_push=1` edited-after-sync). NOT the `IS NULL` backfill.
4. **Delete-safety (normal) — closes C-2.** The merged journal replay re-issues every unconfirmed deletion on the post-reset start.
5. **Delete-safety under the token-less refetch — closes C-2's CRITICAL recovery-only hazard.** The **recovery-scoped tombstone shield**: `completeStart` arms it (a snapshot of the union of every journal deletion id, resolved to `CKRecord.ID`) **before** installing the engine. The fetched-change apply path **awaits the snapshot build** (race-free vs the engine's automatic post-init fetch) and, for any incoming saved record whose id is in the snapshot, **skips the upsert AND the per-repo journal clear** — so the replayed `.deleteRecord` wins on both the local row and the server copy, and a deleted-but-un-propagated record re-delivered by the full refetch is not resurrected. Scoped: a peer re-create of an id **not** in the snapshot upserts normally. Released once every recovered deletion is confirmed sent.
6. **Recovery never wipes the journal.** Recovery resets ONLY the engine state; it never calls `deleteLocalData`/`clearAll` (those are sign-out / account-switch / zone-purge teardown). Provable by construction.

## Tests (TDD)

`BloatStateRecoveryTests.swift` — the **gate decision** and **shield partition** (the two safety-critical pure functions) were verified **red-first** (stubbing them fails the gate, ceiling, and both shield-suppression tests). Coverage:
- Size-gate boundary (`== threshold` is healthy, `+1` is recovered; `nil` byteCount healthy; skipped path).
- Re-armable ceiling (recover→increment, healthy→reset 0, N consecutive→`.bloatedButSkipped`).
- Account/entitlement gating (known-unavailable / no-entitlements disallowed; `.unknown` allowed).
- Shield snapshot through **real GRDB journals**: the deleted id is in the shield and is suppressed; an unrelated peer record applies (scoped).
- Race-free await; empty-journal no-op; shield release on settle.

## Verification

- Full macOS suite **green**; `format-check` clean; build is warning-free (`SWIFT_TREAT_WARNINGS_AS_ERRORS`).
- `code-review` + `concurrency-review` run; **all findings applied** — shield re-checks `isRecoveryShieldActive` after the snapshot await (Critical C-1), `Task.isCancelled` guard in the snapshot build, cancel-previous-task on re-arm, do/catch logging for state read/decode failures, shared off-actor logger, removed PR-archaeology comment.

## For the adversary's data-loss review

- **Shield lifetime** = until every recovered deletion is confirmed (whole-session, not per-id) — matches the design's "duration of the recovery window" semantics; the narrow "local-delete-wins for a same-id peer re-create during the recovery window" trade-off is intentional and documented.
- **Account gate at `prepareEngine` time** uses entitlements + not-known-unavailable (the async account probe hasn't run yet); recovery is data-safe regardless of account state.
- **BLOAT_BYTES = 24 MB** — a false-positive recovery costs only a one-time refetch; the always-on size log feeds future calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
