### PR TITLE
fix(sync): journal shared-instrument deletions for durability (#1097)

### DIFF
--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
@@ -92,4 +92,104 @@ extension GRDBInstrumentRegistryRepository {
     }
     invalidateInstrumentMapCache()
   }
+
+  /// Applies a CKSyncEngine remote-change batch in one transaction: every saved
+  /// row is upserted with the `PricingStatusMerge` CRDT applied (and the
+  /// issue-#1085 stale-echo date gate) and any stale local deletion intent
+  /// cleared (D1-b, issue #1097); every deleted id is removed WITHOUT journaling
+  /// — server-originated deletes are already propagated by CKSyncEngine. If any
+  /// statement throws, the whole batch rolls back so prior on-disk state
+  /// survives byte-equal, per `guides/DATABASE_CODE_GUIDE.md` §5.
+  func applyRemoteChangesSync(saved rows: [InstrumentRow], deleted ids: [String]) throws {
+    try database.write { database in
+      for var row in rows {
+        let existing =
+          try InstrumentRow
+          .filter(InstrumentRow.Columns.id == row.id)
+          .fetchOne(database)
+
+        // Apply the field-level merge rule for `pricingStatus` before
+        // upserting. CKSyncEngine's default "server wins" would let
+        // the daily auto-resolver on one device clobber a `.spam`
+        // classification a user made on another. The rule is
+        // centralised in `PricingStatusMerge.merge` and unit-tested
+        // against the full 3x3 truth table.
+        //
+        // Unrecognised raw values (only possible from a future-version
+        // device sending an enum case this build doesn't compile against,
+        // since legacy records that omit the field decode as `"priced"`
+        // in `InstrumentRow+CloudKit.swift`) decode as `.priced`. That
+        // matches the legacy fallback and keeps the merge defensive
+        // rather than throwing.
+        let mergedStatus = Self.mergedPricingStatus(local: existing, incoming: row)
+
+        // Modification-date gate on identity / provider-mapping fields and
+        // the cached system-fields blob (issue #1085). Instruments have no
+        // `needs_push`; the date gate piggybacks on the `fetchOne` above.
+        // A stale echo (incoming date older-or-equal to the existing row's
+        // cached date) must NOT revert the identity/mapping fields — but
+        // `pricingStatus` is EXEMPT: it always flows through
+        // `PricingStatusMerge` regardless of date, because that merge is a
+        // deliberately recency-independent CRDT (sticky `.spam`) and gating
+        // it wholesale could leave two devices divergent. So a stale echo
+        // writes only the merged `pricingStatus` (and only when it changed,
+        // to skip a no-op write), leaving identity / mapping / blob put.
+        if let existing, Self.isStaleInstrumentEcho(existing: existing, incoming: row) {
+          if mergedStatus != existing.pricingStatus {
+            _ =
+              try InstrumentRow
+              .filter(InstrumentRow.Columns.id == row.id)
+              .updateAll(
+                database, [InstrumentRow.Columns.pricingStatus.set(to: mergedStatus)])
+          }
+          continue
+        }
+
+        row.pricingStatus = mergedStatus
+        try row.upsert(database)
+        // D1-b (issue #1097): a peer re-creating this instrument clears our
+        // stale deletion intent too, so we don't re-delete a record the server
+        // now holds. Apply-path deletions below are NOT journaled —
+        // server-originated deletions are already propagated.
+        try Self.clearDeletionIntent(for: row.id, in: database)
+      }
+      for id in ids {
+        _ = try InstrumentRow.deleteOne(database, key: id)
+      }
+    }
+    // Remote pulls mutate rows just like local writes; the memoised
+    // map must be rebuilt before the next reader (e.g. a price-cache
+    // resolution) observes it.
+    invalidateInstrumentMapCache()
+  }
+
+  /// Resolves the `pricingStatus` raw value to persist for an incoming
+  /// instrument row, applying `PricingStatusMerge` against the existing
+  /// local row's status (issue #1085 keeps this recency-independent, so it
+  /// runs whether or not the date gate rejects the rest of the record).
+  /// With no existing row the incoming status is taken as-is.
+  private static func mergedPricingStatus(
+    local existing: InstrumentRow?, incoming row: InstrumentRow
+  ) -> String {
+    guard let existing else { return row.pricingStatus }
+    let local = TokenPricingStatus(rawValue: existing.pricingStatus) ?? .priced
+    let incoming = TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
+    return PricingStatusMerge.merge(local: local, incoming: incoming).rawValue
+  }
+
+  /// True when `row` is a superseded stale echo relative to `existing` —
+  /// its server `modificationDate` is older-or-equal to the date the local
+  /// row caches (reject-on-tie, design §4). Fail-open: if either date is
+  /// absent (no cached blob, or a dateless incoming record) returns `false`
+  /// so the incoming record applies, matching the gate's behaviour at the
+  /// UUID-keyed sites.
+  private static func isStaleInstrumentEcho(
+    existing: InstrumentRow, incoming row: InstrumentRow
+  ) -> Bool {
+    guard
+      let cached = existing.serverModificationDate,
+      let incoming = row.serverModificationDate
+    else { return false }
+    return incoming <= cached
+  }
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Upsert.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Upsert.swift
@@ -3,12 +3,13 @@
 import Foundation
 import GRDB
 
-// The row-level upsert helpers live here, split out of
-// `GRDBInstrumentRegistryRepository.swift` so that file stays under
+// Row-level upsert helpers for `GRDBInstrumentRegistryRepository`. They
+// live in a sibling extension file so the primary file stays under
 // SwiftLint's `file_length` budget. They are `static` and module-scoped
 // (default `internal`) so the primary type's `register…` methods can call
-// `Self.upsertCrypto` / `Self.upsertStock` across the same-module
-// extension boundary — mirroring the `+SyncHooks` / `+Lookup` split.
+// `Self.upsertCrypto` / `Self.upsertStock`, and `applyRemoteChangesSync`
+// can call `Self.clearDeletionIntent`, across the same-module extension
+// boundary — mirroring the `+SyncHooks` / `+Lookup` split.
 extension GRDBInstrumentRegistryRepository {
   /// Inserts a new crypto row or updates the existing one in-place,
   /// preserving `recordName` and `encodedSystemFields`. Mirrors
@@ -50,6 +51,7 @@ extension GRDBInstrumentRegistryRepository {
       if let status { row.pricingStatus = status.rawValue }
       try row.insert(database)
     }
+    try clearDeletionIntent(for: instrument.id, in: database)
   }
 
   /// Upgrade-only field merge: a nil/empty incoming column must never
@@ -108,5 +110,21 @@ extension GRDBInstrumentRegistryRepository {
       let row = InstrumentRow(domain: instrument)
       try row.insert(database)
     }
+    try clearDeletionIntent(for: instrument.id, in: database)
+  }
+
+  /// Drops any stale durable deletion intent for `id` in the caller's write
+  /// transaction (D1-b, issue #1097), symmetric with `ProfileRow`'s clear in
+  /// `upsert` and `Category`'s in `create`: a delete-then-re-register nets zero
+  /// tombstone, so a start-time replay can never delete the live re-created
+  /// instrument. The intent is keyed by the `profile-index` zone (the bare
+  /// instrument id is its CloudKit recordName). Idempotent. MUST be called from
+  /// inside an existing `database.write { db in … }` closure (it takes the
+  /// `Database` token, so it runs on the GRDB writer's serial queue).
+  static func clearDeletionIntent(for id: String, in database: Database) throws {
+    try DeletionJournal.clear(
+      zoneName: DeletionJournal.profileIndexZoneName,
+      recordName: InstrumentRow.recordName(for: id),
+      in: database)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -95,11 +95,16 @@ final class GRDBInstrumentRegistryRepository:
   // MARK: - Cross-extension internals
   //
   // `attachSyncHooks` and the `fireOnRecord*` helpers live in
-  // `GRDBInstrumentRegistryRepository+SyncHooks.swift`, and the row-level
-  // upsert helpers (`upsertCrypto`, `upsertStock`) live in
-  // `GRDBInstrumentRegistryRepository+Upsert.swift`. They access `hooks`
-  // / are called as `Self.upsert…` via the `internal` visibility implied
-  // by Swift's same-module-extension scope.
+  // `GRDBInstrumentRegistryRepository+SyncHooks.swift`; the row-level
+  // upsert helpers (`upsertCrypto`, `upsertStock`) and the
+  // `clearDeletionIntent(for:in:)` deletion-journal helper live in
+  // `GRDBInstrumentRegistryRepository+Upsert.swift`; and the remote-apply
+  // entry point (`applyRemoteChangesSync`, which calls
+  // `Self.clearDeletionIntent`) lives in
+  // `GRDBInstrumentRegistryRepository+SyncEntryPoints.swift`. They access
+  // `hooks` / are called as `Self.upsert…` / `Self.clearDeletionIntent`
+  // via the `internal` visibility implied by Swift's same-module-extension
+  // scope.
 
   // MARK: - InstrumentRegistryRepository conformance
 
@@ -184,7 +189,26 @@ final class GRDBInstrumentRegistryRepository:
           .fetchOne(database)
       else { return false }
       guard existing.kind != fiatKind else { return false }
-      return try InstrumentRow.deleteOne(database, key: id)
+      let didDelete = try InstrumentRow.deleteOne(database, key: id)
+      if didDelete {
+        // Durable deletion intent (issue #1097) written in the SAME
+        // transaction as the row delete, so an engine-down window or a
+        // sync-state reset can't lose it before the `.deleteRecord`
+        // propagates — otherwise a token-less refetch (zone purge,
+        // encrypted-data reset, or #1090/#12 bloated-state recovery) would
+        // resurrect the instrument. Instruments live in the profile-index DB
+        // and sync in the `profile-index` zone (like `ProfileRow`, NOT the
+        // per-profile `@profile-data` sentinel), so the real index zone name
+        // is stored — the start-time replay then re-enqueues it as a
+        // `.deleteRecord` and the recovery shield snapshots it for free.
+        try DeletionJournal.record(
+          zoneName: DeletionJournal.profileIndexZoneName,
+          recordName: InstrumentRow.recordName(for: id),
+          recordType: InstrumentRow.recordType,
+          at: Date(),
+          in: database)
+      }
+      return didDelete
     }
     guard didDelete else { return }
     invalidateInstrumentMapCache()
@@ -247,99 +271,11 @@ final class GRDBInstrumentRegistryRepository:
 
   // MARK: - Sync entry points (synchronous, GRDB-queue-blocking)
   //
-  // Called from the CKSyncEngine delegate executor on a non-MainActor
-  // context. `DatabaseWriter.write { db in … }` has both async and sync
-  // overloads; the sync form blocks the calling thread until the queue's
-  // serial executor admits the closure. Never call these from
-  // `@MainActor`.
-
-  func applyRemoteChangesSync(saved rows: [InstrumentRow], deleted ids: [String]) throws {
-    try database.write { database in
-      for var row in rows {
-        let existing =
-          try InstrumentRow
-          .filter(InstrumentRow.Columns.id == row.id)
-          .fetchOne(database)
-
-        // Apply the field-level merge rule for `pricingStatus` before
-        // upserting. CKSyncEngine's default "server wins" would let
-        // the daily auto-resolver on one device clobber a `.spam`
-        // classification a user made on another. The rule is
-        // centralised in `PricingStatusMerge.merge` and unit-tested
-        // against the full 3x3 truth table.
-        //
-        // Unrecognised raw values (only possible from a future-version
-        // device sending an enum case this build doesn't compile against,
-        // since legacy records that omit the field decode as `"priced"`
-        // in `InstrumentRow+CloudKit.swift`) decode as `.priced`. That
-        // matches the legacy fallback and keeps the merge defensive
-        // rather than throwing.
-        let mergedStatus = Self.mergedPricingStatus(local: existing, incoming: row)
-
-        // Modification-date gate on identity / provider-mapping fields and
-        // the cached system-fields blob (issue #1085). Instruments have no
-        // `needs_push`; the date gate piggybacks on the `fetchOne` above.
-        // A stale echo (incoming date older-or-equal to the existing row's
-        // cached date) must NOT revert the identity/mapping fields — but
-        // `pricingStatus` is EXEMPT: it always flows through
-        // `PricingStatusMerge` regardless of date, because that merge is a
-        // deliberately recency-independent CRDT (sticky `.spam`) and gating
-        // it wholesale could leave two devices divergent. So a stale echo
-        // writes only the merged `pricingStatus` (and only when it changed,
-        // to skip a no-op write), leaving identity / mapping / blob put.
-        if let existing, Self.isStaleInstrumentEcho(existing: existing, incoming: row) {
-          if mergedStatus != existing.pricingStatus {
-            _ =
-              try InstrumentRow
-              .filter(InstrumentRow.Columns.id == row.id)
-              .updateAll(
-                database, [InstrumentRow.Columns.pricingStatus.set(to: mergedStatus)])
-          }
-          continue
-        }
-
-        row.pricingStatus = mergedStatus
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ = try InstrumentRow.deleteOne(database, key: id)
-      }
-    }
-    // Remote pulls mutate rows just like local writes; the memoised
-    // map must be rebuilt before the next reader (e.g. a price-cache
-    // resolution) observes it.
-    invalidateInstrumentMapCache()
-  }
-
-  /// Resolves the `pricingStatus` raw value to persist for an incoming
-  /// instrument row, applying `PricingStatusMerge` against the existing
-  /// local row's status (issue #1085 keeps this recency-independent, so it
-  /// runs whether or not the date gate rejects the rest of the record).
-  /// With no existing row the incoming status is taken as-is.
-  private static func mergedPricingStatus(
-    local existing: InstrumentRow?, incoming row: InstrumentRow
-  ) -> String {
-    guard let existing else { return row.pricingStatus }
-    let local = TokenPricingStatus(rawValue: existing.pricingStatus) ?? .priced
-    let incoming = TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
-    return PricingStatusMerge.merge(local: local, incoming: incoming).rawValue
-  }
-
-  /// True when `row` is a superseded stale echo relative to `existing` —
-  /// its server `modificationDate` is older-or-equal to the date the local
-  /// row caches (reject-on-tie, design §4). Fail-open: if either date is
-  /// absent (no cached blob, or a dateless incoming record) returns `false`
-  /// so the incoming record applies, matching the gate's behaviour at the
-  /// UUID-keyed sites.
-  private static func isStaleInstrumentEcho(
-    existing: InstrumentRow, incoming row: InstrumentRow
-  ) -> Bool {
-    guard
-      let cached = existing.serverModificationDate,
-      let incoming = row.serverModificationDate
-    else { return false }
-    return incoming <= cached
-  }
+  // `applyRemoteChangesSync` (the CKSyncEngine remote-apply path) and its
+  // `mergedPricingStatus` / `isStaleInstrumentEcho` helpers live in the
+  // sibling `+SyncEntryPoints` extension file, alongside the other
+  // synchronous sync entry points, so this file stays under SwiftLint's
+  // `file_length` budget.
 
   /// Persists a new `pricingStatus` for the row identified by
   /// `registration.instrument.id`, leaving every other column unchanged.

--- a/MoolahTests/Backends/GRDB/InstrumentDeletionJournalTests.swift
+++ b/MoolahTests/Backends/GRDB/InstrumentDeletionJournalTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Durable deletion-journal wiring for the shared instrument registry
+/// (issue #1097). Instruments live in the profile-index DB and sync in the
+/// `profile-index` zone (like `ProfileRow`, NOT the per-profile `@profile-data`
+/// sentinel). A hard delete must record a durable intent in the SAME
+/// transaction as the row delete so an engine-down window / state reset can't
+/// lose it (and a token-less refetch can't resurrect the instrument); a
+/// (re-)register clears that intent (D1-b); a fiat remove is a no-op and never
+/// journals.
+@Suite("Instrument deletion journal (#1097)")
+struct InstrumentDeletionJournalTests {
+
+  private func makeDatabase() throws -> DatabaseQueue {
+    try ProfileIndexDatabase.openInMemory()
+  }
+
+  private func entries(_ database: DatabaseQueue) async throws -> [DeletionJournalRow] {
+    try await database.read { try DeletionJournal.allEntries(in: $0) }
+  }
+
+  // MARK: - Delete journals an index-zone intent
+
+  @Test("removing a crypto instrument journals an index-zone deletion atomically")
+  func cryptoRemoveJournalsIndexZoneDeletion() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    #expect(try await entries(database).isEmpty)
+
+    try await registry.remove(id: eth.id)
+
+    let afterDelete = try await entries(database)
+    #expect(afterDelete.count == 1)
+    let entry = try #require(afterDelete.first)
+    #expect(entry.zoneName == DeletionJournal.profileIndexZoneName)
+    #expect(entry.recordName == InstrumentRow.recordName(for: eth.id))
+    #expect(entry.recordName == eth.id)  // bare id, no recordType| prefix
+    #expect(entry.recordType == InstrumentRow.recordType)
+  }
+
+  @Test("removing a stock instrument journals an index-zone deletion")
+  func stockRemoveJournalsIndexZoneDeletion() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try await registry.registerStock(bhp)
+
+    try await registry.remove(id: bhp.id)
+
+    let entry = try #require(try await entries(database).first)
+    #expect(entry.zoneName == DeletionJournal.profileIndexZoneName)
+    #expect(entry.recordName == bhp.id)
+    #expect(entry.recordType == InstrumentRow.recordType)
+  }
+
+  // MARK: - Clear-on-recreate (D1-b)
+
+  @Test("delete-then-re-register a crypto id nets zero tombstone")
+  func cryptoRecreateClearsTombstone() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    let mapping = CryptoProviderMapping(
+      instrumentId: eth.id, coingeckoId: "ethereum",
+      cryptocompareSymbol: nil, binanceSymbol: nil)
+    try await registry.registerCrypto(eth, mapping: mapping)
+    try await registry.remove(id: eth.id)
+    #expect(try await entries(database).count == 1)
+
+    // Re-register the SAME id (undo / re-discovery) → the register write drops
+    // the stale intent in the same transaction.
+    try await registry.registerCrypto(eth, mapping: mapping)
+    #expect(try await entries(database).isEmpty)
+  }
+
+  @Test("delete-then-re-register a stock id nets zero tombstone")
+  func stockRecreateClearsTombstone() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try await registry.registerStock(bhp)
+    try await registry.remove(id: bhp.id)
+    #expect(try await entries(database).count == 1)
+
+    try await registry.registerStock(bhp)
+    #expect(try await entries(database).isEmpty)
+  }
+
+  @Test("the forcing-status crypto overload also clears a stale tombstone")
+  func cryptoForcingStatusRecreateClearsTombstone() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    let mapping = CryptoProviderMapping(
+      instrumentId: eth.id, coingeckoId: "ethereum",
+      cryptocompareSymbol: nil, binanceSymbol: nil)
+    try await registry.registerCrypto(eth, mapping: mapping)
+    try await registry.remove(id: eth.id)
+    #expect(try await entries(database).count == 1)
+
+    try await registry.registerCrypto(eth, mapping: mapping, forcingStatus: .spam)
+    #expect(try await entries(database).isEmpty)
+  }
+
+  // MARK: - Apply-path (peer save clears a stale intent)
+
+  @Test("a peer save of the same id clears our stale instrument intent (D1-b)")
+  func applyPathSaveClearsStaleIntent() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    try await registry.remove(id: eth.id)
+    #expect(try await entries(database).count == 1)
+
+    let row = InstrumentRow(domain: eth)
+    try registry.applyRemoteChangesSync(saved: [row], deleted: [])
+    #expect(try await entries(database).isEmpty)
+  }
+
+  @Test("a server-originated apply-path delete does not journal")
+  func applyPathDeleteNeverJournals() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    try registry.applyRemoteChangesSync(saved: [], deleted: [eth.id])
+    #expect(try await entries(database).isEmpty)
+  }
+
+  // MARK: - Fiat is never hard-deleted → never journaled
+
+  @Test("removing a fiat id is a no-op and never journals")
+  func fiatRemoveNeverJournals() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+
+    try await registry.remove(id: "AUD")  // ambient fiat — no stored row
+    #expect(try await entries(database).isEmpty)
+
+    try await registry.remove(id: "DOES_NOT_EXIST:FOO")  // unknown id
+    #expect(try await entries(database).isEmpty)
+  }
+
+  // MARK: - Rollback: a failed journal write rolls back the row delete
+
+  @Test("a forced journal-insert failure rolls back the instrument delete atomically")
+  func journalWriteFailureRollsBackDelete() async throws {
+    let database = try makeDatabase()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try await registry.registerStock(bhp)
+
+    // Abort any INSERT into the journal mid-transaction, so the row delete that
+    // precedes it in the same `database.write` must roll back with it — the row
+    // survives, the deletion is not lost half-way. A universal (no-`WHEN`)
+    // trigger suffices: `remove(id:)` is the only journal INSERT in this
+    // in-memory DB, and it avoids interpolating a value into a `sql:` argument
+    // (DATABASE_CODE_GUIDE §4).
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_instrument_journal
+          BEFORE INSERT ON deletion_journal
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    await #expect(throws: (any Error).self) {
+      try await registry.remove(id: bhp.id)
+    }
+
+    // The instrument row survived byte-equal (delete rolled back) and no journal
+    // row landed — no partial write.
+    #expect(try await entries(database).isEmpty)
+    #expect(try registry.fetchRowSync(id: bhp.id) != nil)
+  }
+}

--- a/MoolahTests/Backends/GRDB/ProfileIndexPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileIndexPlanPinningTests.swift
@@ -20,6 +20,10 @@ import Testing
 ///    `GRDBProfileIndexRepository.profile(forID:)` (every session-open)
 ///    and `mergeDataFormatVersionSync` (every sync-merge). Must use the
 ///    table's primary key.
+/// 3. `deletion_journal` ordered by `queued_at` — the start-time
+///    deletion-journal replay sweep (`DeletionJournal.allEntries(in:)`,
+///    issue #1090 / #1097). Must hit `deletion_journal_by_queued_at`
+///    and avoid a temp B-tree sort.
 @Suite("Profile-index GRDB query plans")
 struct ProfileIndexPlanPinningTests {
   /// `PlanPinningTestHelpers.makeDatabase` opens the per-profile
@@ -74,5 +78,21 @@ struct ProfileIndexPlanPinningTests {
     // pin.
     #expect(detail.contains("sqlite_autoindex_profile_1"))
     #expect(!detail.contains("SCAN"))
+  }
+
+  @Test("allEntries ORDER BY queued_at uses deletion_journal_by_queued_at index")
+  func deletionJournalOrderByQueuedAtUsesIndex() throws {
+    let database = try makeDatabase()
+    let detail = try PlanPinningTestHelpers.planDetail(
+      database,
+      query: """
+        SELECT zone_name, record_name, record_type, queued_at
+        FROM deletion_journal ORDER BY queued_at
+        """)
+    // `DeletionJournal.allEntries(in:)` runs at every engine start to drive the
+    // deletion-journal replay (issue #1090 / #1097); pinning the index prevents
+    // a future schema edit from regressing it to a temp-B-tree sort.
+    #expect(detail.contains("USING INDEX deletion_journal_by_queued_at"))
+    #expect(!detail.contains("USE TEMP B-TREE"))
   }
 }

--- a/MoolahTests/Sync/BloatStateRecoveryTests.swift
+++ b/MoolahTests/Sync/BloatStateRecoveryTests.swift
@@ -132,6 +132,40 @@ struct BloatStateRecoveryTests {
     #expect(toApply.map(\.recordID) == [peerID])
   }
 
+  @Test(
+    "the shield covers a just-deleted-un-propagated instrument: a re-delivered save is suppressed (#1097)"
+  )
+  func shieldCoversDeletedInstrument() async throws {
+    let (coordinator, manager) = try Support.makeCoordinator()
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+    // Instruments are journaled in the profile-index DB; the recovery snapshot
+    // unions the index DB's journal, so a journaled instrument deletion is
+    // shielded for free.
+    let registry = GRDBInstrumentRegistryRepository(database: manager.profileIndexDatabase)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    try await registry.remove(id: eth.id)
+
+    coordinator.armRecoveryShield()
+    let doomedID = CKRecord.ID(recordName: eth.id, zoneID: indexZoneID)
+    let shield = await coordinator.activeRecoveryShield()
+    #expect(shield.contains(doomedID))
+
+    // The forced refetch re-delivers the deleted instrument → it must be
+    // suppressed, not resurrected; an unrelated peer instrument applies.
+    let doomedRecord = CKRecord(recordType: InstrumentRow.recordType, recordID: doomedID)
+    let peerID = CKRecord.ID(recordName: "1:0xpeer", zoneID: indexZoneID)
+    let peerRecord = CKRecord(recordType: InstrumentRow.recordType, recordID: peerID)
+    let (toApply, suppressed) = await coordinator.recoveryShieldedSaves([doomedRecord, peerRecord])
+    #expect(suppressed.map(\.recordID) == [doomedID])
+    #expect(toApply.map(\.recordID) == [peerID])
+  }
+
   @Test("an empty journal arms no shield (nothing to suppress)")
   func emptyJournalArmsNoShield() async throws {
     let (coordinator, manager) = try Support.makeCoordinator()

--- a/MoolahTests/Sync/DeletionReplayTests.swift
+++ b/MoolahTests/Sync/DeletionReplayTests.swift
@@ -146,6 +146,37 @@ struct DeletionReplayTests {
     #expect(deletes.allSatisfy { $0.zoneID == indexZoneID })
   }
 
+  // MARK: - 3b. Instrument deletion replays as an index-zone .deleteRecord (#1097)
+
+  @Test(
+    "a journaled instrument deletion survives a state reset and replays as an index-zone .deleteRecord"
+  )
+  func deletedInstrumentReplaysIndexRecordDeletion() async throws {
+    let fixture = try await Self.makeFixture()
+    let indexZoneID = fixture.coordinator.profileIndexHandler.zoneID
+    // The shared instrument registry lives in the profile-index DB and syncs in
+    // the `profile-index` zone — the same DB the replay reads for index entries.
+    let registry = GRDBInstrumentRegistryRepository(
+      database: fixture.manager.profileIndexDatabase)
+
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    try await registry.remove(id: eth.id)
+
+    let store = InMemoryPendingChangeStore()
+    await fixture.coordinator.replayDeletionJournal(into: store)
+
+    let expected = CKRecord.ID(recordName: eth.id, zoneID: indexZoneID)
+    let deletes = Self.deleteRecordIDs(store.pendingRecordZoneChanges)
+    #expect(deletes.contains(expected))
+    #expect(deletes.allSatisfy { $0.zoneID == indexZoneID })
+  }
+
   // MARK: - 4. Clear-on-confirm → no infinite re-replay across restarts
 
   @Test(


### PR DESCRIPTION
## Corrected diagnosis

#1097 claims the shared instrument registry's `onRecordDeleted` is **unwired**, so instrument deletions never propagate. **That is false on current `main`.** `App/MoolahApp+SharedInstrumentScope.swift` (`attachSharedInstrumentRegistrySyncHooks`) wires `onRecordDeleted` → `coordinator.queueDeletion(recordName:zoneID:)`, so the engine already uploads the `.deleteRecord`.

The real gap is **durability** (the issue's consequence (b)): the deletion was queued in CKSyncEngine state but **never written to the durable `deletion_journal`**. So if the engine is down / its state is reset before the pending `.deleteRecord` propagates, the deletion is lost, and the next token-less full refetch — zone purge, encrypted-data reset, or the #1090/#12 bloated-state recovery — **resurrects the instrument**. It was also **not** covered by #12's recovery tombstone shield, which snapshots journal rows (instruments weren't there).

## The fix — journal instrument deletions like the index-zone `ProfileRow`

Instruments live in the shared **profile-index DB** and sync in the **`profile-index` zone** (same as `ProfileRow`; not the per-profile `@profile-data` sentinel). So this mirrors `GRDBProfileIndexRepository`'s `ProfileRow` journaling exactly:

1. **Durable delete.** `GRDBInstrumentRegistryRepository.remove(id:)` records a `profile-index`-zone deletion intent **inside the same transaction** as `InstrumentRow.deleteOne` — a throw rolls back both. Fiat instruments aren't hard-deleted, so nothing is journaled for them.
2. **Clear-on-recreate (D1-b).** The register/upsert paths (`upsertCrypto`, `upsertStock`) and the remote apply-path save clear the tombstone in the same write, so a delete-then-re-register nets zero.
3. **Replay (#1098) picks it up automatically.** `replayDeletionJournal` resolves index-DB journal rows to the `profile-index` zone by `zoneName`, with no record-type special-casing — so a journaled instrument deletion replays as `.deleteRecord(instrumentRecordID)`. **No replay extension was needed** — verified by an end-to-end test.
4. **#12 recovery shield now covers instruments for free.** `resolveAllJournalDeletions` unions the index-DB + profile-DB journal tombstones; once instruments are journaled they're shielded. **Verified, not assumed**, by a new shield test.

`applyRemoteChangesSync` (and its pricing-status-merge helpers) moved to the sibling `+SyncEntryPoints.swift` file to keep the primary file under the `file_length` budget — behaviour-preserving except for the added D1-b clear.

## Tests (TDD, red-first)

New `InstrumentDeletionJournalTests` + additions to `DeletionReplayTests` / `BloatStateRecoveryTests`:

- instrument hard-delete writes an index-zone journal row atomically; a forced journal-insert failure rolls back the delete;
- delete-then-re-register clears the tombstone (crypto / stock / forcing-status overloads);
- fiat remove and apply-path (server-originated) delete never journal;
- a journaled instrument deletion survives a state reset → replays as `.deleteRecord` in the `profile-index` zone;
- the recovery shield suppresses a re-delivered just-deleted-un-propagated instrument;
- plan-pinning for the index-DB journal replay sweep.

Full macOS suite green, `format-check` clean, zero warnings. `code-review` + `concurrency-review` + `database-code-review` run; all findings applied.

> **Note for reviewers:** the design doc `plans/sync-deletion-durability-and-recovery.md` (on branch `design/1090-bloated-state-self-heal`, not on `main`) still says "InstrumentRow NOT journaled (instrument deletions never sync)." That premise is closed by this PR. I did not edit it here to avoid pulling a foreign-branch file into this PR and creating a cross-branch conflict — the design-branch owner should update it to "InstrumentRow journaled as an index-zone deletion (propagates + durable)."

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)