### PR TITLE
feat(crypto): local name-based spam heuristics for discovered tokens (#1102)

### DIFF
--- a/MoolahTests/Shared/CryptoImport/CryptoSpamHeuristicsTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoSpamHeuristicsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Unit tests for the local, name-based crypto spam heuristics (issue #1102,
+/// bullets 4 & 5: URL/domain in the name, and airdrop/"invitation" scam
+/// phrasing). The heuristics are deterministic and operate purely on the
+/// token's name and symbol — no network. They are only consulted for tokens
+/// that did not resolve to a price provider, so the false-positive risk for
+/// domain-branded but legitimately listed tokens is handled by the caller.
+@Suite("CryptoSpamHeuristics")
+struct CryptoSpamHeuristicsTests {
+  // MARK: - URL / domain in the name
+
+  @Test(
+    "Explicit URLs and domains in the name are flagged",
+    arguments: [
+      "Visit https://op-rewards.xyz to claim",
+      "claim at usdc-claim.com",
+      "www.free-eth.io",
+      "Rewards | t.me/scamchannel",
+      "ETHFI.app airdrop",
+      "1000 USDC at sushi-claim.finance",
+      "Bonus pool — claimusdc.top",
+    ])
+  func flagsEmbeddedDomains(name: String) {
+    #expect(CryptoSpamHeuristics.spamSignal(name: name, symbol: nil) == .embeddedURL)
+  }
+
+  @Test("A domain in the symbol is flagged even when the name is clean")
+  func flagsDomainInSymbol() {
+    #expect(
+      CryptoSpamHeuristics.spamSignal(name: "Reward", symbol: "claim.com") == .embeddedURL)
+  }
+
+  // MARK: - Scam keyword phrasing
+
+  @Test(
+    "Airdrop / invitation / voucher scam phrasing is flagged",
+    arguments: [
+      "Invitation Token",
+      "You can claim your airdrop",
+      "USDC Voucher",
+      "Free giveaway — redeem now",
+      "Presale access token",
+      "OP Airdrop",
+    ])
+  func flagsScamKeywords(name: String) {
+    #expect(CryptoSpamHeuristics.spamSignal(name: name, symbol: nil) == .scamKeyword)
+  }
+
+  // MARK: - Legitimate tokens are not flagged
+
+  @Test(
+    "Well-known legitimate token names are not flagged",
+    arguments: [
+      ("USD Coin", "USDC"),
+      ("Ethereum", "ETH"),
+      ("Optimism", "OP"),
+      ("Uniswap", "UNI"),
+      ("Wrapped Bitcoin", "WBTC"),
+      ("Dai Stablecoin", "DAI"),
+      ("Aave Token", "AAVE"),
+      ("Lido DAO Token", "LDO"),
+      ("Chainlink", "LINK"),
+      ("AirSwap", "AST"),
+      // Keyword detection anchors to the start of a word: "claim" must not
+      // fire on "Reclaim" or "Disclaimer".
+      ("Reclaim Protocol", "RCM"),
+      ("Disclaimer", "DSC"),
+    ])
+  func doesNotFlagLegitimateTokens(name: String, symbol: String) {
+    #expect(CryptoSpamHeuristics.spamSignal(name: name, symbol: symbol) == nil)
+    #expect(!CryptoSpamHeuristics.isLikelySpam(name: name, symbol: symbol))
+  }
+
+  @Test("Empty name and symbol are not flagged")
+  func emptyInputsAreClean() {
+    #expect(CryptoSpamHeuristics.spamSignal(name: "", symbol: nil) == nil)
+    #expect(CryptoSpamHeuristics.spamSignal(name: "", symbol: "") == nil)
+  }
+
+  @Test("isLikelySpam agrees with spamSignal")
+  func isLikelySpamMatchesSignal() {
+    #expect(CryptoSpamHeuristics.isLikelySpam(name: "claim at evil.com", symbol: nil))
+    #expect(CryptoSpamHeuristics.isLikelySpam(name: "Invitation", symbol: nil))
+    #expect(!CryptoSpamHeuristics.isLikelySpam(name: "Ethereum", symbol: "ETH"))
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
 import Foundation
 import Testing
 
@@ -178,6 +177,54 @@ struct CryptoTokenDiscoveryServiceTests {
     #expect(
       subject.alchemy.callCount(
         for: .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased())) == 0)
+  }
+
+  // MARK: - Local spam heuristics (#1102)
+
+  @Test("Unpriced token with a URL in its name → .spam via local heuristic")
+  func unpricedWithDomainNameIsSpam() async throws {
+    struct ProviderFailed: Error {}
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .failure(ProviderFailed()))
+    subject.alchemy.setDefaultSpam(false)
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      // Keyword-free symbol so this exercises the domain path, not the
+      // keyword path (the name carries both signals).
+      symbol: "SCM",
+      name: "Visit op-rewards.xyz for details",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .spam)
+    #expect(!registration.mapping.hasProviderMapping)
+    let stored = try await subject.registry.cryptoRegistration(byId: Self.usdcId)
+    #expect(stored?.pricingStatus == .spam)
+  }
+
+  @Test("A priced token keeps .priced even when its name contains a domain")
+  func pricedDomainBrandedTokenStaysPriced() async throws {
+    // yearn.finance / YFI: a legitimately listed token whose name is a
+    // domain. Because the provider resolves it, the local domain heuristic
+    // must not demote it to .spam.
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "yearn-finance", cryptocompare: nil, binance: nil))
+    subject.alchemy.setDefaultSpam(false)
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "YFI",
+      name: "yearn.finance",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .priced)
+    #expect(registration.mapping.coingeckoId == "yearn-finance")
   }
 
   // MARK: - Chain-id entry point

--- a/Shared/CryptoImport/CryptoSpamHeuristics.swift
+++ b/Shared/CryptoImport/CryptoSpamHeuristics.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Local, deterministic spam heuristics for discovered crypto tokens, applied
+/// purely to a token's name and symbol — no network round-trip.
+///
+/// These implement issue #1102 bullets 4 and 5:
+/// * a URL or domain name embedded in the token name (scam airdrops point the
+///   holder at a phishing site);
+/// * "invitation" / airdrop / voucher scam phrasing.
+///
+/// Crucially, the caller (`CryptoTokenDiscoveryService`) only consults these
+/// for tokens that did **not** resolve to a price provider. A legitimately
+/// listed token whose name happens to contain a domain — e.g. `yearn.finance`
+/// (YFI) — resolves on CoinGecko and keeps its `.priced` status, so the
+/// domain rule never demotes it. The heuristics only ever turn an otherwise
+/// `.unpriced` token into `.spam`, which the user can still override.
+enum CryptoSpamHeuristics {
+  /// Why a token was classified as spam by the local heuristics.
+  enum SpamSignal: String, Sendable {
+    /// The name or symbol contains a URL or a `label.tld` domain.
+    case embeddedURL
+    /// The name or symbol contains airdrop / invitation / voucher phrasing.
+    case scamKeyword
+  }
+
+  /// Returns the heuristic that classifies `(name, symbol)` as spam, or `nil`
+  /// when the token shows no name-based spam signal. URL/domain detection
+  /// takes precedence over keyword detection so the reported reason reflects
+  /// the strongest signal.
+  static func spamSignal(name: String, symbol: String?) -> SpamSignal? {
+    let haystack = ([name, symbol ?? ""].joined(separator: " "))
+      .lowercased()
+    guard !haystack.allSatisfy(\.isWhitespace) else { return nil }
+    if containsURLOrDomain(haystack) { return .embeddedURL }
+    if containsScamKeyword(haystack) { return .scamKeyword }
+    return nil
+  }
+
+  /// Convenience boolean wrapper over `spamSignal(name:symbol:)`.
+  static func isLikelySpam(name: String, symbol: String?) -> Bool {
+    spamSignal(name: name, symbol: symbol) != nil
+  }
+
+  // MARK: - URL / domain detection
+
+  private static func containsURLOrDomain(_ haystack: String) -> Bool {
+    if haystack.contains("http://") || haystack.contains("https://")
+      || haystack.contains("www.")
+    {
+      return true
+    }
+    return matches(domainRegex, in: haystack)
+  }
+
+  /// Matches a `label.tld` domain where `tld` is a common (and scam-favoured)
+  /// top-level domain. The leading negative lookbehind keeps the match
+  /// anchored to a label boundary; the trailing lookahead stops a TLD from
+  /// matching the prefix of a longer word.
+  private static let domainRegex: NSRegularExpression = {
+    let tlds = [
+      "com", "net", "org", "io", "co", "xyz", "app", "finance", "fi", "site",
+      "click", "vip", "top", "live", "info", "me", "biz", "online", "store",
+      "gift", "cash", "money", "fund", "win", "pro", "gg", "lol", "cc", "ru",
+      "cn", "tk", "ml", "ga", "cf", "gq", "fun", "monster", "icu", "li", "sh",
+      "ws", "in", "us", "to", "ai", "dev", "page", "link",
+    ].joined(separator: "|")
+    let pattern = "(?<![a-z0-9])[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.(?:\(tlds))(?![a-z0-9])"
+    return compile(pattern)
+  }()
+
+  // MARK: - Scam keyword detection
+
+  /// Words that are textbook in airdrop / voucher / "invitation" scam tokens
+  /// and essentially never lead a word in a legitimate token's name. The
+  /// negative lookbehind anchors each match to the start of a word, so
+  /// "claim" fires on "Claim your reward" but not on "Reclaim Protocol" or
+  /// "Disclaimer"; trailing characters are unconstrained so plural/inflected
+  /// forms ("rewards", "claims") still match.
+  private static let scamKeywordRegex: NSRegularExpression = {
+    let keywords = [
+      "airdrop", "invitation", "invite", "voucher", "giveaway", "redeem",
+      "presale", "claim", "reward", "winner", "you won", "free entry",
+    ].joined(separator: "|")
+    return compile("(?<![a-z0-9])(?:\(keywords))")
+  }()
+
+  private static func containsScamKeyword(_ haystack: String) -> Bool {
+    matches(scamKeywordRegex, in: haystack)
+  }
+
+  // MARK: - Regex plumbing
+
+  /// Compiles a pattern that is a compile-time constant. A failure here can
+  /// only mean a maintainer garbled the pattern string, so trap loudly rather
+  /// than silently classify every token as not-spam.
+  private static func compile(_ pattern: String) -> NSRegularExpression {
+    do {
+      return try NSRegularExpression(pattern: pattern)
+    } catch {
+      fatalError("CryptoSpamHeuristics: invalid regex pattern '\(pattern)' — \(error)")
+    }
+  }
+
+  private static func matches(_ regex: NSRegularExpression, in haystack: String) -> Bool {
+    let range = NSRange(haystack.startIndex..., in: haystack)
+    return regex.firstMatch(in: haystack, range: range) != nil
+  }
+}

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -1,4 +1,3 @@
-// Shared/CryptoImport/CryptoTokenDiscoveryService.swift
 import Foundation
 import OSLog
 
@@ -21,6 +20,10 @@ import OSLog
 /// 4. Apply the design's status precedence:
 ///    - `isSpam == true` → `.spam` (regardless of resolver outcome).
 ///    - resolver succeeded with at least one provider id → `.priced`.
+///    - no provider price but `CryptoSpamHeuristics` flags the name/symbol
+///      (embedded URL/domain or airdrop-"invitation" phrasing) → `.spam`
+///      (issue #1102). Runs only on otherwise-`.unpriced` tokens so a listed
+///      domain-branded token like yearn.finance keeps its price.
 ///    - else → `.unpriced` (surfaces in the Discovered Tokens inbox).
 /// 5. Persist via the registry. Status is sticky-positive: once a row
 ///    transitions out of `.unpriced`, the next sync cycle leaves it alone.
@@ -170,11 +173,26 @@ actor CryptoTokenDiscoveryService {
     let mapping: CryptoProviderMapping
     let status: TokenPricingStatus
     if isSpam {
+      // Alchemy's curated spam database is authoritative and wins even over
+      // a successful provider resolution.
       status = .spam
       mapping = resolved?.mapping ?? emptyMapping(for: instrument.id)
     } else if let resolved, resolved.mapping.hasProviderMapping {
+      // A token with a real price from a provider is legitimate — the local
+      // name heuristics deliberately do not run here, so a domain-branded but
+      // listed token (e.g. yearn.finance / YFI) keeps its `.priced` status.
       status = .priced
       mapping = resolved.mapping
+    } else if let signal = CryptoSpamHeuristics.spamSignal(
+      name: instrument.name, symbol: instrument.ticker)
+    {
+      // No provider price and the name/symbol carries a spam signal (an
+      // embedded URL/domain or airdrop-"invitation" phrasing) — issue #1102.
+      logger.debug(
+        "Local spam heuristic (\(signal.rawValue, privacy: .public)) flagged \(instrument.id, privacy: .public)"
+      )
+      status = .spam
+      mapping = emptyMapping(for: instrument.id)
     } else {
       status = .unpriced
       mapping = emptyMapping(for: instrument.id)


### PR DESCRIPTION
## Summary

First slice of [#1102](https://github.com/moolah-rocks/moolah-native/pull/1102) (improve crypto spam detection). Implements the two issue bullets that need **no external data and no design clarification**:

- **Bullet 4** — a URL or `label.tld` domain embedded in a token's name/symbol → spam.
- **Bullet 5** — airdrop / "invitation" / voucher scam phrasing → spam.

A new pure `CryptoSpamHeuristics` enum does the classification (regex over the lowercased `name + symbol`), and `CryptoTokenDiscoveryService.performResolution` consults it.

## Why it's safe

The heuristics run **only on tokens that did not resolve to a price provider**. The status precedence is now:

1. Alchemy `isSpam` → `.spam` (authoritative, unchanged).
2. Provider mapping resolved → `.priced` (heuristics never run here).
3. No price **and** a name/symbol spam signal → `.spam` (new).
4. else → `.unpriced`.

So a legitimately listed but domain-branded token like **yearn.finance (YFI)** resolves on CoinGecko and keeps `.priced` — the domain rule never demotes it. Both detections anchor matches to word boundaries, so `claim` fires on "Claim your reward" but **not** on "Reclaim Protocol" / "Disclaimer". A misclassification is still user-overridable in the Discovered Tokens inbox.

## Tests

- `CryptoSpamHeuristicsTests` — pure unit tests: embedded domains, scam keywords, and a precision suite of legitimate tokens (incl. AirSwap, Reclaim Protocol, Disclaimer) that must **not** be flagged.
- `CryptoTokenDiscoveryServiceTests` — two integration tests: an unpriced domain-name token becomes `.spam`; a priced domain-branded token (yearn.finance) stays `.priced`.

`just test-mac` (these suites) green; `just format-check` clean.

## Deferred to follow-up

The remaining #1102 bullets need a trusted/canonical token list or external data and are being handled on the research + clarification track:

- canonical-address impersonation (OP only on Optimism; canonical stablecoin addresses);
- the 0-value-same-name-different-address rule;
- block-explorer "suspicious" flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)