### PR TITLE
fix(sync): recovery shield must snapshot the journal before clear-on-confirm (#1090 / #12)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+DeletionReplay.swift
@@ -175,6 +175,20 @@ extension SyncCoordinator {
     let confirmed = Self.confirmedReplayedDeletions(
       replayedDeletionsInFlight, pending: state.pendingRecordZoneChanges)
     guard !confirmed.isEmpty else { return }
+    // The recovery tombstone shield snapshots the journal via an async task
+    // armed at recovery start (`recoverySnapshotTask`). Clearing a journal row
+    // before that read runs would let the snapshot read an already-emptied
+    // journal and drop this id from the shield — so the still-draining forced
+    // refetch could resurrect the just-deleted record. Await the snapshot so it
+    // captures the journal BEFORE we delete from it. No-op outside a recovery
+    // session (the task is nil). Issue #1090 / #12.
+    await recoverySnapshotTask?.value
+    // `Task.isCancelled` here is the CALLING task (e.g. `zoneSetupTask`
+    // cancelled by `stop()`) while we awaited the snapshot — skip the GRDB
+    // clear so we don't write through a torn-down coordinator. The snapshot
+    // task's own cancellation is handled separately (`stop()` zeroes the
+    // shield), so a cancelled snapshot here is harmless.
+    guard !Task.isCancelled else { return }
     await clearJournalRows(for: confirmed)
     // Only retire the in-flight tracking once the journal writes have run (and
     // not after a stop cancelled them) — re-tracking on the next start is safe,

--- a/MoolahTests/Sync/BloatStateRecoveryTests.swift
+++ b/MoolahTests/Sync/BloatStateRecoveryTests.swift
@@ -234,6 +234,39 @@ struct BloatStateRecoveryTests {
     #expect(!(await Support.suppresses(fixture.doomedID, coordinator)))
   }
 
+  @Test(
+    "clear-on-confirm captures the shield snapshot BEFORE deleting journal rows (deterministic race lock)"
+  )
+  func clearOnConfirmCapturesSnapshotBeforeClearingJournal() async throws {
+    let fixture = try await Support.makeShieldFixture()
+    let coordinator = fixture.coordinator
+
+    // Resolve the journal refs up front — no shield is armed yet, so there is
+    // no snapshot task to race, and these are the exact refs the real replay
+    // would track.
+    let resolved = await coordinator.resolveAllJournalDeletions().resolved
+    #expect(resolved[fixture.doomedID] != nil)
+
+    // Arm the shield (which spawns the async snapshot task) and then seed the
+    // in-flight replay state WITHOUT any suspension point. Holding the MainActor
+    // synchronously guarantees the snapshot task has not run when clear-on-
+    // confirm starts — the precise ordering that used to lose the race.
+    coordinator.armRecoveryShield()
+    coordinator.replayedDeletionsInFlight = resolved
+    coordinator.recoveryReplayDidRun = true
+
+    // The empty pending store makes the doomed delete read as confirmed, so its
+    // journal row is cleared. Clear-on-confirm must await the snapshot first, so
+    // the snapshot reads the journal while the tombstone still exists and the id
+    // stays shielded. Without the fix the row is deleted first, the snapshot
+    // reads an empty journal, drops the id, and the still-draining refetch could
+    // resurrect the just-deleted record (#1090 / #12).
+    await coordinator.clearConfirmedReplayedDeletions(against: InMemoryPendingChangeStore())
+
+    #expect(coordinator.isRecoveryShieldActive)
+    #expect(await Support.suppresses(fixture.doomedID, coordinator))
+  }
+
   @Test("the shield also releases when the refetch settles before the delete is confirmed")
   func shieldReleasesWhenRefetchSettlesThenDeleteConfirms() async throws {
     let fixture = try await Support.makeShieldFixture()


### PR DESCRIPTION
## Summary

Fixes a flaky test — `BloatStateRecoveryTests.shieldOutlivesDeleteConfirmUntilRefetchSettles` (the failure that intermittently blocked the merge queue) — which turned out to be a **real data-resurrection race** in the bloated-state recovery tombstone shield (#1090 / #12), not just a test-timing issue.

## The race

- `armRecoveryShield()` spawns an **async** `recoverySnapshotTask` that reads the deletion journal into `recoveringDeletions` (the shield).
- `clearConfirmedReplayedDeletions` → `clearJournalRows` **deletes journal rows** for confirmed deletions.

If the snapshot's async journal read runs *after* the clear deletes a row, the snapshot reads an empty journal, `applyRecoverySnapshot` takes its `recoveringDeletions.isEmpty` branch and **deactivates the shield** — so the still-draining forced refetch could resurrect a just-deleted record.

Reproduced empirically: **1 failure in 25 runs (~4%)** on `main`, always at the same assertion. (In production the window is small because clear-on-confirm requires a network round-trip while the snapshot read is local — but the 3-attempt/100 ms-retry journal read can widen it, so it's a genuine latent bug.)

## The fix

`clearConfirmedReplayedDeletions` now `await recoverySnapshotTask?.value` **before** `clearJournalRows`, so the snapshot captures the journal while the tombstone still exists. It's a no-op outside a recovery session (the task is nil), and it reuses the same synchronisation primitive the apply path (`recoveryShieldedSaves`) already awaits. sync-review confirmed the other journal-clear paths (the repo's in-transaction clear on re-create; the sign-out `clearAll`) are already protected, so this is the one site that needed it.

## Verification

- **Deterministic regression test** added (`clearOnConfirmCapturesSnapshotBeforeClearingJournal`): seeds the in-flight state synchronously so the snapshot task provably hasn't run when clear starts — **verified to fail without the fix and pass with it**, and not itself flaky.
- **Post-fix stress: 40/40 green** (vs 1/25 failing before); 6 sibling sync suites (45 tests) pass; `just format-check` clean.
- sync-review: no Critical, no data-loss path; applied its comment-clarification finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)