### PR TITLE
test(support): expectEventually polling helper + fix AutomationServiceEarmark flake

### DIFF
--- a/MoolahTests/Automation/AutomationServiceEarmarkTests.swift
+++ b/MoolahTests/Automation/AutomationServiceEarmarkTests.swift
@@ -31,7 +31,7 @@ struct AutomationServiceEarmarkTests {
 
   @Test("createEarmark creates and lists earmarks")
   func createAndListEarmarks() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     let earmark = try await service.createEarmark(
       profileIdentifier: "Test",
@@ -42,34 +42,29 @@ struct AutomationServiceEarmarkTests {
     #expect(earmark.name == "Holiday Fund")
     #expect(earmark.savingsGoal?.quantity == 5000)
 
-    // EarmarkStore is reactive — the new earmark is observable via
-    // observeAll() shortly after the GRDB write commits, not synchronously.
-    try await session.earmarkStore.waitForNextEmission(
-      matching: { $0.earmarks.contains { $0.name == "Holiday Fund" } },
-      description: "new earmark observable"
-    )
-
-    let earmarks = try service.listEarmarks(profileIdentifier: "Test")
-    #expect(earmarks.count == 1)
-    #expect(earmarks.first?.name == "Holiday Fund")
+    // EarmarkStore is reactive — the new earmark becomes listable shortly after
+    // the GRDB write commits. Poll the exact asserted value (the service
+    // listing) so a racing observation pass can't slip a stale read between an
+    // awaited emission and a single read.
+    await expectEventually("created earmark is listed via the service") {
+      let earmarks = (try? service.listEarmarks(profileIdentifier: "Test")) ?? []
+      return earmarks.count == 1 && earmarks.first?.name == "Holiday Fund"
+    }
   }
 
   @Test("resolveEarmark finds earmark case-insensitively")
   func resolveEarmarkCaseInsensitive() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     _ = try await service.createEarmark(
       profileIdentifier: "Test",
       name: "Emergency Fund"
     )
 
-    try await session.earmarkStore.waitForNextEmission(
-      matching: { $0.earmarks.contains { $0.name == "Emergency Fund" } },
-      description: "new earmark observable"
-    )
-
-    let resolved = try service.resolveEarmark(named: "emergency fund", profileIdentifier: "Test")
-    #expect(resolved.name == "Emergency Fund")
+    await expectEventually("created earmark resolves case-insensitively") {
+      (try? service.resolveEarmark(named: "emergency fund", profileIdentifier: "Test"))?.name
+        == "Emergency Fund"
+    }
   }
 
   @Test("resolveEarmark throws when not found")

--- a/MoolahTests/Support/ExpectEventually.swift
+++ b/MoolahTests/Support/ExpectEventually.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Polls `condition` on the `@MainActor` until it returns `true` or `timeout`
+/// elapses. On timeout it records a Swift Testing issue at the call site so the
+/// test fails with a clear message.
+///
+/// Use this to assert post-mutation store / service state instead of the
+/// flake-prone "await one observation emission, then read the value once"
+/// shape. A reactive store's published state can be momentarily overwritten by
+/// a racing observation pass (e.g. an instrument-registry refetch) in the
+/// window between the emission you awaited and the value you read — so the
+/// single read occasionally sees stale state even though the steady state is
+/// correct.
+///
+/// Polling the **exact asserted expression** closes that gap: put the entire
+/// post-condition inside the closure so there is no second, unguarded read
+/// afterwards. The condition runs on the `@MainActor` (it reads
+/// `@MainActor`-isolated store state), and the `Task.sleep` between polls
+/// yields the actor so the observation pipeline keeps making progress.
+///
+/// This complements — does not replace — `TestableStoreObservation`'s
+/// `waitForNextEmission`: use that to assert an emission *occurs*; use this to
+/// assert a *value* settles. A `condition` that throws should be wrapped in
+/// `try?` by the caller (a thrown error reads as "not yet satisfied").
+@MainActor
+func expectEventually(
+  _ description: @autoclosure () -> String = "condition to hold",
+  timeout: Duration = .seconds(2),
+  pollInterval: Duration = .milliseconds(20),
+  sourceLocation: SourceLocation = #_sourceLocation,
+  _ condition: @MainActor () async -> Bool
+) async {
+  let clock = ContinuousClock()
+  let deadline = clock.now.advanced(by: timeout)
+  while clock.now < deadline {
+    if await condition() { return }
+    try? await Task.sleep(for: pollInterval)
+  }
+  // One final check so a condition that becomes true exactly at the deadline
+  // isn't reported as a spurious timeout.
+  if await condition() { return }
+  Issue.record(
+    "expectEventually timed out after \(timeout): \(description())",
+    sourceLocation: sourceLocation)
+}


### PR DESCRIPTION
## Summary

Introduces a reusable test helper to eliminate a whole **category** of store-observation flakes (the kind that intermittently ejects PRs from the merge queue), and fixes the one that's actually been biting — `AutomationServiceEarmarkTests`.

### The anti-pattern
Many store tests do: `await waitForNextEmission(matching: X)` → then **separately** read store/service state once and `#expect` on it. A reactive store's published state can be momentarily overwritten by a racing observation pass (e.g. an instrument-registry refetch) in the gap between the awaited emission and the single read — so the read occasionally sees stale state even though the steady state is correct. That's a textbook intermittent flake.

### The helper
`expectEventually("desc") { <exact asserted expression> }` polls the **exact asserted expression** on the MainActor until it holds or times out (then records a Swift Testing issue). Polling the real value — with the full post-condition inside the closure — closes the wait-then-read gap regardless of each store's internals. It complements `waitForNextEmission` (which asserts an emission *occurs*); this asserts a *value settles*.

### This PR
- Adds `MoolahTests/Support/ExpectEventually.swift`.
- Migrates `AutomationServiceEarmarkTests` (`createEarmark creates and lists earmarks` was failing in CI with count 0 vs 1; also `resolveEarmark…`).

### Rollout
A sweep found **~134 instances** of this anti-pattern across **37 files**. This PR lands the helper + the one that has demonstrably flaked; the rest follow in per-area batches (so the diff stays reviewable and the merge queue isn't flooded).

`just test-mac AutomationServiceEarmarkTests` green; `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)