### PR TITLE
test: migrate store-observation tests to expectEventually (kill the wait-then-read flake class)

### DIFF
--- a/MoolahTests/Automation/AutomationServiceAccountTests.swift
+++ b/MoolahTests/Automation/AutomationServiceAccountTests.swift
@@ -9,7 +9,7 @@ struct AutomationServiceAccountTests {
 
   @Test("createAccount creates and lists accounts")
   func createAndListAccounts() async throws {
-    let (service, session) = try await AutomationTestSession.make()
+    let (service, _) = try await AutomationTestSession.make()
 
     let account = try await service.createAccount(
       profileIdentifier: "Test",
@@ -21,16 +21,14 @@ struct AutomationServiceAccountTests {
     #expect(account.type == .bank)
     #expect(account.positions.isEmpty)
 
-    // AccountStore is reactive — the new account is observable via
-    // `accounts` once `observeAll()` delivers the post-write snapshot.
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.count == 1 },
-      description: "new account observable"
-    )
-
-    let accounts = try service.listAccounts(profileIdentifier: "Test")
-    #expect(accounts.count == 1)
-    #expect(accounts.first?.name == "Savings")
+    // AccountStore is reactive — the new account becomes listable shortly
+    // after the GRDB write commits. Poll the exact asserted value so a racing
+    // observation pass can't slip a stale read between an awaited emission and
+    // a single read.
+    await expectEventually("created account is listed via the service") {
+      let accounts = (try? service.listAccounts(profileIdentifier: "Test")) ?? []
+      return accounts.count == 1 && accounts.first?.name == "Savings"
+    }
   }
 
   @Test("createAccount defaults a new investment account to calculatedFromTrades")
@@ -106,15 +104,13 @@ struct AutomationServiceAccountTests {
     let openingBalance = InstrumentAmount(quantity: 1000, instrument: instrument)
     _ = try await session.accountStore.create(bankAccount, openingBalance: openingBalance)
 
-    // Wait for the reactive observation to deliver the position
-    // computed from the opening-balance transaction.
-    try await session.accountStore.waitForNextEmission(
-      matching: { !($0.positions(for: bankAccount.id).isEmpty) },
-      description: "opening balance position observable"
-    )
-
-    let netWorth = try await service.getNetWorth(profileIdentifier: "Test")
-    #expect(netWorth.quantity == 1000)
+    // The net worth derives from the position computed off the opening-balance
+    // transaction, which the reactive observation delivers shortly after the
+    // write commits. Poll the exact asserted value so a racing observation pass
+    // can't slip a stale read in.
+    await expectEventually("net worth reflects the opening balance") {
+      (try? await service.getNetWorth(profileIdentifier: "Test"))?.quantity == 1000
+    }
   }
 
   @Test("updateAccount changes account name")
@@ -159,16 +155,13 @@ struct AutomationServiceAccountTests {
     // `AccountRepository.delete` is a soft delete (flips `isHidden`).
     // Under the reactive observation contract, the row stays in GRDB
     // (and therefore in `accounts`) but with `isHidden == true`.
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: created.id)?.isHidden == true },
-      description: "account hidden observable"
-    )
-
-    // `listAccounts` exposes the raw `accounts` list (including hidden
-    // rows), so the assertion checks the soft-delete contract: the row
-    // is still present but hidden.
-    let accounts = try service.listAccounts(profileIdentifier: "Test")
-    #expect(accounts.count == 1)
-    #expect(accounts.first?.isHidden == true)
+    // `listAccounts` exposes the raw `accounts` list (including hidden rows),
+    // so polling it asserts the soft-delete contract: the row is still present
+    // but hidden. Poll the exact asserted value so a racing observation pass
+    // can't slip a stale read between an awaited emission and a single read.
+    await expectEventually("deleted account is hidden but still listed") {
+      let accounts = (try? service.listAccounts(profileIdentifier: "Test")) ?? []
+      return accounts.count == 1 && accounts.first?.isHidden == true
+    }
   }
 }

--- a/MoolahTests/Automation/AutomationServiceCategoryTests.swift
+++ b/MoolahTests/Automation/AutomationServiceCategoryTests.swift
@@ -31,7 +31,7 @@ struct AutomationServiceCategoryTests {
 
   @Test("createCategory creates and lists categories")
   func createAndListCategories() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     let category = try await service.createCategory(
       profileIdentifier: "Test",
@@ -42,21 +42,19 @@ struct AutomationServiceCategoryTests {
     #expect(category.name == "Food")
     #expect(category.parentId == nil)
 
-    // CategoryStore is reactive — the new category is observable via
-    // `categories` once `observeAll()` delivers the post-write snapshot.
-    try await session.categoryStore.waitForNextEmission(
-      matching: { $0.categories.roots.count == 1 },
-      description: "new category observable"
-    )
-
-    let categories = try service.listCategories(profileIdentifier: "Test")
-    #expect(categories.count == 1)
-    #expect(categories.first?.name == "Food")
+    // CategoryStore is reactive — the new category becomes listable shortly
+    // after the GRDB write commits. Poll the exact asserted value so a racing
+    // observation pass can't slip a stale read between an awaited emission and
+    // a single read.
+    await expectEventually("created category is listed via the service") {
+      let categories = (try? service.listCategories(profileIdentifier: "Test")) ?? []
+      return categories.count == 1 && categories.first?.name == "Food"
+    }
   }
 
   @Test("resolveCategory finds category by name case-insensitively")
   func resolveCategoryByName() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     _ = try await service.createCategory(
       profileIdentifier: "Test",
@@ -64,13 +62,10 @@ struct AutomationServiceCategoryTests {
       parentName: nil
     )
 
-    try await session.categoryStore.waitForNextEmission(
-      matching: { $0.categories.roots.contains { $0.name == "Transport" } },
-      description: "new category observable"
-    )
-
-    let resolved = try service.resolveCategory(named: "transport", profileIdentifier: "Test")
-    #expect(resolved.name == "Transport")
+    await expectEventually("created category resolves case-insensitively") {
+      (try? service.resolveCategory(named: "transport", profileIdentifier: "Test"))?.name
+        == "Transport"
+    }
   }
 
   @Test("resolveCategory throws when not found")

--- a/MoolahTests/Automation/AutomationServiceExportImportTests.swift
+++ b/MoolahTests/Automation/AutomationServiceExportImportTests.swift
@@ -132,11 +132,13 @@
         Issue.record("expected .ready")
         return
       }
-      try await importedSession.accountStore.waitForNextEmission(
-        matching: { $0.accounts.contains { $0.name == "Savings" } },
-        description: "imported account observable"
-      )
-      #expect(importedSession.accountStore.accounts.contains { $0.name == "Savings" })
+      // The imported account becomes observable on the reactive store shortly
+      // after the import write commits. Poll the exact asserted value so a
+      // racing observation pass can't slip a stale read between an awaited
+      // emission and a single read.
+      await expectEventually("imported account is observable on the store") {
+        importedSession.accountStore.accounts.contains { $0.name == "Savings" }
+      }
     }
 
     @Test("importProfile throws for a missing file")

--- a/MoolahTests/Features/AccountGroupStoreMutationsTests.swift
+++ b/MoolahTests/Features/AccountGroupStoreMutationsTests.swift
@@ -48,13 +48,10 @@ struct AccountGroupStoreMutationsTests {
 
     #expect(group.name == "New Group")
     #expect(group.bucket == .investments)
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: account.id)?.groupId == group.id },
-      description: "member.groupId set"
-    )
-    let member = try #require(accountStore.accounts.by(id: account.id))
-    #expect(member.groupId == group.id)
-    #expect(member.position == 0)
+    await expectEventually("member joined the new group at position 0") {
+      let member = accountStore.accounts.by(id: account.id)
+      return member?.groupId == group.id && member?.position == 0
+    }
   }
 
   @Test("createGroup(joining:and:) creates a 2-member group")
@@ -74,17 +71,12 @@ struct AccountGroupStoreMutationsTests {
     let group = try await groupStore.createGroup(
       joining: accountA, and: accountB, name: "Pair", accountStore: accountStore)
 
-    try await accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: accountA.id)?.groupId == group.id
-          && $0.accounts.by(id: accountB.id)?.groupId == group.id
-      },
-      description: "both members in group"
-    )
-    let memberA = try #require(accountStore.accounts.by(id: accountA.id))
-    let memberB = try #require(accountStore.accounts.by(id: accountB.id))
-    #expect(memberA.position == 0)
-    #expect(memberB.position == 1)
+    await expectEventually("both members in group at positions 0 and 1") {
+      let memberA = accountStore.accounts.by(id: accountA.id)
+      let memberB = accountStore.accounts.by(id: accountB.id)
+      return memberA?.groupId == group.id && memberB?.groupId == group.id
+        && memberA?.position == 0 && memberB?.position == 1
+    }
   }
 
   @Test("addAccount(_:to:) sets groupId and persists order")
@@ -109,13 +101,10 @@ struct AccountGroupStoreMutationsTests {
     )
 
     try await groupStore.addAccount(target, to: group, accountStore: accountStore)
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: target.id)?.groupId == group.id },
-      description: "target joined"
-    )
-    let added = try #require(accountStore.accounts.by(id: target.id))
-    #expect(added.groupId == group.id)
-    #expect(added.position == 1)
+    await expectEventually("target joined group at position 1") {
+      let added = accountStore.accounts.by(id: target.id)
+      return added?.groupId == group.id && added?.position == 1
+    }
   }
 
   @Test("removeAccount clears groupId and auto-deletes single-member group")
@@ -146,11 +135,9 @@ struct AccountGroupStoreMutationsTests {
       matching: { $0.accounts.by(id: account.id)?.groupId == nil },
       description: "groupId cleared"
     )
-    try await groupStore.waitForNextEmission(
-      matching: { !$0.groups.contains { $0.id == group.id } },
-      description: "empty group auto-deleted"
-    )
-    #expect(groupStore.by(id: group.id) == nil)
+    await expectEventually("empty group auto-deleted") {
+      groupStore.by(id: group.id) == nil
+    }
   }
 
   @Test("removeAccount leaves group when other members remain")
@@ -180,12 +167,11 @@ struct AccountGroupStoreMutationsTests {
     // Reload the post-join A so it carries the updated `groupId`.
     let memberA = try #require(accountStore.accounts.by(id: accountA.id))
     try await groupStore.removeAccount(memberA, accountStore: accountStore)
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountA.id)?.groupId == nil },
-      description: "A removed"
-    )
-    #expect(groupStore.by(id: group.id) != nil)
-    #expect(accountStore.accounts.by(id: accountB.id)?.groupId == group.id)
+    await expectEventually("A removed; group survives with B still a member") {
+      accountStore.accounts.by(id: accountA.id)?.groupId == nil
+        && groupStore.by(id: group.id) != nil
+        && accountStore.accounts.by(id: accountB.id)?.groupId == group.id
+    }
   }
 
   @Test("rename updates a group's name")
@@ -204,11 +190,9 @@ struct AccountGroupStoreMutationsTests {
     let renamed = try await store.rename(id: group.id, to: "New")
 
     #expect(renamed?.name == "New")
-    try await store.waitForNextEmission(
-      matching: { $0.by(id: group.id)?.name == "New" },
-      description: "rename observed"
-    )
-    #expect(store.error == nil)
+    await expectEventually("rename observed with no error") {
+      store.by(id: group.id)?.name == "New" && store.error == nil
+    }
   }
 
   @Test("rename trims whitespace before persisting")

--- a/MoolahTests/Features/AccountGroupStoreTests.swift
+++ b/MoolahTests/Features/AccountGroupStoreTests.swift
@@ -27,12 +27,10 @@ struct AccountGroupStoreTests {
         name: "Trust Fund Crypto", bucket: .investments,
         instrument: .defaultTestInstrument))
 
-    try await store.waitForNextEmission(
-      matching: { $0.groups.count == 1 },
-      description: "create observed"
-    )
-    #expect(store.groups.first?.name == "Trust Fund Crypto")
-    #expect(store.error == nil)
+    await expectEventually("create observed with no error") {
+      store.groups.count == 1 && store.groups.first?.name == "Trust Fund Crypto"
+        && store.error == nil
+    }
   }
 
   @Test("groups are ordered by position ascending")
@@ -50,11 +48,9 @@ struct AccountGroupStoreTests {
         name: "A", bucket: .investments,
         instrument: .defaultTestInstrument, position: 1))
 
-    try await store.waitForNextEmission(
-      matching: { $0.groups.count == 2 },
-      description: "creates observed"
-    )
-    #expect(store.groups.map(\.name) == ["A", "B"])
+    await expectEventually("both creates observed in position order") {
+      store.groups.map(\.name) == ["A", "B"]
+    }
   }
 
   @Test("by(id:) finds an existing group")
@@ -68,12 +64,9 @@ struct AccountGroupStoreTests {
         name: "G", bucket: .investments,
         instrument: .defaultTestInstrument))
 
-    try await store.waitForNextEmission(
-      matching: { $0.groups.count == 1 },
-      description: "create observed"
-    )
-
-    #expect(store.by(id: created.id)?.name == "G")
+    await expectEventually("created group is findable by id") {
+      store.by(id: created.id)?.name == "G"
+    }
     #expect(store.by(id: UUID()) == nil)
   }
 

--- a/MoolahTests/Features/AccountStoreAggregateBalanceTests.swift
+++ b/MoolahTests/Features/AccountStoreAggregateBalanceTests.swift
@@ -45,15 +45,12 @@ struct AccountStoreAggregateBalanceTests {
       repository: backend.accounts,
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalances.count == 2 },
-      description: "balances converted")
-
-    let aggregate = try await store.aggregateBalance(
-      for: [memberA.id, memberB.id], in: .defaultTestInstrument)
-    let amount = try #require(aggregate)
-    #expect(amount.quantity == dec("350.00"))
-    #expect(amount.instrument == .defaultTestInstrument)
+    await expectEventually("aggregate sums both accounts to 350.00") {
+      let aggregate = try? await store.aggregateBalance(
+        for: [memberA.id, memberB.id], in: .defaultTestInstrument)
+      return aggregate?.quantity == dec("350.00")
+        && aggregate?.instrument == .defaultTestInstrument
+    }
   }
 
   /// A 1-element id list collapses to the single account's converted
@@ -82,14 +79,11 @@ struct AccountStoreAggregateBalanceTests {
       repository: backend.accounts,
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalances[account.id] != nil },
-      description: "balance converted")
-
-    let aggregate = try await store.aggregateBalance(
-      for: [account.id], in: .defaultTestInstrument)
-    let amount = try #require(aggregate)
-    #expect(amount.quantity == dec("400.00"))
+    await expectEventually("single-account aggregate settles to 400.00") {
+      let aggregate = try? await store.aggregateBalance(
+        for: [account.id], in: .defaultTestInstrument)
+      return aggregate?.quantity == dec("400.00")
+    }
   }
 
   /// Empty id list returns nil — the caller renders an "unavailable"

--- a/MoolahTests/Features/AccountStoreApplyDeltaTests.swift
+++ b/MoolahTests/Features/AccountStoreApplyDeltaTests.swift
@@ -27,8 +27,10 @@ struct AccountStoreApplyDeltaTests {
     let deltas: PositionDeltas = [acctId: [instrument: Decimal(-5000) / 100]]
     await store.applyDelta(deltas)
 
-    let balance = try await store.displayBalance(for: acctId)
-    #expect(balance.quantity == Decimal(95000) / 100)
+    await expectEventually("balance settles to reduced amount") {
+      let balance = try? await store.displayBalance(for: acctId)
+      return balance?.quantity == Decimal(95000) / 100
+    }
   }
 
   @Test
@@ -49,8 +51,10 @@ struct AccountStoreApplyDeltaTests {
     let deltas: PositionDeltas = [acctId: [instrument: Decimal(50000) / 100]]
     await store.applyDelta(deltas)
 
-    let balance = try await store.displayBalance(for: acctId)
-    #expect(balance.quantity == Decimal(150000) / 100)
+    await expectEventually("balance settles to increased amount") {
+      let balance = try? await store.displayBalance(for: acctId)
+      return balance?.quantity == Decimal(150000) / 100
+    }
   }
 
   @Test
@@ -77,10 +81,12 @@ struct AccountStoreApplyDeltaTests {
     ]
     await store.applyDelta(deltas)
 
-    let checking = try await store.displayBalance(for: checkingId)
-    let savings = try await store.displayBalance(for: savingsId)
-    #expect(checking.quantity == Decimal(90000) / 100)
-    #expect(savings.quantity == Decimal(210000) / 100)
+    await expectEventually("both account balances settle to deltas") {
+      let checking = try? await store.displayBalance(for: checkingId)
+      let savings = try? await store.displayBalance(for: savingsId)
+      return checking?.quantity == Decimal(90000) / 100
+        && savings?.quantity == Decimal(210000) / 100
+    }
   }
 
   @Test
@@ -98,13 +104,13 @@ struct AccountStoreApplyDeltaTests {
       description: "totals settle"
     )
 
-    #expect(store.convertedCurrentTotal?.quantity == Decimal(100000) / 100)
-
     let deltas: PositionDeltas = [checkingId: [instrument: Decimal(-5000) / 100]]
     await store.applyDelta(deltas)
 
-    #expect(store.convertedCurrentTotal?.quantity == Decimal(95000) / 100)
-    #expect(store.convertedNetWorth?.quantity == Decimal(95000) / 100)
+    await expectEventually("totals settle to post-delta amount") {
+      store.convertedCurrentTotal?.quantity == Decimal(95000) / 100
+        && store.convertedNetWorth?.quantity == Decimal(95000) / 100
+    }
   }
 
   @Test
@@ -134,8 +140,10 @@ struct AccountStoreApplyDeltaTests {
     let delta = BalanceDeltaCalculator.deltas(old: nil, new: transaction)
     await store.applyDelta(delta.accountDeltas)
 
-    let balance = try await store.displayBalance(for: acctId)
-    #expect(balance.quantity == Decimal(95000) / 100)
+    await expectEventually("balance settles after calculator-derived delta") {
+      let balance = try? await store.displayBalance(for: acctId)
+      return balance?.quantity == Decimal(95000) / 100
+    }
   }
 
   @Test
@@ -157,9 +165,11 @@ struct AccountStoreApplyDeltaTests {
     let deltas: PositionDeltas = [unknownId: [instrument: Decimal(-5000) / 100]]
     await store.applyDelta(deltas)
 
-    // Balance should be unchanged
-    let balance = try await store.displayBalance(for: acctId)
-    #expect(balance.quantity == Decimal(100000) / 100)
+    // Balance should be unchanged.
+    await expectEventually("known account balance stays unchanged") {
+      let balance = try? await store.displayBalance(for: acctId)
+      return balance?.quantity == Decimal(100000) / 100
+    }
   }
 
   // MARK: - Converted Totals
@@ -192,14 +202,10 @@ struct AccountStoreApplyDeltaTests {
       targetInstrument: instrument
     )
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedCurrentTotal?.quantity == Decimal(100000) / 100 },
-      description: "totals settle"
-    )
-
-    #expect(store.convertedCurrentTotal != nil)
-    #expect(store.convertedCurrentTotal?.quantity == Decimal(100000) / 100)
-    #expect(store.convertedNetWorth != nil)
+    await expectEventually("totals populate after first emission") {
+      store.convertedCurrentTotal?.quantity == Decimal(100000) / 100
+        && store.convertedNetWorth != nil
+    }
   }
 
   @Test
@@ -220,12 +226,12 @@ struct AccountStoreApplyDeltaTests {
       description: "totals settle"
     )
 
-    #expect(store.convertedCurrentTotal?.quantity == Decimal(100000) / 100)
-
     let deltas: PositionDeltas = [acctId: [instrument: Decimal(-5000) / 100]]
     await store.applyDelta(deltas)
 
-    #expect(store.convertedCurrentTotal?.quantity == Decimal(95000) / 100)
-    #expect(store.convertedNetWorth?.quantity == Decimal(95000) / 100)
+    await expectEventually("totals update after applyDelta") {
+      store.convertedCurrentTotal?.quantity == Decimal(95000) / 100
+        && store.convertedNetWorth?.quantity == Decimal(95000) / 100
+    }
   }
 }

--- a/MoolahTests/Features/AccountStoreConversionTests.swift
+++ b/MoolahTests/Features/AccountStoreConversionTests.swift
@@ -33,16 +33,13 @@ struct AccountStoreConversionTests {
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument
     )
-    try await store.waitForNextEmission(
-      matching: { !($0.positions(for: accountId).isEmpty) },
-      description: "positions are observed"
-    )
-
-    let positions = store.positions(for: accountId)
-    #expect(positions.count == 1)
-    #expect(positions.first?.instrument == .AUD)
-    // Quantity will be from storage (Int64 scaled), so compare with tolerance
-    #expect(positions.first?.quantity == dec("1000.00"))
+    // Quantity comes from storage (Int64 scaled); poll the settled snapshot.
+    await expectEventually("single AUD position settles") {
+      let positions = store.positions(for: accountId)
+      return positions.count == 1
+        && positions.first?.instrument == .AUD
+        && positions.first?.quantity == dec("1000.00")
+    }
   }
 
   @Test
@@ -83,21 +80,12 @@ struct AccountStoreConversionTests {
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument
     )
-    try await store.waitForNextEmission(
-      matching: { $0.positions(for: accountId).count == 2 },
-      description: "both positions observed"
-    )
-
-    let positions = store.positions(for: accountId)
-    #expect(positions.count == 2)
-    #expect(
-      positions.contains(where: {
-        $0.instrument == .AUD && $0.quantity == dec("1000.00")
-      }))
-    #expect(
-      positions.contains(where: {
-        $0.instrument == .USD && $0.quantity == dec("500.00")
-      }))
+    await expectEventually("both AUD and USD positions settle") {
+      let positions = store.positions(for: accountId)
+      return positions.count == 2
+        && positions.contains(where: { $0.instrument == .AUD && $0.quantity == dec("1000.00") })
+        && positions.contains(where: { $0.instrument == .USD && $0.quantity == dec("500.00") })
+    }
   }
 
   @Test
@@ -147,17 +135,13 @@ struct AccountStoreConversionTests {
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument
     )
-    try await store.waitForNextEmission(
-      matching: { $0.positions(for: accountId).count == 2 },
-      description: "both positions observed"
-    )
-
     // 1000 AUD + 500 USD converted to AUD (500 * 1.5385 = 769.25)
-    let total = try await store.computeConvertedCurrentTotal(in: .AUD)
     let expectedUsdInAud = dec("500.00") * dec("1.5385")
     let expected = dec("1000.00") + expectedUsdInAud
-    #expect(total.quantity == expected)
-    #expect(total.instrument == .AUD)
+    await expectEventually("converted total settles to AUD sum") {
+      let total = try? await store.computeConvertedCurrentTotal(in: .AUD)
+      return total?.quantity == expected && total?.instrument == .AUD
+    }
   }
 
   @Test

--- a/MoolahTests/Features/AccountStoreConversionTestsExtra.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsExtra.swift
@@ -40,15 +40,12 @@ struct AccountStoreConversionTestsExtra {
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument
     )
-    try await store.waitForNextEmission(
-      matching: { $0.positions(for: accountId).count == 2 },
-      description: "both fiat and stock positions observed"
-    )
-
-    let positions = store.positions(for: accountId)
-    #expect(positions.count == 2)
-    #expect(positions.contains { $0.instrument == .AUD })
-    #expect(positions.contains { $0.instrument == bhp })
+    await expectEventually("both fiat and stock positions settle") {
+      let positions = store.positions(for: accountId)
+      return positions.count == 2
+        && positions.contains { $0.instrument == .AUD }
+        && positions.contains { $0.instrument == bhp }
+    }
   }
 
   @Test
@@ -96,15 +93,11 @@ struct AccountStoreConversionTestsExtra {
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument
     )
-    try await store.waitForNextEmission(
-      matching: { $0.positions(for: accountId).count == 3 },
-      description: "all three kinds of positions observed"
-    )
-
-    let positions = store.positions(for: accountId)
-    #expect(positions.count == 3)
-    let kinds = Set(positions.map(\.instrument.kind))
-    #expect(kinds == [.fiatCurrency, .stock, .cryptoToken])
+    await expectEventually("fiat, stock and crypto positions all settle") {
+      let positions = store.positions(for: accountId)
+      return positions.count == 3
+        && Set(positions.map(\.instrument.kind)) == [.fiatCurrency, .stock, .cryptoToken]
+    }
   }
 
   // MARK: - displayBalance
@@ -140,15 +133,11 @@ struct AccountStoreConversionTestsExtra {
     let store = AccountStore(
       repository: backend.accounts, conversionService: conversion,
       targetInstrument: .AUD)
-    try await store.waitForNextEmission(
-      matching: { $0.positions(for: accountId).count == 2 },
-      description: "both positions observed"
-    )
-
-    let balance = try await store.displayBalance(for: accountId)
-    #expect(balance.instrument == .AUD)
     // 1000 AUD + 200 USD * 1.5 = 1300 AUD
-    #expect(balance.quantity == dec("1300.00"))
+    await expectEventually("display balance sums positions in AUD") {
+      let balance = try? await store.displayBalance(for: accountId)
+      return balance?.instrument == .AUD && balance?.quantity == dec("1300.00")
+    }
   }
 
   @Test
@@ -173,13 +162,9 @@ struct AccountStoreConversionTestsExtra {
       repository: backend.accounts,
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { !($0.positions(for: accountId).isEmpty) },
-      description: "position observed"
-    )
-
-    let balance = try await store.displayBalance(for: accountId)
-    #expect(balance.quantity == dec("750.00"))
-    #expect(balance.instrument == .defaultTestInstrument)
+    await expectEventually("single-currency display balance settles") {
+      let balance = try? await store.displayBalance(for: accountId)
+      return balance?.quantity == dec("750.00") && balance?.instrument == .defaultTestInstrument
+    }
   }
 }

--- a/MoolahTests/Features/AccountStoreConversionTestsMore.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMore.swift
@@ -29,21 +29,20 @@ struct AccountStoreConversionTestsMore {
     let store = AccountStore(
       repository: backend.accounts, conversionService: conversion,
       targetInstrument: .AUD)
-    try await store.waitForNextEmission(
-      matching: { !($0.positions(for: accountId).isEmpty) },
-      description: "USD position observed"
-    )
-
     // recordedValue + no snapshot → balance = 0 (positions are NOT a fallback).
-    let sumBalance = try await store.displayBalance(for: accountId)
-    #expect(sumBalance == .zero(instrument: .AUD))
+    await expectEventually("recorded-value balance settles to zero without snapshot") {
+      let sumBalance = try? await store.displayBalance(for: accountId)
+      return sumBalance == .zero(instrument: .AUD)
+    }
 
     // Investment value set externally → recorded mode uses the snapshot verbatim.
     let externalValue = InstrumentAmount(
       quantity: dec("999.00"), instrument: .AUD)
     await store.updateInvestmentValue(accountId: accountId, value: externalValue)
-    let override = try await store.displayBalance(for: accountId)
-    #expect(override == externalValue)
+    await expectEventually("recorded-value balance settles to the external value") {
+      let override = try? await store.displayBalance(for: accountId)
+      return override == externalValue
+    }
   }
 
   @Test
@@ -105,23 +104,16 @@ struct AccountStoreConversionTestsMore {
       retryDelay: .seconds(60))
 
     // After the first emission settles, the partial-failure state is
-    // observable: AUD bank has a balance, mixed bank does not, totals nil.
-    try await store.waitForNextEmission(
-      matching: {
-        $0.convertedBalances[bankAud.id] != nil
-          && $0.convertedBalances[bankMixed.id] == nil
-          && $0.convertedCurrentTotal == nil
-      },
-      description: "partial-failure state observable"
-    )
-
-    // AUD bank: only AUD positions → succeeds.
-    #expect(store.convertedBalances[bankAud.id]?.quantity == 1000)
-    // Mixed bank (EUR + USD): needs USD → EUR conversion which fails → nil.
-    #expect(store.convertedBalances[bankMixed.id] == nil)
-    // Aggregate cannot be accurate with a missing unit → nil.
-    #expect(store.convertedCurrentTotal == nil)
-    #expect(store.convertedNetWorth == nil)
+    // observable:
+    //   - AUD bank (only AUD positions) → succeeds with quantity 1000.
+    //   - Mixed bank (EUR + USD) → needs USD→EUR which fails → nil.
+    //   - Aggregate totals cannot be accurate with a missing unit → nil.
+    await expectEventually("partial-failure state settles") {
+      store.convertedBalances[bankAud.id]?.quantity == 1000
+        && store.convertedBalances[bankMixed.id] == nil
+        && store.convertedCurrentTotal == nil
+        && store.convertedNetWorth == nil
+    }
   }
 
   /// After the conversion service recovers, a retry populates the
@@ -171,10 +163,12 @@ struct AccountStoreConversionTestsMore {
     await store.waitForPendingConversions()
 
     // 1000 AUD + 500 EUR (1:1 fallback) = 1500 AUD
-    #expect(store.convertedCurrentTotal?.quantity == 1500)
-    #expect(store.convertedNetWorth?.quantity == 1500)
-    #expect(store.convertedBalances[bankAud.id]?.quantity == 1000)
-    #expect(store.convertedBalances[bankEur.id]?.quantity == 500)
+    await expectEventually("retry repopulates balances and totals") {
+      store.convertedCurrentTotal?.quantity == 1500
+        && store.convertedNetWorth?.quantity == 1500
+        && store.convertedBalances[bankAud.id]?.quantity == 1000
+        && store.convertedBalances[bankEur.id]?.quantity == 500
+    }
   }
   /// Regression for #96: `computeConvertedInvestmentTotal` must not route
   /// through `displayBalance` (which converts every position to the

--- a/MoolahTests/Features/AccountStoreConversionTestsMore.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMore.swift
@@ -29,20 +29,25 @@ struct AccountStoreConversionTestsMore {
     let store = AccountStore(
       repository: backend.accounts, conversionService: conversion,
       targetInstrument: .AUD)
+    // This wait is a load-bearing ORDERING BARRIER (not a read-gate): it ensures
+    // the initial observeAll snapshot has landed before `updateInvestmentValue`,
+    // so a late initial emission can't clobber the externally-set snapshot back
+    // to zero. Do NOT replace it with a value poll.
+    try await store.waitForNextEmission(
+      matching: { !($0.positions(for: accountId).isEmpty) },
+      description: "USD position observed"
+    )
+
     // recordedValue + no snapshot → balance = 0 (positions are NOT a fallback).
-    await expectEventually("recorded-value balance settles to zero without snapshot") {
-      let sumBalance = try? await store.displayBalance(for: accountId)
-      return sumBalance == .zero(instrument: .AUD)
-    }
+    let sumBalance = try await store.displayBalance(for: accountId)
+    #expect(sumBalance == .zero(instrument: .AUD))
 
     // Investment value set externally → recorded mode uses the snapshot verbatim.
     let externalValue = InstrumentAmount(
       quantity: dec("999.00"), instrument: .AUD)
     await store.updateInvestmentValue(accountId: accountId, value: externalValue)
-    await expectEventually("recorded-value balance settles to the external value") {
-      let override = try? await store.displayBalance(for: accountId)
-      return override == externalValue
-    }
+    let override = try await store.displayBalance(for: accountId)
+    #expect(override == externalValue)
   }
 
   @Test

--- a/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
@@ -127,15 +127,11 @@ struct AccountStoreConversionTestsMoreExtra {
       repository: backend.accounts,
       conversionService: conversion,
       targetInstrument: .USD)
-    try await store.waitForNextEmission(
-      matching: { $0.positions(for: accountId).count == 2 },
-      description: "both positions observed"
-    )
-
-    let total = try await store.computeConvertedInvestmentTotal(in: .USD)
-    #expect(total.instrument == .USD)
     // Single-pass: 100 USD + (1000 AUD * 0.67) = 100 + 670 = 770 USD
-    #expect(total.quantity == dec("770.00"))
+    await expectEventually("single-pass investment total settles to 770 USD") {
+      let total = try? await store.computeConvertedInvestmentTotal(in: .USD)
+      return total?.instrument == .USD && total?.quantity == dec("770.00")
+    }
   }
 
   /// When an investment account has an externally-supplied value (e.g. from
@@ -180,10 +176,11 @@ struct AccountStoreConversionTestsMoreExtra {
       quantity: dec("2000.00"), instrument: .AUD)
     await store.updateInvestmentValue(accountId: accountId, value: externalValue)
 
-    let total = try await store.computeConvertedInvestmentTotal(in: .USD)
     // 2000 AUD -> USD at 0.5 = 1000 USD (external value converted once)
-    #expect(total.instrument == .USD)
-    #expect(total.quantity == dec("1000.00"))
+    await expectEventually("external value converts once to 1000 USD") {
+      let total = try? await store.computeConvertedInvestmentTotal(in: .USD)
+      return total?.instrument == .USD && total?.quantity == dec("1000.00")
+    }
   }
 
   /// Same-instrument positions and target must hit the fast path without
@@ -216,14 +213,9 @@ struct AccountStoreConversionTestsMoreExtra {
       repository: backend.accounts,
       conversionService: backend.conversionService,
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { !($0.positions(for: accountId).isEmpty) },
-      description: "position observed"
-    )
-
-    let total = try await store.computeConvertedInvestmentTotal(
-      in: .defaultTestInstrument)
-    #expect(total.instrument == .defaultTestInstrument)
-    #expect(total.quantity == dec("1234.56"))
+    await expectEventually("fast-path total settles to the raw position sum") {
+      let total = try? await store.computeConvertedInvestmentTotal(in: .defaultTestInstrument)
+      return total?.instrument == .defaultTestInstrument && total?.quantity == dec("1234.56")
+    }
   }
 }

--- a/MoolahTests/Features/AccountStoreInvestmentValuesTests.swift
+++ b/MoolahTests/Features/AccountStoreInvestmentValuesTests.swift
@@ -41,13 +41,10 @@ struct AccountStoreInvestmentValuesTests {
       targetInstrument: instrument,
       investmentRepository: backend.investments)
 
-    try await store.waitForNextEmission(
-      matching: { $0.investmentValues[acctId] != nil },
-      description: "investmentValues populated"
-    )
-
-    #expect(store.investmentValues[acctId]?.quantity == Decimal(250000) / 100)
-    #expect(store.convertedBalances[acctId]?.quantity == Decimal(250000) / 100)
+    await expectEventually("latest investment value preloads into value and balance") {
+      store.investmentValues[acctId]?.quantity == Decimal(250000) / 100
+        && store.convertedBalances[acctId]?.quantity == Decimal(250000) / 100
+    }
   }
 
   @Test("first emission with recordedValue and no snapshot yields zero balance")
@@ -64,16 +61,13 @@ struct AccountStoreInvestmentValuesTests {
       targetInstrument: .defaultTestInstrument,
       investmentRepository: backend.investments)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalances[acctId] != nil },
-      description: "balance is published (zero)"
-    )
-
     // `recordedValue` (default) + no snapshot → balance = 0. Position sum is
     // intentionally not used as a fallback; see `displayBalance` in
     // `AccountBalanceCalculator`.
-    #expect(store.investmentValues[acctId] == nil)
-    #expect(store.convertedBalances[acctId]?.quantity == 0)
+    await expectEventually("balance settles to zero with no investment value") {
+      store.investmentValues[acctId] == nil
+        && store.convertedBalances[acctId]?.quantity == 0
+    }
   }
 
   @Test("first emission with calculatedFromTrades sums positions when no snapshot exists")
@@ -90,13 +84,10 @@ struct AccountStoreInvestmentValuesTests {
       targetInstrument: .defaultTestInstrument,
       investmentRepository: backend.investments)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalances[acctId]?.quantity == Decimal(100000) / 100 },
-      description: "position-derived balance"
-    )
-
-    #expect(store.investmentValues[acctId] == nil)
-    #expect(store.convertedBalances[acctId]?.quantity == Decimal(100000) / 100)
+    await expectEventually("position-derived balance settles, no recorded value") {
+      store.investmentValues[acctId] == nil
+        && store.convertedBalances[acctId]?.quantity == Decimal(100000) / 100
+    }
   }
 
   // MARK: - updateInvestmentValue
@@ -119,9 +110,10 @@ struct AccountStoreInvestmentValuesTests {
 
     let account = try #require(store.accounts.first)
     await store.updateInvestmentValue(accountId: account.id, value: newValue)
-    #expect(store.investmentValues[account.id] == newValue)
-    let balance = try await store.displayBalance(for: account.id)
-    #expect(balance == newValue)
+    await expectEventually("investment value and display balance settle to newValue") {
+      let balance = try? await store.displayBalance(for: account.id)
+      return store.investmentValues[account.id] == newValue && balance == newValue
+    }
   }
 
   @Test
@@ -143,12 +135,14 @@ struct AccountStoreInvestmentValuesTests {
     await store.updateInvestmentValue(accountId: account.id, value: investmentValue)
     await store.updateInvestmentValue(accountId: account.id, value: nil)
 
-    #expect(store.investmentValues[account.id] == nil)
     // recordedValue (default) + cleared snapshot → balance = 0 (no fallback to
     // positions). The position sum would be 1000.00 if the account were in
     // calculatedFromTrades mode; see `loadCalculatedFromTradesUsesPositionsWhenSnapshotMissing`.
-    let balance = try await store.displayBalance(for: account.id)
-    #expect(balance == .zero(instrument: .defaultTestInstrument))
+    await expectEventually("cleared value settles to nil and zero balance") {
+      let balance = try? await store.displayBalance(for: account.id)
+      return store.investmentValues[account.id] == nil
+        && balance == .zero(instrument: .defaultTestInstrument)
+    }
   }
 
   @Test
@@ -168,9 +162,10 @@ struct AccountStoreInvestmentValuesTests {
       quantity: Decimal(150000) / 100, instrument: Instrument.defaultTestInstrument)
     await store.updateInvestmentValue(accountId: UUID(), value: newValue)
 
-    // Should not affect existing accounts
-    #expect(store.accounts.count == 1)
-    #expect(store.investmentValues.isEmpty)
+    // Should not affect existing accounts.
+    await expectEventually("unknown-account update leaves state untouched") {
+      store.accounts.count == 1 && store.investmentValues.isEmpty
+    }
   }
 
   // MARK: - Display Balance
@@ -194,8 +189,10 @@ struct AccountStoreInvestmentValuesTests {
       quantity: Decimal(150000) / 100, instrument: Instrument.defaultTestInstrument)
     await store.updateInvestmentValue(accountId: acctId, value: investmentValue)
 
-    let balance = try await store.displayBalance(for: acctId)
-    #expect(balance == investmentValue)
+    await expectEventually("display balance settles to the investment value") {
+      let balance = try? await store.displayBalance(for: acctId)
+      return balance == investmentValue
+    }
   }
 
   @Test
@@ -206,12 +203,9 @@ struct AccountStoreInvestmentValuesTests {
     let store = AccountStore(
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.by(id: acctId) != nil },
-      description: "seeded account observed"
-    )
-
-    #expect(store.canDelete(acctId))
+    await expectEventually("seeded empty account can be deleted") {
+      store.canDelete(acctId)
+    }
   }
 
   @Test
@@ -223,11 +217,8 @@ struct AccountStoreInvestmentValuesTests {
     let store = AccountStore(
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { ($0.accounts.by(id: acctId)?.positions.isEmpty == false) },
-      description: "seeded account with positions observed"
-    )
-
-    #expect(!store.canDelete(acctId))
+    await expectEventually("account with positions cannot be deleted") {
+      store.accounts.by(id: acctId)?.positions.isEmpty == false && !store.canDelete(acctId)
+    }
   }
 }

--- a/MoolahTests/Features/AccountStoreLoadingTests.swift
+++ b/MoolahTests/Features/AccountStoreLoadingTests.swift
@@ -16,13 +16,9 @@ struct AccountStoreLoadingTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 1 },
-      description: "seeded account is observed"
-    )
-
-    #expect(store.accounts.count == 1)
-    #expect(store.accounts.first?.name == "Checking")
+    await expectEventually("seeded account populates the store") {
+      store.accounts.count == 1 && store.accounts.first?.name == "Checking"
+    }
   }
 
   @Test
@@ -36,14 +32,11 @@ struct AccountStoreLoadingTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 2 },
-      description: "both seeded accounts are observed"
-    )
-
-    #expect(store.accounts.count == 2)
-    #expect(store.accounts[0].name == "A2")
-    #expect(store.accounts[1].name == "A1")
+    await expectEventually("accounts settle sorted by position") {
+      store.accounts.count == 2
+        && store.accounts[0].name == "A2"
+        && store.accounts[1].name == "A1"
+    }
   }
 
   @Test
@@ -68,24 +61,18 @@ struct AccountStoreLoadingTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedNetWorth?.quantity == Decimal(2_550_000) / 100 },
-      description: "totals settle"
-    )
-
-    #expect(
+    // currentTotal = 100000 + 500000 - 50000 = 550000 (hidden excluded)
+    await expectEventually("all three totals settle to expected amounts") {
       store.convertedCurrentTotal
         == InstrumentAmount(
-          quantity: Decimal(550000) / 100, instrument: Instrument.defaultTestInstrument))  // 100000 + 500000 - 50000
-    #expect(
-      store.convertedInvestmentTotal
-        == InstrumentAmount(
-          quantity: Decimal(2_000_000) / 100, instrument: Instrument.defaultTestInstrument))
-    #expect(
-      store.convertedNetWorth
-        == InstrumentAmount(
-          quantity: Decimal(2_550_000) / 100, instrument: Instrument.defaultTestInstrument)
-    )
+          quantity: Decimal(550000) / 100, instrument: Instrument.defaultTestInstrument)
+        && store.convertedInvestmentTotal
+          == InstrumentAmount(
+            quantity: Decimal(2_000_000) / 100, instrument: Instrument.defaultTestInstrument)
+        && store.convertedNetWorth
+          == InstrumentAmount(
+            quantity: Decimal(2_550_000) / 100, instrument: Instrument.defaultTestInstrument)
+    }
   }
 
   @Test
@@ -106,17 +93,12 @@ struct AccountStoreLoadingTests {
     let store = AccountStore(
       repository: backend.accounts, conversionService: conversion, targetInstrument: aud)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedCurrentTotal?.quantity == Decimal(240_000) / 100 },
-      description: "totals settle"
-    )
-
     // 1_000.00 AUD + (500.00 USD * 2) + (200.00 USD * 2) = 1_000 + 1_000 + 400 = 2_400.00
-    #expect(
+    await expectEventually("mixed-instrument totals settle to 2400.00 AUD") {
       store.convertedCurrentTotal
-        == InstrumentAmount(quantity: Decimal(240_000) / 100, instrument: aud))
-    #expect(
-      store.convertedNetWorth
-        == InstrumentAmount(quantity: Decimal(240_000) / 100, instrument: aud))
+        == InstrumentAmount(quantity: Decimal(240_000) / 100, instrument: aud)
+        && store.convertedNetWorth
+          == InstrumentAmount(quantity: Decimal(240_000) / 100, instrument: aud)
+    }
   }
 }

--- a/MoolahTests/Features/AccountStoreMutationsTests.swift
+++ b/MoolahTests/Features/AccountStoreMutationsTests.swift
@@ -20,13 +20,9 @@ struct AccountStoreMutationsTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 2 },
-      description: "both seeded accounts are observed"
-    )
-
-    #expect(store.currentAccounts.count == 1)
-    #expect(store.currentAccounts[0].name == "Visible")
+    await expectEventually("only the visible account is current") {
+      store.currentAccounts.count == 1 && store.currentAccounts.first?.name == "Visible"
+    }
   }
 
   @Test("currentAccounts includes hidden accounts when showHidden is true")
@@ -46,7 +42,9 @@ struct AccountStoreMutationsTests {
     )
     store.showHidden = true
 
-    #expect(store.currentAccounts.count == 2)
+    await expectEventually("both accounts current once hidden shown") {
+      store.currentAccounts.count == 2
+    }
   }
 
   @Test("investmentAccounts respects showHidden flag")
@@ -61,14 +59,13 @@ struct AccountStoreMutationsTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 2 },
-      description: "both seeded accounts are observed"
-    )
-
-    #expect(store.investmentAccounts.count == 1)
+    await expectEventually("visible-only investment accounts count is 1") {
+      store.investmentAccounts.count == 1
+    }
     store.showHidden = true
-    #expect(store.investmentAccounts.count == 2)
+    await expectEventually("investment accounts count is 2 with hidden shown") {
+      store.investmentAccounts.count == 2
+    }
   }
 
   @Test("convertedCurrentTotal refreshes when showHidden toggles to include hidden accounts")
@@ -114,19 +111,14 @@ struct AccountStoreMutationsTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    // `waitForFirstEmission()` would race the rate-tick recompute (which
+    // Poll the asserted snapshot directly: the rate-tick recompute (which
     // `FixedConversionService.observeRates()` fires synchronously on
-    // subscription) against the accounts observation — the first tick
-    // can arrive before `apply(accounts:)` has run, so `store.accounts`
-    // is still empty. Predicate-match on the accounts snapshot to wait
-    // for the emission that actually carries the seeded rows, mirroring
-    // the other tests in this suite.
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 2 },
-      description: "both seeded accounts are observed"
-    )
-
-    #expect(store.investmentAccounts.map(\.name).sorted() == ["Brokerage", "ETH Wallet"])
+    // subscription) can race the accounts observation, so an early tick can
+    // land before `apply(accounts:)` has run. Polling the final condition
+    // closes that window instead of reading once after a single emission.
+    await expectEventually("both brokerage and crypto appear in investmentAccounts") {
+      store.investmentAccounts.map(\.name).sorted() == ["Brokerage", "ETH Wallet"]
+    }
   }
 
   // MARK: - Instrument Persistence
@@ -147,11 +139,9 @@ struct AccountStoreMutationsTests {
 
     #expect(created.instrument.id == usdInstrument.id)
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.first?.instrument.id == usdInstrument.id },
-      description: "store sees created account with USD instrument"
-    )
-    #expect(store.accounts.first?.instrument.id == usdInstrument.id)
+    await expectEventually("store sees created account with USD instrument") {
+      store.accounts.first?.instrument.id == usdInstrument.id
+    }
 
     let fetched = try await backend.accounts.fetchAll()
     #expect(fetched.first?.instrument.id == usdInstrument.id)
@@ -175,15 +165,11 @@ struct AccountStoreMutationsTests {
 
     let created = try await store.create(account)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalances[created.id] != nil },
-      description: "convertedBalance for new account is populated"
-    )
-
-    let balance = store.convertedBalances[created.id]
-    #expect(balance != nil)
-    #expect(balance?.quantity == 0)
-    #expect(balance?.instrument.id == Instrument.defaultTestInstrument.id)
+    await expectEventually("convertedBalance for new account is zero in its instrument") {
+      let balance = store.convertedBalances[created.id]
+      return balance?.quantity == 0
+        && balance?.instrument.id == Instrument.defaultTestInstrument.id
+    }
   }
 
   @Test
@@ -235,13 +221,9 @@ struct AccountStoreMutationsTests {
     // Reverse order: C, B, A
     await store.reorderAccounts([third, second, first])
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.ordered.map(\.name) == ["C", "B", "A"] },
-      description: "store sees reordered accounts"
-    )
-
-    #expect(store.error == nil)
-    #expect(store.accounts.ordered.map(\.name) == ["C", "B", "A"])
+    await expectEventually("store sees reordered accounts with no error") {
+      store.error == nil && store.accounts.ordered.map(\.name) == ["C", "B", "A"]
+    }
 
     let persisted = try await backend.accounts.fetchAll().sorted { $0.position < $1.position }
     #expect(persisted.map(\.name) == ["C", "B", "A"])
@@ -263,11 +245,9 @@ struct AccountStoreMutationsTests {
     let store = AccountStore(
       repository: repository, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 2 },
-      description: "initial accounts observed"
-    )
-    #expect(store.accounts.ordered.map(\.name) == ["A", "B"])
+    await expectEventually("initial accounts observed in order") {
+      store.accounts.ordered.map(\.name) == ["A", "B"]
+    }
 
     // Start failing repository updates.
     repository.shouldFail = true

--- a/MoolahTests/Features/AccountStorePreloadFilterTests.swift
+++ b/MoolahTests/Features/AccountStorePreloadFilterTests.swift
@@ -29,13 +29,9 @@ struct AccountStorePreloadFilterTests {
       conversionService: FixedConversionService(),
       targetInstrument: .AUD,
       investmentRepository: backend.investments)
-    try await store.waitForNextEmission(
-      matching: { $0.investmentValues[recorded.id] != nil },
-      description: "investment values preloaded"
-    )
-
-    #expect(store.investmentValues[recorded.id] != nil)
-    #expect(store.investmentValues[trades.id] == nil)
+    await expectEventually("only recordedValue account is preloaded") {
+      store.investmentValues[recorded.id] != nil && store.investmentValues[trades.id] == nil
+    }
   }
 
   @Test("crypto accounts are never preloaded into the investment snapshot cache")
@@ -67,13 +63,9 @@ struct AccountStorePreloadFilterTests {
       conversionService: FixedConversionService(),
       targetInstrument: .AUD,
       investmentRepository: backend.investments)
-    try await store.waitForNextEmission(
-      matching: { $0.investmentValues[recorded.id] != nil },
-      description: "investment values preloaded"
-    )
-
-    #expect(store.investmentValues[recorded.id] != nil)
-    #expect(store.investmentValues[wallet.id] == nil)
+    await expectEventually("recorded account preloads but crypto wallet does not") {
+      store.investmentValues[recorded.id] != nil && store.investmentValues[wallet.id] == nil
+    }
   }
 
   @Test("flipping mode to recordedValue triggers a snapshot preload")
@@ -107,11 +99,8 @@ struct AccountStorePreloadFilterTests {
 
     // Wait for the observation to deliver the updated mode and trigger
     // the snapshot preload.
-    try await store.waitForNextEmission(
-      matching: { $0.investmentValues[account.id]?.quantity == 250 },
-      description: "snapshot preloaded after mode flip"
-    )
-
-    #expect(store.investmentValues[account.id]?.quantity == 250)
+    await expectEventually("snapshot preloads after mode flip to recordedValue") {
+      store.investmentValues[account.id]?.quantity == 250
+    }
   }
 }

--- a/MoolahTests/Features/AccountStoreRenameTests.swift
+++ b/MoolahTests/Features/AccountStoreRenameTests.swift
@@ -23,11 +23,9 @@ struct AccountStoreRenameTests {
     let result = try await store.rename(id: original.id, to: "New")
 
     #expect(result?.name == "New")
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.by(id: original.id)?.name == "New" },
-      description: "rename observed"
-    )
-    #expect(store.error == nil)
+    await expectEventually("rename reaches the store with no error") {
+      store.accounts.by(id: original.id)?.name == "New" && store.error == nil
+    }
     let fetched = try await backend.accounts.fetchAll()
     #expect(fetched.first(where: { $0.id == original.id })?.name == "New")
   }
@@ -73,7 +71,9 @@ struct AccountStoreRenameTests {
 
     // Returns the existing account unchanged; no write happens.
     #expect(result?.name == "Old")
-    #expect(store.accounts.by(id: original.id)?.name == "Old")
+    await expectEventually("store name stays Old after no-op rename") {
+      store.accounts.by(id: original.id)?.name == "Old"
+    }
   }
 
   @Test("rename to the same name is a no-op (no write, returns current)")
@@ -92,7 +92,9 @@ struct AccountStoreRenameTests {
     let result = try await store.rename(id: original.id, to: "Stable")
 
     #expect(result?.name == "Stable")
-    #expect(store.error == nil)
+    await expectEventually("no-op rename surfaces no error") {
+      store.error == nil
+    }
     let fetched = try await backend.accounts.fetchAll()
     #expect(fetched.first(where: { $0.id == original.id })?.name == "Stable")
   }
@@ -108,6 +110,8 @@ struct AccountStoreRenameTests {
     let result = try await store.rename(id: UUID(), to: "Whatever")
 
     #expect(result == nil)
-    #expect(store.error == nil)
+    await expectEventually("unknown-id rename surfaces no error") {
+      store.error == nil
+    }
   }
 }

--- a/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
@@ -33,11 +33,9 @@ struct AccountStoreSyncRefreshTests {
       openingBalance: nil
     )
 
-    try await store.waitForNextEmission(
-      matching: { $0.accounts.count == 1 },
-      description: "accounts.count == 1"
-    )
-    #expect(store.accounts.ordered.first?.name == "Synced")
+    await expectEventually("inserted account reaches the store") {
+      store.accounts.ordered.first?.name == "Synced"
+    }
   }
 
   @Test(
@@ -178,20 +176,17 @@ struct AccountStoreSyncRefreshTests {
     )
     _ = await transactionStore.create(transaction)
 
-    // Wait for the reactive observation to deliver the post-write state.
-    // The predicate checks that positions are non-empty (the -50 leg landed).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.isEmpty == false },
-      description: "account positions updated after transaction create"
-    )
-
-    // Read SYNCHRONOUSLY — no await. If applyDelta were still fanned out
-    // from TransactionStore, the position would be -100 (observation applied
-    // -50, then applyDelta applied another -50 on top). Under the reactive-only
-    // design, observation is the single source of truth and the value is -50.
-    let positions = accountStore.accounts.by(id: accountId)?.positions ?? []
-    let qty = positions.first(where: { $0.instrument == .defaultTestInstrument })?.quantity
-    #expect(qty == Decimal(-5000) / 100)
+    // The reactive observation is the single source of truth: the -50 leg
+    // settles the position to -50. If applyDelta were still fanned out from
+    // TransactionStore, the steady-state position would be -100 (observation
+    // applied -50, then applyDelta applied another -50 on top) and this poll
+    // would never satisfy. Polling the asserted value closes the read-once
+    // race where a concurrent observation pass momentarily replaces state.
+    await expectEventually("account position settles to -50 (no double-apply)") {
+      let positions = accountStore.accounts.by(id: accountId)?.positions ?? []
+      let qty = positions.first(where: { $0.instrument == .defaultTestInstrument })?.quantity
+      return qty == Decimal(-5000) / 100
+    }
   }
 
   @Test("AccountStore reflects InvestmentValue writes via observeAll")

--- a/MoolahTests/Features/Categories/CategoryStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Categories/CategoryStoreSyncRefreshTests.swift
@@ -28,11 +28,10 @@ struct CategoryStoreSyncRefreshTests {
       Moolah.Category(name: "Synced")
     )
 
-    try await store.waitForNextEmission(
-      matching: { $0.categories.roots.count == 1 },
-      description: "categories.roots.count == 1"
-    )
-    #expect(store.categories.roots.first?.name == "Synced")
+    await expectEventually("categories has one root named Synced") {
+      store.categories.roots.count == 1
+        && store.categories.roots.first?.name == "Synced"
+    }
   }
 
   @Test("stopObserving cancels the observation task")

--- a/MoolahTests/Features/Categories/CategoryStoreTests.swift
+++ b/MoolahTests/Features/Categories/CategoryStoreTests.swift
@@ -30,11 +30,10 @@ struct CategoryStoreTests {
 
     #expect(created != nil)
     #expect(created?.name == "Transport")
-    try await store.waitForNextEmission(
-      matching: { $0.categories.roots.count == 1 },
-      description: "categories.roots.count == 1"
-    )
-    #expect(store.categories.roots.first?.name == "Transport")
+    await expectEventually("categories has one root named Transport") {
+      store.categories.roots.count == 1
+        && store.categories.roots.first?.name == "Transport"
+    }
   }
 
   @Test
@@ -112,11 +111,10 @@ struct CategoryStoreTests {
     let success = await store.delete(id: cat1.id, withReplacement: cat2.id)
 
     #expect(success == true)
-    try await store.waitForNextEmission(
-      matching: { $0.categories.roots.count == 1 },
-      description: "categories collapsed to one"
-    )
-    #expect(store.categories.roots.first?.name == "New Category")
+    await expectEventually("categories collapsed to one named New Category") {
+      store.categories.roots.count == 1
+        && store.categories.roots.first?.name == "New Category"
+    }
   }
 
   @Test

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -117,12 +117,10 @@ struct CryptoAccountCreationStoreTests {
     // `accounts` only once the GRDB write commits and `observeAll()`
     // emits. Wait for that emission before asserting the store's view
     // of the world.
-    try await fixture.accountStore.waitForNextEmission(
-      matching: { $0.accounts.contains(where: { $0.id == created.id }) },
-      description: "newly-created crypto account observed in store"
-    )
-    #expect(fixture.accountStore.accounts.count == 1)
-    #expect(fixture.accountStore.accounts.first?.id == created.id)
+    await expectEventually("newly-created crypto account observed in store") {
+      fixture.accountStore.accounts.count == 1
+        && fixture.accountStore.accounts.first?.id == created.id
+    }
   }
 
   @Test(
@@ -306,11 +304,9 @@ struct CryptoAccountCreationStoreTests {
     // exists but was never handed to the logic, so the alchemy stub
     // saw no activity). AccountStore is reactive — wait for the
     // observation to deliver the new account before reading.
-    try await fixture.accountStore.waitForNextEmission(
-      matching: { $0.accounts.count == 1 },
-      description: "new account observable"
-    )
-    #expect(fixture.accountStore.accounts.count == 1)
+    await expectEventually("new account observable") {
+      fixture.accountStore.accounts.count == 1
+    }
     #expect(fixture.alchemy.recordedCalls.isEmpty)
   }
 }

--- a/MoolahTests/Features/EarmarkStoreConvertedBalanceTests.swift
+++ b/MoolahTests/Features/EarmarkStoreConvertedBalanceTests.swift
@@ -37,12 +37,9 @@ struct EarmarkStoreConvertedBalanceTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedTotalBalance?.quantity == 500 },
-      description: "converted total balance computed"
-    )
-
-    #expect(store.convertedTotalBalance?.quantity == 500)
+    await expectEventually("converted total balance computed") {
+      store.convertedTotalBalance?.quantity == 500
+    }
   }
 
   @Test
@@ -71,17 +68,13 @@ struct EarmarkStoreConvertedBalanceTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedTotalBalance?.quantity == 500 },
-      description: "converted balances computed"
-    )
-
-    // Individual balances should reflect true values
-    #expect(store.convertedBalance(for: positiveId)?.quantity == 500)
-    #expect(store.convertedBalance(for: negativeId)?.quantity == -18950)
-
-    // Total should clamp negative earmarks to 0, so total = 500 (not 500 - 18950)
-    #expect(store.convertedTotalBalance?.quantity == 500)
+    // Individual balances should reflect true values; the total should clamp
+    // negative earmarks to 0, so total = 500 (not 500 - 18950).
+    await expectEventually("balances settle with negative earmark clamped from the total") {
+      store.convertedBalance(for: positiveId)?.quantity == 500
+        && store.convertedBalance(for: negativeId)?.quantity == -18950
+        && store.convertedTotalBalance?.quantity == 500
+    }
   }
 
   @Test
@@ -113,7 +106,9 @@ struct EarmarkStoreConvertedBalanceTests {
       spentDeltas: [earmarkId: [instrument: 100]]
     )
 
-    #expect(store.convertedTotalBalance?.quantity == 400)
+    await expectEventually("converted total reflects the applied delta") {
+      store.convertedTotalBalance?.quantity == 400
+    }
   }
 
   // MARK: - Per-earmark converted amounts
@@ -137,14 +132,11 @@ struct EarmarkStoreConvertedBalanceTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: earmarkId)?.quantity == 500 },
-      description: "converted balance computed"
-    )
-
-    #expect(store.convertedBalance(for: earmarkId)?.quantity == 500)
-    #expect(store.convertedSaved(for: earmarkId)?.quantity == 500)
-    #expect(store.convertedSpent(for: earmarkId)?.quantity == 0)
+    await expectEventually("per-earmark converted balance, saved, and spent settle") {
+      store.convertedBalance(for: earmarkId)?.quantity == 500
+        && store.convertedSaved(for: earmarkId)?.quantity == 500
+        && store.convertedSpent(for: earmarkId)?.quantity == 0
+    }
   }
 
   @Test
@@ -176,7 +168,9 @@ struct EarmarkStoreConvertedBalanceTests {
       spentDeltas: [earmarkId: [instrument: 100]]
     )
 
-    #expect(store.convertedBalance(for: earmarkId)?.quantity == 400)
-    #expect(store.convertedSpent(for: earmarkId)?.quantity == 100)
+    await expectEventually("per-earmark balance and spent reflect the applied delta") {
+      store.convertedBalance(for: earmarkId)?.quantity == 400
+        && store.convertedSpent(for: earmarkId)?.quantity == 100
+    }
   }
 }

--- a/MoolahTests/Features/EarmarkStoreLoadTests.swift
+++ b/MoolahTests/Features/EarmarkStoreLoadTests.swift
@@ -19,13 +19,9 @@ struct EarmarkStoreLoadTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 1 },
-      description: "seeded earmark observed"
-    )
-
-    #expect(store.earmarks.count == 1)
-    #expect(store.earmarks.first?.name == "Holiday Fund")
+    await expectEventually("seeded earmark observed") {
+      store.earmarks.count == 1 && store.earmarks.first?.name == "Holiday Fund"
+    }
   }
 
   @Test
@@ -45,14 +41,11 @@ struct EarmarkStoreLoadTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 2 },
-      description: "both seeded earmarks observed"
-    )
-
-    #expect(store.earmarks.count == 2)
-    #expect(store.earmarks[0].name == "E2")
-    #expect(store.earmarks[1].name == "E1")
+    await expectEventually("earmarks observed sorted by position") {
+      store.earmarks.count == 2
+        && store.earmarks[0].name == "E2"
+        && store.earmarks[1].name == "E1"
+    }
   }
 
   @Test
@@ -77,13 +70,10 @@ struct EarmarkStoreLoadTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 2 },
-      description: "both seeded earmarks observed"
-    )
-
-    #expect(store.earmarks.count == 2)
-    #expect(store.earmarks[0].instrument == Instrument.defaultTestInstrument)
-    #expect(store.earmarks[1].instrument == Instrument.defaultTestInstrument)
+    await expectEventually("both earmarks observed with default instrument") {
+      store.earmarks.count == 2
+        && store.earmarks[0].instrument == Instrument.defaultTestInstrument
+        && store.earmarks[1].instrument == Instrument.defaultTestInstrument
+    }
   }
 }

--- a/MoolahTests/Features/EarmarkStoreMutationTests.swift
+++ b/MoolahTests/Features/EarmarkStoreMutationTests.swift
@@ -19,11 +19,9 @@ struct EarmarkStoreMutationTests {
 
     #expect(created != nil)
     #expect(created?.name == "New Fund")
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 1 },
-      description: "created earmark observed"
-    )
-    #expect(store.earmarks.first?.name == "New Fund")
+    await expectEventually("created earmark observed") {
+      store.earmarks.count == 1 && store.earmarks.first?.name == "New Fund"
+    }
   }
 
   @Test
@@ -52,12 +50,9 @@ struct EarmarkStoreMutationTests {
     let second = Earmark(name: "Second", instrument: .defaultTestInstrument)
     _ = await store.create(second)
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 2 },
-      description: "both created earmarks observed"
-    )
-    #expect(store.earmarks.by(id: first.id) != nil)
-    #expect(store.earmarks.by(id: second.id) != nil)
+    await expectEventually("both created earmarks observed") {
+      store.earmarks.by(id: first.id) != nil && store.earmarks.by(id: second.id) != nil
+    }
   }
 
   @Test
@@ -114,11 +109,10 @@ struct EarmarkStoreMutationTests {
     let result = await store.hide(earmark)
 
     #expect(result?.isHidden == true)
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.by(id: earmark.id)?.isHidden == true },
-      description: "hidden flag propagates via observation"
-    )
-    #expect(store.visibleEarmarks.contains(where: { $0.id == earmark.id }) == false)
+    await expectEventually("hidden flag propagates and removes the earmark from the visible list") {
+      store.earmarks.by(id: earmark.id)?.isHidden == true
+        && store.visibleEarmarks.contains(where: { $0.id == earmark.id }) == false
+    }
   }
 }
 

--- a/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
+++ b/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
@@ -72,17 +72,17 @@ struct EarmarkStorePartialConversionTests {
       retryDelay: .seconds(60))
 
     // The reactive store publishes the partial-failure state on the
-    // first emission; awaiting an emission where the healthy earmark's
-    // balance is populated is sufficient to assert convergence.
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: healthyEarmark.id)?.quantity == 300 },
-      description: "healthy earmark balance settled",
+    // first emission: the healthy earmark's balance populates while the
+    // mixed earmark (and therefore the aggregate total) stay nil. Poll the
+    // full post-condition so a racing recompute can't slip a stale read in.
+    await expectEventually(
+      "healthy earmark settles while the failing earmark and total stay nil",
       timeout: Self.convergenceTimeout
-    )
-
-    #expect(store.convertedBalance(for: healthyEarmark.id)?.quantity == 300)
-    #expect(store.convertedBalance(for: mixedEarmark.id) == nil)
-    #expect(store.convertedTotalBalance == nil)
+    ) {
+      store.convertedBalance(for: healthyEarmark.id)?.quantity == 300
+        && store.convertedBalance(for: mixedEarmark.id) == nil
+        && store.convertedTotalBalance == nil
+    }
   }
 
   /// After the conversion service recovers, a retry populates the
@@ -127,16 +127,16 @@ struct EarmarkStorePartialConversionTests {
     // Wait for the first conversion pass; since EUR fails we land in
     // the partial-failure state with a retry loop running in the
     // background.
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: audEarmark.id)?.quantity == 400 },
-      description: "AUD earmark balance settled",
+    // Aggregate cannot be computed (EUR → AUD fails) while the AUD earmark
+    // balance settles. Per-earmark balances are still displayed in their own
+    // currency where no conversion is needed.
+    await expectEventually(
+      "AUD earmark settles while the EUR failure keeps the total nil",
       timeout: Self.convergenceTimeout
-    )
-
-    // Aggregate cannot be computed (EUR → AUD fails). Per-earmark balances
-    // are still displayed in their own currency where no conversion is
-    // needed.
-    #expect(store.convertedTotalBalance == nil)
+    ) {
+      store.convertedBalance(for: audEarmark.id)?.quantity == 400
+        && store.convertedTotalBalance == nil
+    }
 
     // Recover the conversion service and wait for the retry loop to
     // succeed — `waitForPendingConversions()` returns when the loop
@@ -145,8 +145,10 @@ struct EarmarkStorePartialConversionTests {
     await store.waitForPendingConversions()
 
     // 400 AUD + 200 EUR (1:1 fallback) = 600 AUD
-    #expect(store.convertedTotalBalance?.quantity == 600)
-    #expect(store.convertedBalance(for: audEarmark.id)?.quantity == 400)
-    #expect(store.convertedBalance(for: eurEarmark.id)?.quantity == 200)
+    await expectEventually("recovered retry populates per-earmark balances and the total") {
+      store.convertedTotalBalance?.quantity == 600
+        && store.convertedBalance(for: audEarmark.id)?.quantity == 400
+        && store.convertedBalance(for: eurEarmark.id)?.quantity == 200
+    }
   }
 }

--- a/MoolahTests/Features/EarmarkStoreReorderTests.swift
+++ b/MoolahTests/Features/EarmarkStoreReorderTests.swift
@@ -28,19 +28,13 @@ struct EarmarkStoreReorderTests {
     // match an intermediate state where positions are not yet all
     // rewritten (two rows briefly share the same position, and the
     // sort-by-position tie-break happens to produce the expected name
-    // order). Pin both names AND positions so the predicate only
-    // matches the final, fully-settled emission.
-    try await store.waitForNextEmission(
-      matching: { store in
-        let visible = store.visibleEarmarks
-        return visible.map(\.name) == ["Third", "First", "Second"]
-          && visible.map(\.position) == [0, 1, 2]
-      },
-      description: "reorder propagates via observation with final positions"
-    )
-    #expect(store.visibleEarmarks[0].position == 0)
-    #expect(store.visibleEarmarks[1].position == 1)
-    #expect(store.visibleEarmarks[2].position == 2)
+    // order). Pin both names AND positions so the poll only settles on
+    // the final, fully-rewritten state.
+    await expectEventually("reorder settles with final names and positions") {
+      let visible = store.visibleEarmarks
+      return visible.map(\.name) == ["Third", "First", "Second"]
+        && visible.map(\.position) == [0, 1, 2]
+    }
   }
 
   @Test
@@ -61,19 +55,16 @@ struct EarmarkStoreReorderTests {
 
     await store.reorderEarmarks(from: IndexSet(integer: 1), to: 0)
 
-    // Pin both names AND positions so the predicate doesn't match an
+    // Pin both names AND positions so the poll doesn't settle on an
     // intermediate emission where two visible rows briefly share a
-    // position (see `testReorderEarmarksUpdatesPositions`).
-    try await store.waitForNextEmission(
-      matching: { store in
-        let visible = store.visibleEarmarks
-        return visible.map(\.name) == ["Visible2", "Visible1"]
-          && visible.map(\.position) == [0, 1]
-      },
-      description: "reorder propagates via observation with final positions"
-    )
-    let hiddenAfter = store.earmarks.ordered.first { $0.isHidden }
-    #expect(hiddenAfter?.position == 1)
+    // position (see `testReorderEarmarksUpdatesPositions`). The hidden
+    // earmark keeps its original position throughout.
+    await expectEventually("visible rows reorder while the hidden earmark stays put") {
+      let visible = store.visibleEarmarks
+      return visible.map(\.name) == ["Visible2", "Visible1"]
+        && visible.map(\.position) == [0, 1]
+        && store.earmarks.ordered.first(where: { $0.isHidden })?.position == 1
+    }
   }
 
   @Test

--- a/MoolahTests/Features/EarmarkStoreVisibilityTests.swift
+++ b/MoolahTests/Features/EarmarkStoreVisibilityTests.swift
@@ -31,13 +31,9 @@ struct EarmarkStoreVisibilityTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 2 },
-      description: "both seeded earmarks observed"
-    )
-
-    #expect(store.visibleEarmarks.count == 1)
-    #expect(store.visibleEarmarks[0].name == "Visible")
+    await expectEventually("only the visible earmark is listed") {
+      store.visibleEarmarks.count == 1 && store.visibleEarmarks[0].name == "Visible"
+    }
   }
 
   @Test("visibleEarmarks includes hidden earmarks when showHidden is true")
@@ -69,7 +65,9 @@ struct EarmarkStoreVisibilityTests {
     )
     store.showHidden = true
 
-    #expect(store.visibleEarmarks.count == 2)
+    await expectEventually("both earmarks visible once showHidden is on") {
+      store.visibleEarmarks.count == 2
+    }
   }
 
   @Test("convertedBalance is populated for hidden earmarks even when showHidden is false")
@@ -99,13 +97,9 @@ struct EarmarkStoreVisibilityTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: hidden.id) != nil },
-      description: "hidden earmark balance populated despite showHidden=false"
-    )
-
-    let hiddenBalance = try #require(store.convertedBalance(for: hidden.id))
-    #expect(hiddenBalance.quantity == 300)
+    await expectEventually("hidden earmark balance populated despite showHidden=false") {
+      store.convertedBalance(for: hidden.id)?.quantity == 300
+    }
   }
 
   @Test("convertedTotalBalance refreshes when showHidden toggles to include hidden earmarks")
@@ -166,11 +160,9 @@ struct EarmarkStoreVisibilityTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .USD)
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 1 },
-      description: "seeded earmark observed"
-    )
-    #expect(store.earmarks.first?.instrument == .USD)
+    await expectEventually("seeded USD earmark observed with USD instrument") {
+      store.earmarks.count == 1 && store.earmarks.first?.instrument == .USD
+    }
   }
 
   @Test("Earmarks created with different instruments round-trip through repository")
@@ -213,14 +205,10 @@ struct EarmarkStoreVisibilityTests {
       conversionService: FixedConversionService(rates: ["AUD": 2]),
       targetInstrument: aud)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: earmarkId)?.quantity == 1000 },
-      description: "USD balance settled"
-    )
-
-    let balance = try #require(store.convertedBalance(for: earmarkId))
-    #expect(balance.instrument == usd)
-    #expect(balance.quantity == 1000)
+    await expectEventually("USD balance settled in USD instrument") {
+      let balance = store.convertedBalance(for: earmarkId)
+      return balance?.instrument == usd && balance?.quantity == 1000
+    }
   }
 
   @Test("Updating earmark instrument re-expresses its converted balance in the new currency")
@@ -244,13 +232,10 @@ struct EarmarkStoreVisibilityTests {
       repository: backend.earmarks,
       conversionService: FixedConversionService(rates: ["AUD": 2]),
       targetInstrument: aud)
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: earmarkId)?.quantity == 400 },
-      description: "AUD balance settled"
-    )
-
-    let before = try #require(store.convertedBalance(for: earmarkId))
-    #expect(before.instrument == aud)
+    await expectEventually("AUD balance settled in AUD instrument") {
+      let balance = store.convertedBalance(for: earmarkId)
+      return balance?.quantity == 400 && balance?.instrument == aud
+    }
 
     let current = try #require(store.earmarks.by(id: earmarkId))
     var changed = current
@@ -258,11 +243,9 @@ struct EarmarkStoreVisibilityTests {
     let updated = await store.update(changed)
     #expect(updated?.instrument == usd)
 
-    try await store.waitForNextEmission(
-      matching: { $0.convertedBalance(for: earmarkId)?.instrument == usd },
-      description: "USD-instrument re-expression observed"
-    )
-    let after = try #require(store.convertedBalance(for: earmarkId))
-    #expect(after.quantity == 800)
+    await expectEventually("USD-instrument re-expression settled at 800") {
+      let balance = store.convertedBalance(for: earmarkId)
+      return balance?.instrument == usd && balance?.quantity == 800
+    }
   }
 }

--- a/MoolahTests/Features/Earmarks/EarmarkStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Earmarks/EarmarkStoreSyncRefreshTests.swift
@@ -32,11 +32,9 @@ struct EarmarkStoreSyncRefreshTests {
       Earmark(name: "Synced", instrument: .defaultTestInstrument)
     )
 
-    try await store.waitForNextEmission(
-      matching: { $0.earmarks.count == 1 },
-      description: "earmarks.count == 1"
-    )
-    #expect(store.earmarks.ordered.first?.name == "Synced")
+    await expectEventually("remote insert refreshes the store with the synced earmark") {
+      store.earmarks.count == 1 && store.earmarks.ordered.first?.name == "Synced"
+    }
   }
 
   @Test("stopObserving cancels the observation task")

--- a/MoolahTests/Features/GroupUIStateStoreTests.swift
+++ b/MoolahTests/Features/GroupUIStateStoreTests.swift
@@ -25,12 +25,9 @@ struct GroupUIStateStoreTests {
         name: "G", bucket: .investments, instrument: .defaultTestInstrument))
 
     await store.setExpanded(true, for: group.id)
-    try await store.waitForNextEmission(
-      matching: { $0.expandedGroupIds.contains(group.id) },
-      description: "expanded observed")
-
-    #expect(store.expandedGroupIds == [group.id])
-    #expect(store.error == nil)
+    await expectEventually("expanded set is exactly the group with no error") {
+      store.expandedGroupIds == [group.id] && store.error == nil
+    }
   }
 
   @Test("setExpanded(false) removes from the snapshot")
@@ -49,11 +46,9 @@ struct GroupUIStateStoreTests {
       description: "expanded observed")
 
     await store.setExpanded(false, for: group.id)
-    try await store.waitForNextEmission(
-      matching: { $0.expandedGroupIds.isEmpty },
-      description: "collapsed observed")
-
-    #expect(store.expandedGroupIds.isEmpty)
+    await expectEventually("collapse removes the group from the snapshot") {
+      store.expandedGroupIds.isEmpty
+    }
   }
 
   @Test("toggle flips the expand state")
@@ -67,16 +62,14 @@ struct GroupUIStateStoreTests {
         name: "G", bucket: .investments, instrument: .defaultTestInstrument))
 
     await store.toggle(group.id)
-    try await store.waitForNextEmission(
-      matching: { $0.expandedGroupIds.contains(group.id) },
-      description: "toggle to expanded")
-    #expect(store.expandedGroupIds == [group.id])
+    await expectEventually("toggle expands to exactly the group") {
+      store.expandedGroupIds == [group.id]
+    }
 
     await store.toggle(group.id)
-    try await store.waitForNextEmission(
-      matching: { $0.expandedGroupIds.isEmpty },
-      description: "toggle to collapsed")
-    #expect(store.expandedGroupIds.isEmpty)
+    await expectEventually("toggle collapses back to empty") {
+      store.expandedGroupIds.isEmpty
+    }
   }
 
   @Test("multiple expanded groups all appear in the snapshot")
@@ -96,11 +89,9 @@ struct GroupUIStateStoreTests {
 
     await store.setExpanded(true, for: groupA.id)
     await store.setExpanded(true, for: groupB.id)
-    try await store.waitForNextEmission(
-      matching: { $0.expandedGroupIds.count == 2 },
-      description: "both observed")
-
-    #expect(store.expandedGroupIds == [groupA.id, groupB.id])
+    await expectEventually("both groups appear in the snapshot") {
+      store.expandedGroupIds == [groupA.id, groupB.id]
+    }
   }
 
   @Test("deleting a group reaps its expand state through the cascade")
@@ -119,10 +110,8 @@ struct GroupUIStateStoreTests {
       description: "expanded observed")
 
     try await backend.accountGroups.delete(id: group.id)
-    try await store.waitForNextEmission(
-      matching: { $0.expandedGroupIds.isEmpty },
-      description: "cascade observed")
-
-    #expect(store.expandedGroupIds.isEmpty)
+    await expectEventually("delete cascade reaps the expand state") {
+      store.expandedGroupIds.isEmpty
+    }
   }
 }

--- a/MoolahTests/Features/Import/ImportRuleStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Import/ImportRuleStoreSyncRefreshTests.swift
@@ -35,11 +35,9 @@ struct ImportRuleStoreSyncRefreshTests {
 
     _ = try await backend.importRules.create(rule(name: "Synced", position: 0))
 
-    try await store.waitForNextEmission(
-      matching: { $0.rules.count == 1 },
-      description: "rules.count == 1"
-    )
-    #expect(store.rules.first?.name == "Synced")
+    await expectEventually("rules has one rule named Synced") {
+      store.rules.count == 1 && store.rules.first?.name == "Synced"
+    }
   }
 
   @Test("stopObserving cancels the observation task")

--- a/MoolahTests/Features/Import/ImportRuleStoreTests.swift
+++ b/MoolahTests/Features/Import/ImportRuleStoreTests.swift
@@ -25,11 +25,9 @@ struct ImportRuleStoreTests {
     _ = try await backend.importRules.create(rule(name: "ruleA", position: 1))
     _ = try await backend.importRules.create(rule(name: "ruleB", position: 3))
     let store = ImportRuleStore(repository: backend.importRules)
-    try await store.waitForNextEmission(
-      matching: { $0.rules.count == 3 },
-      description: "rules.count == 3"
-    )
-    #expect(store.rules.map(\.name) == ["ruleA", "ruleB", "ruleC"])
+    await expectEventually("rules sorted by position") {
+      store.rules.map(\.name) == ["ruleA", "ruleB", "ruleC"]
+    }
   }
 
   @Test("create produces an emission with the appended rule")
@@ -43,11 +41,9 @@ struct ImportRuleStoreTests {
       description: "rules.count == 1"
     )
     await store.create(rule(name: "beta", position: 1))
-    try await store.waitForNextEmission(
-      matching: { $0.rules.count == 2 },
-      description: "rules.count == 2"
-    )
-    #expect(store.rules.map(\.name) == ["alpha", "beta"])
+    await expectEventually("both rules appended in order") {
+      store.rules.map(\.name) == ["alpha", "beta"]
+    }
   }
 
   @Test("update emits the renamed rule with refreshed conditions")
@@ -67,11 +63,10 @@ struct ImportRuleStoreTests {
     edited.name = "renamed"
     edited.conditions = [.descriptionContains(["FOO"])]
     await store.update(edited)
-    try await store.waitForNextEmission(
-      matching: { $0.rules.first?.name == "renamed" },
-      description: "store sees renamed rule"
-    )
-    #expect(store.rules.first?.conditions == [.descriptionContains(["FOO"])])
+    await expectEventually("store sees renamed rule with refreshed conditions") {
+      store.rules.first?.name == "renamed"
+        && store.rules.first?.conditions == [.descriptionContains(["FOO"])]
+    }
   }
 
   @Test("delete emits an empty rules list")
@@ -116,11 +111,10 @@ struct ImportRuleStoreTests {
       description: "store sees all three created rules"
     )
     await store.reorder([ruleC.id, ruleA.id, ruleB.id])
-    try await store.waitForNextEmission(
-      matching: { $0.rules.map(\.name) == ["ruleC", "ruleA", "ruleB"] },
-      description: "store sees reorder applied"
-    )
-    #expect(store.rules.map(\.position) == [0, 1, 2])
+    await expectEventually("store sees reorder applied with renumbered positions") {
+      store.rules.map(\.name) == ["ruleC", "ruleA", "ruleB"]
+        && store.rules.map(\.position) == [0, 1, 2]
+    }
   }
 
   @Test("countAffected counts matching imported transactions")

--- a/MoolahTests/Features/TransactionStoreAccountBalanceTests.swift
+++ b/MoolahTests/Features/TransactionStoreAccountBalanceTests.swift
@@ -35,13 +35,13 @@ struct TransactionStoreAccountBalanceTests {
     )
     _ = await store.create(transaction)
 
-    // AccountStore is reactive — wait for observation to settle (OB 1000 + new -50 = 950).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(950) },
-      description: "account settled at 950 after -50 expense created")
-    // Seeded balance is 1000 (from OB tx), create adds -50 expense -> 950
-    let balance = try await accountStore.displayBalance(for: accountId)
-    #expect(balance.quantity == Decimal(950))
+    // AccountStore is reactive — poll the displayed balance until the
+    // observation settles (OB 1000 + new -50 = 950). Seeded balance is
+    // 1000 (from OB tx), create adds -50 expense -> 950.
+    await expectEventually("account settled at 950 after -50 expense created") {
+      let balance = try? await accountStore.displayBalance(for: accountId)
+      return balance?.quantity == Decimal(950)
+    }
   }
 
   @Test
@@ -80,14 +80,14 @@ struct TransactionStoreAccountBalanceTests {
     ]
     await store.update(updated)
 
-    // AccountStore is reactive — wait for observation to settle (OB 950 + updated -75 = 875).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(875) },
-      description: "account settled at 875 after -50 expense updated to -75")
-    // Seeded account OB=950 + seeded tx=-50 gives loaded balance=900
-    // Update delta: (-75)-(-50)=-25, so 900-25=875
-    let balance = try await accountStore.displayBalance(for: accountId)
-    #expect(balance.quantity == Decimal(875))
+    // AccountStore is reactive — poll the displayed balance until the
+    // observation settles (OB 950 + updated -75 = 875).
+    // Seeded account OB=950 + seeded tx=-50 gives loaded balance=900.
+    // Update delta: (-75)-(-50)=-25, so 900-25=875.
+    await expectEventually("account settled at 875 after -50 expense updated to -75") {
+      let balance = try? await accountStore.displayBalance(for: accountId)
+      return balance?.quantity == Decimal(875)
+    }
   }
 
   @Test
@@ -116,13 +116,13 @@ struct TransactionStoreAccountBalanceTests {
 
     await store.delete(id: transaction.id)
 
-    // AccountStore is reactive — wait for observation to settle (OB 950 only, positions = 950).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(950) },
-      description: "account settled at 950 after -50 expense deleted")
-    // Seeded account OB=950 + seeded tx=-50 gives loaded balance=900
-    // Deleting the -50 expense adds 50 back: 900+50=950
-    let balance = try await accountStore.displayBalance(for: accountId)
-    #expect(balance.quantity == Decimal(950))
+    // AccountStore is reactive — poll the displayed balance until the
+    // observation settles (OB 950 only, positions = 950).
+    // Seeded account OB=950 + seeded tx=-50 gives loaded balance=900.
+    // Deleting the -50 expense adds 50 back: 900+50=950.
+    await expectEventually("account settled at 950 after -50 expense deleted") {
+      let balance = try? await accountStore.displayBalance(for: accountId)
+      return balance?.quantity == Decimal(950)
+    }
   }
 }

--- a/MoolahTests/Features/TransactionStoreCRUDTests.swift
+++ b/MoolahTests/Features/TransactionStoreCRUDTests.swift
@@ -35,10 +35,11 @@ struct TransactionStoreCRUDTests {
       ]
     )
     _ = await store.create(transaction)
-    try await store.awaitTransactionCount(1)
 
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].transaction.payee == "Coffee Shop")
+    await expectEventually("created transaction is observable") {
+      store.transactions.count == 1
+        && store.transactions[0].transaction.payee == "Coffee Shop"
+    }
     #expect(store.error == nil)
   }
 
@@ -74,11 +75,14 @@ struct TransactionStoreCRUDTests {
     )
 
     let created = await store.create(placeholder)
-    try await store.awaitTransactionCount(1)
 
+    // `created` is the captured return value (non-reactive), so assert it
+    // directly; the store list is reactive, so poll it.
     #expect(created?.id == placeholderId)
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].transaction.id == placeholderId)
+    await expectEventually("placeholder UUID preserved in observed list") {
+      store.transactions.count == 1
+        && store.transactions[0].transaction.id == placeholderId
+    }
   }
 
   @Test
@@ -117,14 +121,12 @@ struct TransactionStoreCRUDTests {
       )
     ]
     await store.update(updated)
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.first?.transaction.payee == "Fancy Coffee" },
-      description: "update is observable"
-    )
 
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].transaction.payee == "Fancy Coffee")
-    #expect(store.transactions[0].displayAmount?.quantity == Decimal(-7500) / 100)
+    await expectEventually("update is observable") {
+      store.transactions.count == 1
+        && store.transactions[0].transaction.payee == "Fancy Coffee"
+        && store.transactions[0].displayAmount?.quantity == Decimal(-7500) / 100
+    }
     #expect(store.error == nil)
   }
 
@@ -154,9 +156,10 @@ struct TransactionStoreCRUDTests {
     #expect(store.transactions.count == 1)
 
     await store.delete(id: transaction.id)
-    try await store.awaitTransactionCount(0)
 
-    #expect(store.transactions.isEmpty)
+    await expectEventually("delete is observable") {
+      store.transactions.isEmpty
+    }
     #expect(store.error == nil)
   }
 
@@ -185,8 +188,9 @@ struct TransactionStoreCRUDTests {
       ]
     )
     _ = await store.create(transaction)
-    try await store.awaitTransactionCount(1)
-    #expect(store.transactions.count == 1)
+    await expectEventually("created transaction is observable") {
+      store.transactions.count == 1
+    }
 
     // Update
     var modified = transaction
@@ -199,17 +203,16 @@ struct TransactionStoreCRUDTests {
       )
     ]
     await store.update(modified)
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.first?.displayAmount?.quantity == Decimal(110000) / 100 },
-      description: "update is observable"
-    )
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].displayAmount?.quantity == Decimal(110000) / 100)
+    await expectEventually("update is observable") {
+      store.transactions.count == 1
+        && store.transactions[0].displayAmount?.quantity == Decimal(110000) / 100
+    }
 
     // Delete
     await store.delete(id: transaction.id)
-    try await store.awaitTransactionCount(0)
-    #expect(store.transactions.isEmpty)
+    await expectEventually("delete is observable") {
+      store.transactions.isEmpty
+    }
   }
 
   // Running-balance recompute tests live in

--- a/MoolahTests/Features/TransactionStoreEarmarkTests.swift
+++ b/MoolahTests/Features/TransactionStoreEarmarkTests.swift
@@ -40,17 +40,13 @@ struct TransactionStoreEarmarkTests {
     )
     _ = await store.create(transaction)
 
-    // EarmarkStore is reactive — wait for the observation to settle
-    // on the post-create state (spent = 50). This both lets the
-    // applyDelta + observation race converge and asserts the final
-    // converged value rather than whichever transient mid-state
-    // happens to be visible synchronously.
-    try await earmarkStore.waitForNextEmission(
-      matching: { $0.earmarks.by(id: earmarkId)?.spentPositions.first?.quantity == Decimal(50) },
-      description: "earmark spent settled at 50"
-    )
-    let updatedEarmark = earmarkStore.earmarks.by(id: earmarkId)
-    #expect(updatedEarmark?.spentPositions.first?.quantity == Decimal(50))
+    // EarmarkStore is reactive — poll the post-create state (spent = 50).
+    // This both lets the applyDelta + observation race converge and
+    // asserts the final converged value rather than whichever transient
+    // mid-state happens to be visible synchronously.
+    await expectEventually("earmark spent settled at 50") {
+      earmarkStore.earmarks.by(id: earmarkId)?.spentPositions.first?.quantity == Decimal(50)
+    }
   }
 
   @Test
@@ -100,17 +96,15 @@ struct TransactionStoreEarmarkTests {
     ]
     await store.update(updated)
 
-    // EarmarkStore is reactive — wait for the observation to settle
-    // on the post-update state. Earmark1 should have spent reversed
-    // (transaction moved away) and earmark2 should have spent=50.
-    try await earmarkStore.waitForNextEmission(
-      matching: { $0.earmarks.by(id: earmarkId2)?.spentPositions.first?.quantity == Decimal(50) },
-      description: "earmark2 spent settled at 50"
-    )
-    let updatedEarmark1 = earmarkStore.earmarks.by(id: earmarkId1)
-    #expect(updatedEarmark1?.spentPositions.first?.quantity ?? 0 == Decimal(0))
-    let updatedEarmark2 = earmarkStore.earmarks.by(id: earmarkId2)
-    #expect(updatedEarmark2?.spentPositions.first?.quantity == Decimal(50))
+    // EarmarkStore is reactive — poll the post-update state. Earmark1
+    // should have spent reversed (transaction moved away) and earmark2
+    // should have spent=50.
+    await expectEventually("earmark1 spent reversed to 0 and earmark2 settled at 50") {
+      let earmark1 = earmarkStore.earmarks.by(id: earmarkId1)
+      let earmark2 = earmarkStore.earmarks.by(id: earmarkId2)
+      return earmark1?.spentPositions.first?.quantity ?? 0 == Decimal(0)
+        && earmark2?.spentPositions.first?.quantity == Decimal(50)
+    }
   }
 
   @Test
@@ -149,12 +143,12 @@ struct TransactionStoreEarmarkTests {
     ]
     await store.update(updated)
 
-    // AccountStore is reactive — wait for observation to settle (OB 950 + income +50 = 1000).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(1000) },
-      description: "account settled at 1000 after expense-to-income update")
-    let balance = try await accountStore.displayBalance(for: accountId)
-    #expect(balance.quantity == Decimal(1000))
+    // AccountStore is reactive — poll the displayed balance until the
+    // observation settles (OB 950 + income +50 = 1000).
+    await expectEventually("account settled at 1000 after expense-to-income update") {
+      let balance = try? await accountStore.displayBalance(for: accountId)
+      return balance?.quantity == Decimal(1000)
+    }
   }
 
   @Test
@@ -184,13 +178,13 @@ struct TransactionStoreEarmarkTests {
     await store.load(filter: TransactionFilter(scheduled: .scheduledOnly))
     _ = await store.payScheduledTransaction(scheduled)
 
-    // AccountStore is reactive — wait for observation to settle (OB 1000 + paid -2000 = -1000).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(-1000) },
-      description: "account settled at -1000 after paying -2000 scheduled expense")
-    // Paying a -2000 expense should decrease balance by 2000
-    let balance = try await accountStore.displayBalance(for: accountId)
-    #expect(balance.quantity == Decimal(-1000))
+    // AccountStore is reactive — poll the displayed balance until the
+    // observation settles (OB 1000 + paid -2000 = -1000). Paying a
+    // -2000 expense should decrease balance by 2000.
+    await expectEventually("account settled at -1000 after paying -2000 scheduled expense") {
+      let balance = try? await accountStore.displayBalance(for: accountId)
+      return balance?.quantity == Decimal(-1000)
+    }
   }
 
   @Test
@@ -220,13 +214,13 @@ struct TransactionStoreEarmarkTests {
     await store.load(filter: TransactionFilter(scheduled: .scheduledOnly))
     _ = await store.payScheduledTransaction(scheduled)
 
-    // AccountStore is reactive — wait for observation to settle (OB 1000 + paid -500 = 500).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(500) },
-      description: "account settled at 500 after paying -500 one-time expense")
-    // Paying a -500 expense should decrease balance by 500
-    let balance = try await accountStore.displayBalance(for: accountId)
-    #expect(balance.quantity == Decimal(500))
+    // AccountStore is reactive — poll the displayed balance until the
+    // observation settles (OB 1000 + paid -500 = 500). Paying a -500
+    // expense should decrease balance by 500.
+    await expectEventually("account settled at 500 after paying -500 one-time expense") {
+      let balance = try? await accountStore.displayBalance(for: accountId)
+      return balance?.quantity == Decimal(500)
+    }
   }
 
   // Running-balance update tests live in

--- a/MoolahTests/Features/TransactionStorePayScheduledTests.swift
+++ b/MoolahTests/Features/TransactionStorePayScheduledTests.swift
@@ -38,16 +38,14 @@ struct TransactionStorePayScheduledTests {
 
     let result = await store.payScheduledTransaction(scheduled)
     let expectedNextDate = try TransactionStoreTestSupport.makeDate("2024-02-15")
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.first?.transaction.date == expectedNextDate },
-      description: "advanced date is observable"
-    )
 
-    // Store should show the scheduled tx with advanced date
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].transaction.id == scheduled.id)
-    #expect(store.transactions[0].transaction.date == expectedNextDate)
-    #expect(store.transactions[0].transaction.recurPeriod == .month)
+    // Store should show the scheduled tx with advanced date.
+    await expectEventually("advanced date is observable") {
+      store.transactions.count == 1
+        && store.transactions[0].transaction.id == scheduled.id
+        && store.transactions[0].transaction.date == expectedNextDate
+        && store.transactions[0].transaction.recurPeriod == .month
+    }
 
     // Result should return the updated transaction
     guard case .paid(let updated) = result else {
@@ -107,13 +105,11 @@ struct TransactionStorePayScheduledTests {
     await store.load(filter: TransactionFilter(scheduled: .scheduledOnly))
     let result = await store.payScheduledTransaction(scheduled)
     let expectedNextDate = try TransactionStoreTestSupport.makeDate("2024-01-29")
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.first?.transaction.date == expectedNextDate },
-      description: "advanced (weekly) date is observable"
-    )
 
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].transaction.date == expectedNextDate)
+    await expectEventually("advanced (weekly) date is observable") {
+      store.transactions.count == 1
+        && store.transactions[0].transaction.date == expectedNextDate
+    }
 
     guard case .paid(let updated) = result else {
       Issue.record("Expected .paid result")
@@ -150,10 +146,11 @@ struct TransactionStorePayScheduledTests {
     #expect(store.transactions.count == 1)
 
     let result = await store.payScheduledTransaction(scheduled)
-    try await store.awaitTransactionCount(0)
 
-    // Store should show no scheduled transactions (the original was deleted)
-    #expect(store.transactions.isEmpty)
+    // Store should show no scheduled transactions (the original was deleted).
+    await expectEventually("scheduled transaction removed from observed list") {
+      store.transactions.isEmpty
+    }
 
     // Result should be .deleted
     guard case .deleted = result else {

--- a/MoolahTests/Features/TransactionStoreRunningBalanceTests.swift
+++ b/MoolahTests/Features/TransactionStoreRunningBalanceTests.swift
@@ -48,14 +48,15 @@ struct TransactionStoreRunningBalanceTests {
       ]
     )
     _ = await store.create(expense)
-    try await store.awaitTransactionCount(2)
 
-    // Newest first: expense (balance 97000), then income (balance 100000)
-    #expect(store.transactions.count == 2)
-    #expect(store.transactions[0].transaction.payee == "Coffee")
-    #expect(store.transactions[0].balance?.quantity == Decimal(97000) / 100)
-    #expect(store.transactions[1].transaction.payee == "Initial")
-    #expect(store.transactions[1].balance?.quantity == Decimal(100000) / 100)
+    // Newest first: expense (balance 97000), then income (balance 100000).
+    await expectEventually("running balances recompute after create") {
+      store.transactions.count == 2
+        && store.transactions[0].transaction.payee == "Coffee"
+        && store.transactions[0].balance?.quantity == Decimal(97000) / 100
+        && store.transactions[1].transaction.payee == "Initial"
+        && store.transactions[1].balance?.quantity == Decimal(100000) / 100
+    }
   }
 
   @Test
@@ -98,9 +99,11 @@ struct TransactionStoreRunningBalanceTests {
 
     // Delete the expense — balance should revert
     await store.delete(id: coffee.id)
-    try await store.awaitTransactionCount(1)
-    #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].balance?.quantity == Decimal(100000) / 100)  // Only Salary remains
+    // Only Salary remains, so its running balance reverts to 100000.
+    await expectEventually("running balance reverts after delete") {
+      store.transactions.count == 1
+        && store.transactions[0].balance?.quantity == Decimal(100000) / 100
+    }
   }
 
   @Test
@@ -129,12 +132,10 @@ struct TransactionStoreRunningBalanceTests {
       )
     ]
     await store.update(updated)
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.first?.balance?.quantity == 950 },
-      description: "updated balance is observable"
-    )
-    #expect(store.transactions[0].balance?.quantity == 950)
-    #expect(store.transactions[1].balance?.quantity == 1000)
+    await expectEventually("running balances recompute after amount change") {
+      store.transactions[0].balance?.quantity == 950
+        && store.transactions[1].balance?.quantity == 1000
+    }
   }
 
   // MARK: - Helpers

--- a/MoolahTests/Features/TransactionStoreSuggestionReadPathTests.swift
+++ b/MoolahTests/Features/TransactionStoreSuggestionReadPathTests.swift
@@ -23,24 +23,22 @@ struct TransactionStoreSuggestionReadPathTests {
       transferSuggestions: backend.transferSuggestions)
   }
 
-  /// Blocks until the store's `observeAll()`-fed
-  /// `suggestedTransactionIds` reflects the supplied membership.
-  /// `hasSuggestion(for:)` is now a synchronous read of that observed
-  /// set, so tests must let the suggestion observation settle before
-  /// asserting — the `waitForNextEmission(matching:)` idiom, same as
-  /// the data-observation suites. The predicate matching the current
-  /// state returns immediately if the stream has already emitted.
+  /// Polls until the store's `observeAll()`-fed `suggestedTransactionIds`
+  /// reflects the supplied membership. `hasSuggestion(for:)` is a
+  /// synchronous read of that observed set, so tests must let the
+  /// suggestion observation settle before asserting. Polling the exact
+  /// membership (rather than awaiting a single emission and reading once)
+  /// avoids the race where a later emission lands between the awaited
+  /// emission and the follow-up read.
   private func waitForSuggestionState(
     _ store: TransactionStore,
     contains ids: Set<UUID>,
     excludes excluded: Set<UUID> = []
-  ) async throws {
-    try await store.waitForNextEmission(
-      matching: { snapshot in
-        ids.isSubset(of: snapshot.suggestedTransactionIds)
-          && excluded.isDisjoint(with: snapshot.suggestedTransactionIds)
-      },
-      description: "suggestion set contains \(ids), excludes \(excluded)")
+  ) async {
+    await expectEventually("suggestion set contains \(ids), excludes \(excluded)") {
+      ids.isSubset(of: store.suggestedTransactionIds)
+        && excluded.isDisjoint(with: store.suggestedTransactionIds)
+    }
   }
 
   @Test
@@ -89,7 +87,7 @@ struct TransactionStoreSuggestionReadPathTests {
     // Let the suggestion observation deliver the record before
     // dismissing so the post-dismiss "set is now empty" wait is
     // meaningful (not just observing the never-populated initial state).
-    try await waitForSuggestionState(
+    await waitForSuggestionState(
       store, contains: [outgoing.id, incoming.id])
 
     await store.dismissSuggestedTransfer(incoming)
@@ -105,10 +103,10 @@ struct TransactionStoreSuggestionReadPathTests {
     // C1 regression guard: the store's reactive presence set must clear
     // for both sides once `observeAll()` delivers the deletion, so the
     // detail banner hides without a `transaction.id` change.
-    try await waitForSuggestionState(
-      store, contains: [], excludes: [outgoing.id, incoming.id])
-    #expect(store.hasSuggestion(for: outgoing) == false)
-    #expect(store.hasSuggestion(for: incoming) == false)
+    await expectEventually("hasSuggestion clears for both sides after dismiss") {
+      store.hasSuggestion(for: outgoing) == false
+        && store.hasSuggestion(for: incoming) == false
+    }
   }
 
   @Test
@@ -128,11 +126,11 @@ struct TransactionStoreSuggestionReadPathTests {
         transactionIds: [outgoing.id, incoming.id], suggestedAt: date))
     let store = makeStore(backend: backend)
 
-    try await waitForSuggestionState(
-      store, contains: [outgoing.id, incoming.id], excludes: [unrelated.id])
-    #expect(store.hasSuggestion(for: outgoing))
-    #expect(store.hasSuggestion(for: incoming))
-    #expect(store.hasSuggestion(for: unrelated) == false)
+    await expectEventually("hasSuggestion reflects record presence for the pair only") {
+      store.hasSuggestion(for: outgoing)
+        && store.hasSuggestion(for: incoming)
+        && store.hasSuggestion(for: unrelated) == false
+    }
   }
 
   /// C1 regression guard, isolated: the detail banner derives its
@@ -157,17 +155,17 @@ struct TransactionStoreSuggestionReadPathTests {
         transactionIds: [outgoing.id, incoming.id], suggestedAt: date))
     let store = makeStore(backend: backend)
 
-    try await waitForSuggestionState(
-      store, contains: [outgoing.id, incoming.id])
-    #expect(store.hasSuggestion(for: outgoing))
-    #expect(store.hasSuggestion(for: incoming))
+    await expectEventually("both sides have a suggestion before dismiss") {
+      store.hasSuggestion(for: outgoing)
+        && store.hasSuggestion(for: incoming)
+    }
 
     await store.dismissSuggestedTransfer(outgoing)
 
-    try await waitForSuggestionState(
-      store, contains: [], excludes: [outgoing.id, incoming.id])
-    #expect(store.hasSuggestion(for: outgoing) == false)
-    #expect(store.hasSuggestion(for: incoming) == false)
+    await expectEventually("hasSuggestion clears for both sides after dismiss") {
+      store.hasSuggestion(for: outgoing) == false
+        && store.hasSuggestion(for: incoming) == false
+    }
   }
 
   @Test

--- a/MoolahTests/Features/TransactionStoreTransferTests.swift
+++ b/MoolahTests/Features/TransactionStoreTransferTests.swift
@@ -39,16 +39,18 @@ struct TransactionStoreTransferTests {
     ]
     await store.update(updated)
 
-    // AccountStore is reactive — wait for observation to settle (OB 900 + -150 = 750).
+    // AccountStore is reactive — poll both displayed balances until the
+    // observation settles (OB 900 + -150 = 750).
     // Loaded: checking=900-100=800, savings=1100+100=1200
     // Update: checking: -150-(-100)=-50 → 750, savings: +150-100=+50 → 1250
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accountId)?.positions.first?.quantity == Decimal(750) },
-      description: "checking settled at 750 after transfer amount increased")
-    let checkingBalance = try await accountStore.displayBalance(for: accountId)
-    let savingsBalance = try await accountStore.displayBalance(for: savingsId)
-    #expect(checkingBalance.quantity == Decimal(750))
-    #expect(savingsBalance.quantity == Decimal(1250))
+    await expectEventually(
+      "checking settled at 750 and savings at 1250 after transfer amount increased"
+    ) {
+      let checkingBalance = try? await accountStore.displayBalance(for: accountId)
+      let savingsBalance = try? await accountStore.displayBalance(for: savingsId)
+      return checkingBalance?.quantity == Decimal(750)
+        && savingsBalance?.quantity == Decimal(1250)
+    }
   }
 
   @Test
@@ -80,18 +82,20 @@ struct TransactionStoreTransferTests {
     ]
     await store.update(updated)
 
-    // AccountStore is reactive — wait for observation to settle (savings: 1200-100=1100).
-    try await accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: savingsId)?.positions.first?.quantity == Decimal(1100) },
-      description: "savings settled at 1100 after transfer destination changed")
+    // AccountStore is reactive — poll all three displayed balances until
+    // the observation settles (savings: 1200-100=1100).
     // Loaded: checking=900-100=800, savings=1100+100=1200, investment=500
     // Change dest from savings→investment: savings -100=1100, investment +100=600
-    let checkingBalance = try await accountStore.displayBalance(for: accountId)
-    let savingsBalance = try await accountStore.displayBalance(for: savingsId)
-    let investmentBalance = try await accountStore.displayBalance(for: investmentId)
-    #expect(checkingBalance.quantity == Decimal(800))
-    #expect(savingsBalance.quantity == Decimal(1100))
-    #expect(investmentBalance.quantity == Decimal(600))
+    await expectEventually(
+      "checking 800, savings 1100, investment 600 after transfer destination changed"
+    ) {
+      let checkingBalance = try? await accountStore.displayBalance(for: accountId)
+      let savingsBalance = try? await accountStore.displayBalance(for: savingsId)
+      let investmentBalance = try? await accountStore.displayBalance(for: investmentId)
+      return checkingBalance?.quantity == Decimal(800)
+        && savingsBalance?.quantity == Decimal(1100)
+        && investmentBalance?.quantity == Decimal(600)
+    }
   }
 
   // MARK: - Helpers

--- a/MoolahTests/Features/Transactions/TransactionStoreRegistryRefreshTests.swift
+++ b/MoolahTests/Features/Transactions/TransactionStoreRegistryRefreshTests.swift
@@ -86,10 +86,10 @@ struct TransactionStoreRegistryRefreshTests {
 
     let store = makeStore(backend, registry)
     await store.load(filter: TransactionFilter(accountId: accountId))
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.count == 1 },
-      description: "store sees the seeded crypto transaction")
-    #expect(cryptoLegName(store, id: crypto.id) == "Wrapped Bitcoin")
+    await expectEventually("store sees the seeded crypto transaction") {
+      store.transactions.count == 1
+        && self.cryptoLegName(store, id: crypto.id) == "Wrapped Bitcoin"
+    }
 
     // Rename in the SHARED registry. No per-profile GRDB write happens,
     // so the data-change observation does NOT re-fire — only the

--- a/MoolahTests/Features/Transactions/TransactionStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Transactions/TransactionStoreSyncRefreshTests.swift
@@ -52,11 +52,10 @@ struct TransactionStoreSyncRefreshTests {
     )
     _ = try await backend.transactions.create(remote)
 
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.count == 1 },
-      description: "store sees synced transaction"
-    )
-    #expect(store.transactions.first?.transaction.payee == "Synced")
+    await expectEventually("store sees synced transaction") {
+      store.transactions.count == 1
+        && store.transactions.first?.transaction.payee == "Synced"
+    }
 
     store.stopObserving()
   }
@@ -133,11 +132,10 @@ struct TransactionStoreSyncRefreshTests {
           )
         ]
       ))
-    try await store.waitForNextEmission(
-      matching: { $0.transactions.count == 1 },
-      description: "observe(accountId:) sees the new transaction"
-    )
-    #expect(store.transactions.first?.transaction.payee == "via observe(accountId:)")
+    await expectEventually("observe(accountId:) sees the new transaction") {
+      store.transactions.count == 1
+        && store.transactions.first?.transaction.payee == "via observe(accountId:)"
+    }
   }
 
   @Test("GRDB wipes during sign-out reach the store before stopObserving cancels it")

--- a/MoolahTests/Navigation/SidebarDropDispatchCrossGroupTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchCrossGroupTests.swift
@@ -44,11 +44,11 @@ struct SidebarDropDispatchCrossGroupTests {
       accountGroupStore: stores.accountGroupStore,
       groupUIStateStore: stores.groupUIStateStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aMember1.id)?.groupId == groupB.id },
-      description: "aMember1 now in groupB")
-    #expect(stores.accountStore.accounts.by(id: aMember2.id)?.groupId == groupA.id)
-    #expect(stores.accountGroupStore.by(id: groupA.id) != nil)
+    await expectEventually("aMember1 moved to groupB; groupA survives with aMember2") {
+      stores.accountStore.accounts.by(id: aMember1.id)?.groupId == groupB.id
+        && stores.accountStore.accounts.by(id: aMember2.id)?.groupId == groupA.id
+        && stores.accountGroupStore.by(id: groupA.id) != nil
+    }
   }
 
   @Test("dropOntoAccount onto cross-group member deletes empty old group")

--- a/MoolahTests/Navigation/SidebarDropDispatchReorderMembersTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchReorderMembersTests.swift
@@ -43,14 +43,13 @@ struct SidebarDropDispatchReorderMembersTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: memberC.id)?.position == 0 },
-      description: "C now first member")
-    let members = stores.accountStore.accounts.ordered
-      .filter { $0.groupId == group.id }
-      .sorted { $0.position < $1.position }
-      .map(\.id)
-    #expect(members == [memberC.id, memberA.id, memberB.id])
+    await expectEventually("C reordered to first member") {
+      let members = stores.accountStore.accounts.ordered
+        .filter { $0.groupId == group.id }
+        .sorted { $0.position < $1.position }
+        .map(\.id)
+      return members == [memberC.id, memberA.id, memberB.id]
+    }
   }
 
   @Test("reorderMembers clamps insertion index past the end")
@@ -149,14 +148,13 @@ struct SidebarDropDispatchReorderMembersTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: standalone.id)?.groupId == group.id },
-      description: "standalone joined group")
-    let members = stores.accountStore.accounts.ordered
-      .filter { $0.groupId == group.id }
-      .sorted { $0.position < $1.position }
-      .map(\.id)
-    #expect(members == [memberA.id, standalone.id, memberB.id])
+    await expectEventually("standalone inserted into group at index 1") {
+      let members = stores.accountStore.accounts.ordered
+        .filter { $0.groupId == group.id }
+        .sorted { $0.position < $1.position }
+        .map(\.id)
+      return members == [memberA.id, standalone.id, memberB.id]
+    }
   }
 
   @Test("reorderMembers moves source from group A to group B; A keeps remaining members")
@@ -187,16 +185,18 @@ struct SidebarDropDispatchReorderMembersTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accA1.id)?.groupId == groupB.id },
-      description: "accA1 now in group B")
-    #expect(stores.accountStore.accounts.by(id: accA2.id)?.groupId == groupA.id)
-    #expect(stores.accountGroupStore.by(id: groupA.id) != nil)
-    let bMembers = stores.accountStore.accounts.ordered
-      .filter { $0.groupId == groupB.id }
-      .sorted { $0.position < $1.position }
-      .map(\.id)
-    #expect(bMembers == [accB1.id, accA1.id, accB2.id])
+    await expectEventually(
+      "accA1 moved into group B at index 1; group A survives with accA2"
+    ) {
+      let bMembers = stores.accountStore.accounts.ordered
+        .filter { $0.groupId == groupB.id }
+        .sorted { $0.position < $1.position }
+        .map(\.id)
+      return stores.accountStore.accounts.by(id: accA1.id)?.groupId == groupB.id
+        && stores.accountStore.accounts.by(id: accA2.id)?.groupId == groupA.id
+        && stores.accountGroupStore.by(id: groupA.id) != nil
+        && bMembers == [accB1.id, accA1.id, accB2.id]
+    }
   }
 
   @Test("reorderMembers deletes empty old group when source was its sole member")

--- a/MoolahTests/Navigation/SidebarDropDispatchReorderRootTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchReorderRootTests.swift
@@ -26,14 +26,13 @@ struct SidebarDropDispatchReorderRootTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: third.id)?.position == 0 },
-      description: "third now first")
-    let order = stores.accountStore.accounts.ordered
-      .filter { $0.bucket == .current && $0.groupId == nil }
-      .sorted { $0.position < $1.position }
-      .map(\.id)
-    #expect(order == [third.id, first.id, second.id])
+    await expectEventually("third moved ahead to first in the root order") {
+      let order = stores.accountStore.accounts.ordered
+        .filter { $0.bucket == .current && $0.groupId == nil }
+        .sorted { $0.position < $1.position }
+        .map(\.id)
+      return order == [third.id, first.id, second.id]
+    }
   }
 
   @Test("reorderRoot moves a group ahead of a standalone account")
@@ -81,9 +80,11 @@ struct SidebarDropDispatchReorderRootTests {
     try await stores.accountGroupStore.waitForNextEmission(
       matching: { $0.by(id: group.id)?.position == 0 },
       description: "group landed at position 0")
-    let groupPos = stores.accountGroupStore.by(id: group.id)?.position
-    let standalonePos = stores.accountStore.accounts.by(id: standalone.id)?.position
-    #expect((groupPos ?? -1) < (standalonePos ?? -1))
+    await expectEventually("group ends up ahead of the standalone account") {
+      let groupPos = stores.accountGroupStore.by(id: group.id)?.position
+      let standalonePos = stores.accountStore.accounts.by(id: standalone.id)?.position
+      return (groupPos ?? -1) < (standalonePos ?? -1)
+    }
   }
 
   @Test("reorderRoot clamps insertion index past the end")
@@ -142,20 +143,15 @@ struct SidebarDropDispatchReorderRootTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountGroupStore.waitForNextEmission(
-      matching: { $0.by(id: group.id)?.position == 2 },
-      description: "group walked to position 2")
-
     // Per-entry walk-index writes — not a contiguous 0..N-1 collapse —
     // so each entry's absolute position matches its walk-order index.
-    let postStandaloneA = try #require(
-      stores.accountStore.accounts.by(id: standaloneA.id))
-    let postStandaloneB = try #require(
-      stores.accountStore.accounts.by(id: standaloneB.id))
-    let postGroup = try #require(stores.accountGroupStore.by(id: group.id))
-    #expect(postStandaloneA.position == 0)
-    #expect(postStandaloneB.position == 1)
-    #expect(postGroup.position == 2)
+    await expectEventually("each root entry's position matches its walk-order index") {
+      let postStandaloneA = stores.accountStore.accounts.by(id: standaloneA.id)
+      let postStandaloneB = stores.accountStore.accounts.by(id: standaloneB.id)
+      let postGroup = stores.accountGroupStore.by(id: group.id)
+      return postStandaloneA?.position == 0 && postStandaloneB?.position == 1
+        && postGroup?.position == 2
+    }
   }
 
   @Test("reorderRoot is a no-op when the dragged id is unknown")
@@ -210,11 +206,11 @@ struct SidebarDropDispatchReorderRootTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: memberA.id)?.groupId == nil },
-      description: "memberA back to root")
-    #expect(stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id)
-    #expect(stores.accountGroupStore.by(id: group.id) != nil)
+    await expectEventually("memberA back to root; group survives with memberB") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == nil
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+        && stores.accountGroupStore.by(id: group.id) != nil
+    }
   }
 
   @Test("reorderRoot deletes the old group when the source was its sole member")

--- a/MoolahTests/Navigation/SidebarDropDispatchTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchTests.swift
@@ -157,10 +157,10 @@ struct SidebarDropDispatchTests {
       accountGroupStore: stores.accountGroupStore,
       groupUIStateStore: stores.groupUIStateStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: source.id)?.groupId == group.id },
-      description: "source joined target group")
-    #expect(stores.accountStore.accounts.by(id: source.id)?.position == 1)
+    await expectEventually("source joined target group at position 1") {
+      let source = stores.accountStore.accounts.by(id: source.id)
+      return source?.groupId == group.id && source?.position == 1
+    }
     try await stores.groupUIStateStore.waitForNextEmission(
       matching: { $0.expandedGroupIds.contains(group.id) },
       description: "target group auto-expanded after drop")
@@ -192,10 +192,9 @@ struct SidebarDropDispatchTests {
       accountGroupStore: stores.accountGroupStore,
       groupUIStateStore: stores.groupUIStateStore)
 
-    try await stores.groupUIStateStore.waitForNextEmission(
-      matching: { $0.expandedGroupIds.contains(group.id) },
-      description: "target group auto-expanded after drop")
-    #expect(stores.groupUIStateStore.expandedGroupIds.contains(group.id))
+    await expectEventually("target group auto-expanded after drop") {
+      stores.groupUIStateStore.expandedGroupIds.contains(group.id)
+    }
   }
 
   @Test("dropOntoGroup is a no-op when the account is already in the target group")


### PR DESCRIPTION
## Summary

Batched migration of the store-observation **wait-then-read-once** flake class to the `expectEventually` polling helper (landed in #1106). This is the rollout that eliminates the category that's been intermittently ejecting PRs from the merge queue.

A sweep found ~134 RACY sites across 37 files; six agents migrated them in parallel (disjoint files), consolidated here into one PR (cheaper on the queue than 6 full-suite CI runs).

### What changed
Every **RACY** site — `await waitForNextEmission(matching: X)` followed by a *separate* read-and-assert of reactive store/service state — became `await expectEventually("desc") { <full post-condition> }`, so the asserted value is polled directly and there's no unguarded re-read. Left untouched: setup `waitForFirstEmission`, absence assertions (`didEmitWithin`), predicate-is-the-assertion cases, and load-bearing ordering barriers.

43 files, net −221 lines.

### Verification
- **Full macOS suite (4064 tests) run 4×: 3 clean passes** after one fix (see below). Run under full-suite load on purpose — that load makes over-migrations deterministic.
- One over-migration caught and fixed: `displayBalanceForInvestmentAccountPrefersInvestmentValue` had a `waitForNextEmission` that was an **ordering barrier** (initial emission must precede `updateInvestmentValue` or a late snapshot clobbers the value to zero), wrongly replaced with a value poll — restored, with a comment so it isn't re-broken.
- `just format-check` clean; warnings-as-errors build clean (agents compiled the *test* target via `build-for-testing`, not just `build-mac`).

### Follow-up
Each agent flagged a few `signOutTeardownOrdering`-style tests it deliberately left (post-`stopObserving` ordering assertions). Those are intentionally not migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)