### PR TITLE
fix(positions): holdings UI polish from #1107 review (#1108)

### DIFF
--- a/Shared/Views/Positions/PositionRow.swift
+++ b/Shared/Views/Positions/PositionRow.swift
@@ -11,13 +11,22 @@ import SwiftUI
 struct PositionRow: View {
   let row: ValuedPosition
 
+  // Rows breathe a little more under touch (12pt) than under a pointer
+  // (8pt), per `guides/UI_GUIDE.md`. `@ScaledMetric` so the padding tracks
+  // Dynamic Type, matching `TransactionRowView`.
+  #if os(macOS)
+    @ScaledMetric private var verticalPadding: CGFloat = 8
+  #else
+    @ScaledMetric private var verticalPadding: CGFloat = 12
+  #endif
+
   var body: some View {
     HStack(alignment: .firstTextBaseline) {
       leadingColumn
       Spacer()
       trailingColumn
     }
-    .padding(.vertical, 8)
+    .padding(.vertical, verticalPadding)
     .accessibilityElement(children: .combine)
     .accessibilityLabel(accessibilityLabel)
   }

--- a/Shared/Views/Positions/PositionsChart.swift
+++ b/Shared/Views/Positions/PositionsChart.swift
@@ -49,7 +49,15 @@ struct PositionsChart: View {
             .foregroundStyle(.secondary)
         }
         .buttonStyle(.plain)
-        .frame(minWidth: 44, minHeight: 44)
+        #if os(macOS)
+          .frame(minWidth: 44, minHeight: 44)
+        #else
+          // Pin to exactly 44×44 on iOS: with only a `minWidth`/`minHeight`
+          // a constrained header `HStack` can still compress the hit area
+          // below the HIG touch minimum. The `maxWidth`/`maxHeight` clamp
+          // makes the 44pt target non-compressible.
+          .frame(minWidth: 44, maxWidth: 44, minHeight: 44, maxHeight: 44)
+        #endif
         .contentShape(Rectangle())
         .accessibilityLabel("Clear instrument filter, showing all positions")
         Spacer()
@@ -76,7 +84,7 @@ struct PositionsChart: View {
       ContentUnavailableView {
         Label("No chart data yet", systemImage: "chart.line.uptrend.xyaxis")
       } description: {
-        Text("Record a trade to start tracking value over time.")
+        Text("Record your first trade and we'll start charting its value over time.")
       }
       .frame(minHeight: 200)
     } else {

--- a/Shared/Views/Positions/PositionsTable.swift
+++ b/Shared/Views/Positions/PositionsTable.swift
@@ -44,7 +44,9 @@ struct PositionsTable: View {
       TableColumn("Instrument", value: \.instrument.name) { row in
         instrumentCell(for: row)
       }
-      TableColumn("Qty", value: \.quantity) { row in
+      // Full word, not "Qty": macOS `Table` reads the column header to
+      // VoiceOver, where "Qty" would be spoken as an abbreviation.
+      TableColumn("Quantity", value: \.quantity) { row in
         Text(row.quantityFormatted).monospacedDigit()
       }
       TableColumn("Unit Price", value: \.unitPriceQuantity) { row in
@@ -73,6 +75,15 @@ struct PositionsTable: View {
         }
       }
     }
+    // The wide `Table` gives this cell a fixed column width, so the caption
+    // (exchange / chain summary) clips rather than wraps at the largest
+    // accessibility sizes. Cap Dynamic Type at the guide's standard ceiling
+    // (`guides/UI_GUIDE.md` §4: `.medium...accessibility3`) — the tradeoff is
+    // that accessibility4+ users see this cell at accessibility3 scale. The cap
+    // is scoped to the instrument cell so the numeric columns keep scaling for
+    // low-vision readability; the narrow `List` layout (`PositionRow`) keeps the
+    // full range since it can wrap.
+    .dynamicTypeSize(...DynamicTypeSize.accessibility3)
     .accessibilityElement(children: .combine)
     .accessibilityLabel(instrumentLabel(for: row))
   }


### PR DESCRIPTION
Addresses **5 of 6** checklist items in [#1108](https://github.com/moolah-rocks/moolah-native/issues/1108) — the holdings UI polish deferred from the [#1107](https://github.com/moolah-rocks/moolah-native/pull/1107) cross-chain review. All five are presentational; no logic changes.

### Done
- [x] **`PositionRow` vertical padding** — flat `.padding(.vertical, 8)` → platform-conditional `@ScaledMetric` (8pt macOS / 12pt iOS) per `guides/UI_GUIDE.md`, matching `TransactionRowView`.
- [x] **`PositionsTable` Dynamic Type cap** — the wide `Table` instrument cell now caps Dynamic Type so the fixed-width column can't clip the exchange / chain caption. Capped at **`accessibility3`** (the guide's standard ceiling, `UI_GUIDE.md` §4) rather than the `accessibility2` the issue suggested — `accessibility2` belongs to `AccountPerformanceTiles`' tighter 3-up tile layout, and `accessibility3` is the documented norm. Cap is cell-scoped so the numeric columns keep scaling for low-vision readability; the narrow `List` layout (`PositionRow`) keeps the full range since it wraps.
- [x] **`PositionsTable` "Qty" → "Quantity"** — macOS `Table` reads the column header to VoiceOver, where "Qty" speaks as an abbreviation.
- [x] **`PositionsChart` clear-filter hit target** — pinned to exactly 44×44 on iOS (min+max) so a constrained header `HStack` can't compress the hit area below the HIG touch minimum; macOS stays min-only.
- [x] **`PositionsChart` empty-state copy** — warmer per `guides/BRAND_GUIDE.md`: "Record your first trade and we'll start charting its value over time."

### Deferred (blocked on #1107)
- [ ] Switch `crossChainEthRollsIntoOneHolding` to `DateBasedFixedConversionService`. That test only exists on the unmerged #1107 branch; it'll be done as a follow-up once #1107 lands on `main`. **#1108 should stay open** until then.

### Verification
- `just build-mac` — **BUILD SUCCEEDED**
- `just format-check` — clean
- No test references the renamed header or the old empty-state copy.
- Reviewed by the `ui-review` agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)