### PR TITLE
test(positions): guard valuation-date threading in cross-chain fold (#1108)

### DIFF
--- a/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
+++ b/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
@@ -129,9 +129,16 @@ struct InvestmentStorePositionsInputTests {
     try await registerCoingeckoOnly(ethMainnet, coingeckoId: "ethereum", in: backend)
     try await registerCoingeckoOnly(ethOptimism, coingeckoId: "ethereum", in: backend)
 
-    let conversionService = FixedConversionService(rates: [
-      ethMainnet.id: Decimal(3_000),
-      ethOptimism.id: Decimal(3_000),
+    // Date-based fixed rates (effective from well before the earliest trade)
+    // so the conversion exercises the `on date:` valuation-date threading
+    // rather than a flat per-currency rate. The fold itself introduces no
+    // conversions, so the held quantity is unaffected.
+    let rateEffectiveFrom = Date(timeIntervalSinceNow: -86_400 * 365)
+    let conversionService = DateBasedFixedConversionService(rates: [
+      rateEffectiveFrom: [
+        ethMainnet.id: Decimal(3_000),
+        ethOptimism.id: Decimal(3_000),
+      ]
     ])
     let store = InvestmentStore(
       repository: backend.investments,


### PR DESCRIPTION
Completes the final checklist item in [#1108](https://github.com/moolah-rocks/moolah-native/issues/1108), deferred from the [#1107](https://github.com/moolah-rocks/moolah-native/pull/1107) review until that PR landed (it just did).

- [x] Switch `crossChainEthRollsIntoOneHolding` from `FixedConversionService` (a flat per-currency rate) to `DateBasedFixedConversionService` so the test exercises the `on date:` valuation-date threading rather than a date-blind rate. The rate is keyed to an effective-from date a year before the earliest trade, so any reasonable valuation date resolves correctly.

Low risk: the holdings fold introduces no conversions, so the asserted held quantity (5 ETH, one rolled-up "ethereum" row) is unchanged. Verified by running the suite.

The other five items shipped in #1110. With this, **#1108 is fully addressed.**

Fixes #1108

### Verification
- `just test-mac InvestmentStorePositionsInputTests` — **TEST SUCCEEDED** (4/4)
- `just format-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)