### PR TITLE
test(support): default store-wait timeouts to 10s; drop redundant short caps

### DIFF
--- a/MoolahTests/App/ProfileSessionPragmaOptimizeTests.swift
+++ b/MoolahTests/App/ProfileSessionPragmaOptimizeTests.swift
@@ -43,7 +43,7 @@ struct ProfileSessionPragmaOptimizeTests {
     // generous because heavily-loaded CI (iOS Simulator under merge-queue
     // contention) can drag the 20 ms cadence into seconds-range; we only
     // need *eventually*-fires, not tight cadence (#884).
-    try await waitUntil(timeout: .seconds(10)) {
+    try await waitUntil {
       session.pragmaOptimizeRunCount >= baseline + 3
     }
 
@@ -66,7 +66,7 @@ struct ProfileSessionPragmaOptimizeTests {
     // takes effect.
     session.startPeriodicPragmaOptimize(interval: .milliseconds(20))
 
-    try await waitUntil(timeout: .seconds(10)) {
+    try await waitUntil {
       session.pragmaOptimizeRunCount >= baselineAfterFirstStart + 2
     }
 
@@ -87,7 +87,7 @@ struct ProfileSessionPragmaOptimizeTests {
     session.startPeriodicPragmaOptimize(interval: .milliseconds(20))
 
     // Let it fire at least once so we know the loop is running.
-    try await waitUntil(timeout: .seconds(10)) {
+    try await waitUntil {
       session.pragmaOptimizeRunCount >= 1
     }
 
@@ -109,7 +109,7 @@ struct ProfileSessionPragmaOptimizeTests {
   /// timeout elapses. Throws `TimeoutError` if the condition never holds.
   /// Used to wait on background ticks without relying on a fixed sleep.
   private func waitUntil(
-    timeout: Duration,
+    timeout: Duration = .seconds(10),
     pollEvery: Duration = .milliseconds(10),
     _ condition: @MainActor () -> Bool
   ) async throws {

--- a/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
@@ -87,8 +87,7 @@ struct AccountStoreSyncRefreshTests {
 
     try await store.waitForNextEmission(
       matching: { _ in true },
-      description: "any emission post-rate-write to \(table)",
-      timeout: .seconds(2)
+      description: "any emission post-rate-write to \(table)"
     )
   }
 
@@ -219,8 +218,7 @@ struct AccountStoreSyncRefreshTests {
 
     try await store.waitForNextEmission(
       matching: { $0.convertedBalances[investmentAccount.id]?.quantity == 12345 },
-      description: "investment value reaches account store",
-      timeout: .seconds(2)
+      description: "investment value reaches account store"
     )
   }
 
@@ -326,8 +324,7 @@ struct AccountStoreSyncRefreshTests {
     }
     try await store.waitForNextEmission(
       matching: { $0.accounts.ordered.isEmpty },
-      description: "wipe propagated to store before cancellation",
-      timeout: .seconds(2)
+      description: "wipe propagated to store before cancellation"
     )
     store.stopObserving()
     #expect(store.accounts.ordered.isEmpty)

--- a/MoolahTests/Features/Categories/CategoryStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Categories/CategoryStoreSyncRefreshTests.swift
@@ -79,8 +79,7 @@ struct CategoryStoreSyncRefreshTests {
     }
     try await store.waitForNextEmission(
       matching: { $0.categories.roots.isEmpty },
-      description: "wipe propagated to store before cancellation",
-      timeout: .seconds(2)
+      description: "wipe propagated to store before cancellation"
     )
     store.stopObserving()
     #expect(store.categories.roots.isEmpty)

--- a/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
+++ b/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
@@ -7,19 +7,6 @@ import Testing
 @MainActor
 struct EarmarkStorePartialConversionTests {
 
-  /// Timeout for the first-emission convergence waits in this suite.
-  ///
-  /// Deliberately more generous than the helper's 2s default: unlike the
-  /// other store tests (which drive emissions via an explicit action such
-  /// as `applyDelta`), these waits race the store's init-spawned
-  /// observation task through a GRDB `observeAll()` emission *and* N async
-  /// per-earmark conversion calls. On a loaded CI runner that first
-  /// emission can land just past 2s — a timing artefact, not a regression
-  /// (see issue #1025). `waitForNextEmission` polls the predicate every
-  /// 20ms, so the fast path still returns the instant state settles; the
-  /// larger cap only buys headroom for a slow runner.
-  private static let convergenceTimeout: Duration = .seconds(10)
-
   /// When one earmark's positions can't be converted to its own instrument,
   /// other earmarks whose conversions succeed still appear in
   /// `convertedBalances`. The aggregate `convertedTotalBalance` stays nil
@@ -76,8 +63,7 @@ struct EarmarkStorePartialConversionTests {
     // mixed earmark (and therefore the aggregate total) stay nil. Poll the
     // full post-condition so a racing recompute can't slip a stale read in.
     await expectEventually(
-      "healthy earmark settles while the failing earmark and total stay nil",
-      timeout: Self.convergenceTimeout
+      "healthy earmark settles while the failing earmark and total stay nil"
     ) {
       store.convertedBalance(for: healthyEarmark.id)?.quantity == 300
         && store.convertedBalance(for: mixedEarmark.id) == nil
@@ -131,8 +117,7 @@ struct EarmarkStorePartialConversionTests {
     // balance settles. Per-earmark balances are still displayed in their own
     // currency where no conversion is needed.
     await expectEventually(
-      "AUD earmark settles while the EUR failure keeps the total nil",
-      timeout: Self.convergenceTimeout
+      "AUD earmark settles while the EUR failure keeps the total nil"
     ) {
       store.convertedBalance(for: audEarmark.id)?.quantity == 400
         && store.convertedTotalBalance == nil

--- a/MoolahTests/Features/Earmarks/EarmarkStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Earmarks/EarmarkStoreSyncRefreshTests.swift
@@ -92,8 +92,7 @@ struct EarmarkStoreSyncRefreshTests {
     }
     try await store.waitForNextEmission(
       matching: { $0.earmarks.ordered.isEmpty },
-      description: "wipe propagated to store before cancellation",
-      timeout: .seconds(2)
+      description: "wipe propagated to store before cancellation"
     )
     store.stopObserving()
     #expect(store.earmarks.ordered.isEmpty)

--- a/MoolahTests/Features/Import/ImportRuleStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Import/ImportRuleStoreSyncRefreshTests.swift
@@ -81,8 +81,7 @@ struct ImportRuleStoreSyncRefreshTests {
     }
     try await store.waitForNextEmission(
       matching: { $0.rules.isEmpty },
-      description: "wipe propagated to store before cancellation",
-      timeout: .seconds(2)
+      description: "wipe propagated to store before cancellation"
     )
     store.stopObserving()
     #expect(store.rules.isEmpty)

--- a/MoolahTests/Features/Insights/InsightStoreShowLessTests.swift
+++ b/MoolahTests/Features/Insights/InsightStoreShowLessTests.swift
@@ -76,7 +76,7 @@ struct InsightStoreShowLessTests {
     #expect(store.items.count == 2)
 
     // The per-kind fatigue count was persisted (all fixtures share one kind).
-    try await waitUntil(timeout: .seconds(5)) {
+    try await waitUntil {
       let count =
         (try? await backend.insightDismissals.fetchAll())?
         .first { $0.kind == .netWorthMilestone }?.count
@@ -116,7 +116,7 @@ struct InsightStoreShowLessTests {
   // MARK: - Polling helper
 
   private func waitUntil(
-    timeout: Duration,
+    timeout: Duration = .seconds(10),
     pollEvery: Duration = .milliseconds(20),
     _ condition: @MainActor () async -> Bool
   ) async throws {

--- a/MoolahTests/Features/Insights/InsightStoreTests.swift
+++ b/MoolahTests/Features/Insights/InsightStoreTests.swift
@@ -263,7 +263,7 @@ struct InsightStoreTests {
 
     // The write-through fires in a detached `Task`; poll the repository until
     // the committed increment lands (no fixed sleep — bounded poll).
-    try await waitUntil(timeout: .seconds(5)) {
+    try await waitUntil {
       let count =
         (try? await backend.insightDismissals.fetchAll())?
         .first { $0.kind == .uncategorizedBacklog }?.count
@@ -293,7 +293,7 @@ struct InsightStoreTests {
     _ = try await backend.insightDismissals.recordDismissal(of: .uncategorizedBacklog)
     let store = makeStore(backend)
 
-    try await waitUntil(timeout: .seconds(5)) {
+    try await waitUntil {
       store.overrideLastLoadedAtForTesting(nil)  // force each poll to rebuild
       await store.refresh()
       guard
@@ -311,7 +311,7 @@ struct InsightStoreTests {
   /// elapses, throwing `TimeoutError` otherwise. Used to wait on the async
   /// write-through / observation seam without a fixed sleep.
   private func waitUntil(
-    timeout: Duration,
+    timeout: Duration = .seconds(10),
     pollEvery: Duration = .milliseconds(20),
     _ condition: @MainActor () async -> Bool
   ) async throws {

--- a/MoolahTests/Features/Investments/InvestmentStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Investments/InvestmentStoreSyncRefreshTests.swift
@@ -39,8 +39,7 @@ struct InvestmentStoreSyncRefreshTests {
 
     try await store.waitForNextEmission(
       matching: { $0.values.contains(where: { $0.value.quantity == dec("12345.00") }) },
-      description: "values contains the remote-sync write",
-      timeout: .seconds(2)
+      description: "values contains the remote-sync write"
     )
   }
 
@@ -89,13 +88,11 @@ struct InvestmentStoreSyncRefreshTests {
     store.setActiveAccount(accountA)
     try await store.waitForNextEmission(
       matching: { $0.values.first?.value.quantity == dec("100.00") },
-      description: "store sees account A's value",
-      timeout: .seconds(2))
+      description: "store sees account A's value")
 
     store.setActiveAccount(accountB)
     try await store.waitForNextEmission(
       matching: { $0.values.first?.value.quantity == dec("200.00") },
-      description: "store sees account B's value after switch",
-      timeout: .seconds(2))
+      description: "store sees account B's value after switch")
   }
 }

--- a/MoolahTests/Features/Transactions/TransactionStoreRegistryRefreshTests.swift
+++ b/MoolahTests/Features/Transactions/TransactionStoreRegistryRefreshTests.swift
@@ -98,8 +98,7 @@ struct TransactionStoreRegistryRefreshTests {
 
     try await store.waitForNextEmission(
       matching: { self.cryptoLegName($0, id: crypto.id) == "Renamed WBTC" },
-      description: "registry rename live-refreshes the open list",
-      timeout: .seconds(2))
+      description: "registry rename live-refreshes the open list")
 
     store.stopObserving()
   }

--- a/MoolahTests/Features/Transactions/TransactionStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Transactions/TransactionStoreSyncRefreshTests.swift
@@ -177,8 +177,7 @@ struct TransactionStoreSyncRefreshTests {
     }
     try await store.waitForNextEmission(
       matching: { $0.transactions.isEmpty },
-      description: "wipe propagated to store before cancellation",
-      timeout: .seconds(2)
+      description: "wipe propagated to store before cancellation"
     )
     store.stopObserving()
     #expect(store.transactions.isEmpty)

--- a/MoolahTests/Support/ExpectEventually.swift
+++ b/MoolahTests/Support/ExpectEventually.swift
@@ -25,10 +25,14 @@ import Testing
 /// `waitForNextEmission`: use that to assert an emission *occurs*; use this to
 /// assert a *value* settles. A `condition` that throws should be wrapped in
 /// `try?` by the caller (a thrown error reads as "not yet satisfied").
+/// The default timeout is deliberately generous (10s): a value-settling wait
+/// should never fail because a loaded CI runner was slow — short timeouts are
+/// a leading source of CI flakes. Polling means the fast path still returns
+/// the instant the value settles, so the large cap only buys headroom.
 @MainActor
 func expectEventually(
   _ description: @autoclosure () -> String = "condition to hold",
-  timeout: Duration = .seconds(2),
+  timeout: Duration = .seconds(10),
   pollInterval: Duration = .milliseconds(20),
   sourceLocation: SourceLocation = #_sourceLocation,
   _ condition: @MainActor () async -> Bool

--- a/MoolahTests/Support/TestableStoreObservation.swift
+++ b/MoolahTests/Support/TestableStoreObservation.swift
@@ -38,7 +38,14 @@ extension TestableStoreObservation {
   /// already cancelled the observation) counts as a timeout, not a
   /// completion — `didEmitWithin` relies on this distinction to assert
   /// the absence of post-cancellation emissions.
-  func waitForFirstEmission(timeout: Duration = .seconds(2)) async throws {
+  ///
+  /// The default is deliberately generous (10s). A match-wait should never
+  /// fail because a loaded CI runner was slow — short timeouts are a leading
+  /// source of CI flakes. The helper returns the instant the emission lands,
+  /// so the large cap only buys headroom, never latency. Pass a short
+  /// `timeout` only to assert the *absence* of an emission (see
+  /// `didEmitWithin`).
+  func waitForFirstEmission(timeout: Duration = .seconds(10)) async throws {
     let ticks = observationTicks
     try await withEmissionTimeout(
       timeout,
@@ -53,7 +60,7 @@ extension TestableStoreObservation {
       // timeout-task in `withEmissionTimeout` always wins, so the
       // caller observes "no emission" rather than a false-positive
       // completion. 5 minutes is far past every per-test timeout in
-      // the suite (default 2s) but tight enough that a runaway
+      // the suite (default 10s) but tight enough that a runaway
       // cancellation doesn't hang CI for an hour.
       try? await Task.sleep(for: .seconds(300))
     }
@@ -64,10 +71,15 @@ extension TestableStoreObservation {
   /// `timeout`. The predicate runs on `@MainActor` (it reads
   /// `@MainActor`-isolated store state); each tick body hops to
   /// `@MainActor` to read the snapshot before evaluating.
+  ///
+  /// The default is deliberately generous (10s) — see `waitForFirstEmission`.
+  /// Callers should not pass a `timeout`; a match-wait wants headroom, not a
+  /// short cap. Short timeouts belong only on absence assertions
+  /// (`didEmitWithin`).
   func waitForNextEmission(
     matching predicate: @MainActor @Sendable @escaping (State) -> Bool,
     description: String = "<predicate>",
-    timeout: Duration = .seconds(2)
+    timeout: Duration = .seconds(10)
   ) async throws {
     let ticks = observationTicks
     // The body must be `@Sendable` for `withTaskGroup`; we cannot

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -128,7 +128,7 @@ extension TransactionStore {
   /// by tests that want a one-line "do mutation; await emission"
   /// pattern rather than calling `waitForNextEmission(matching:)` with
   /// a custom predicate.
-  func awaitNextSyncRefresh(timeout: Duration = .seconds(2)) async throws {
+  func awaitNextSyncRefresh(timeout: Duration = .seconds(10)) async throws {
     try await waitForFirstEmission(timeout: timeout)
   }
 
@@ -136,7 +136,7 @@ extension TransactionStore {
   /// `transactions.count` matches `expected`". Useful for the most
   /// common test shape after a create/update/delete.
   func awaitTransactionCount(
-    _ expected: Int, timeout: Duration = .seconds(2)
+    _ expected: Int, timeout: Duration = .seconds(10)
   ) async throws {
     if transactions.count == expected { return }
     try await waitForNextEmission(


### PR DESCRIPTION
Implements the policy from review feedback on the `AccountStoreConversionTestsMore.perAccountBalancePopulatesEvenWhenAnotherAccountFails` flake: **short per-wait timeouts are a leading source of CI flakes, so the default should just be long enough and callers shouldn't pass a `timeout:` at all.**

### Root cause (for the record)
The merge-queue CI for #1110 ejected on a 2s timeout in that test: a match-wait races the store's init-spawned observation through a GRDB `observeAll()` emission **plus N async conversion calls**, which can land just past 2s on a loaded runner — even though the awaited state is correct and the helpers poll continuously (the larger cap only buys headroom, never latency). The *read-once race* in that test class was separately fixed on `main` by the `expectEventually` migration; this PR fixes the orthogonal *short-timeout* class.

### Change
Raise the default to **10s** on every match-wait helper and let callers inherit it:
- `waitForFirstEmission`, `waitForNextEmission` (`TestableStoreObservation`)
- `expectEventually` (`ExpectEventually`)
- `awaitNextSyncRefresh`, `awaitTransactionCount` (`TransactionStoreTestSupport`)
- the local `waitUntil` helpers in `ProfileSessionPragmaOptimize` / `InsightStore` / `InsightStoreShowLess`

Drop the now-redundant explicit `timeout:` args — the `.seconds(2)` sync-refresh waits, the `.seconds(5)` insight waits, and the per-suite `convergenceTimeout` constant in `EarmarkStorePartialConversionTests` — so they inherit the generous default.

Short timeouts now survive **only where they're correct**: absence assertions via `didEmitWithin(timeout: .milliseconds(200))` (a deliberately short cap to assert *no* emission), and the already-generous 30s stream `progressTimeout`.

### Verification
- `just test-mac` across the 12 affected suites — **48/48 passed**
- `just format-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)