### PR TITLE
fix(export): include account groups in JSON export and import

### DIFF
--- a/Backends/CloudKit/CloudKitDataImporter.swift
+++ b/Backends/CloudKit/CloudKitDataImporter.swift
@@ -4,6 +4,7 @@ import OSLog
 
 struct ImportResult: Sendable {
   let accountCount: Int
+  let accountGroupCount: Int
   let categoryCount: Int
   let earmarkCount: Int
   let budgetItemCount: Int
@@ -11,8 +12,8 @@ struct ImportResult: Sendable {
   let investmentValueCount: Int
 
   var totalCount: Int {
-    accountCount + categoryCount + earmarkCount + budgetItemCount + transactionCount
-      + investmentValueCount
+    accountCount + accountGroupCount + categoryCount + earmarkCount + budgetItemCount
+      + transactionCount + investmentValueCount
   }
 }
 
@@ -66,11 +67,12 @@ struct CloudKitDataImporter {
     let investmentValueCount = data.investmentValues.values.reduce(0) { $0 + $1.count }
 
     logger.info(
-      "Import complete: \(data.accounts.count) accounts, \(data.transactions.count) transactions, \(investmentValueCount) investment values"
+      "Import complete: \(data.accounts.count) accounts, \(data.accountGroups.count) groups, \(data.transactions.count) transactions, \(investmentValueCount) investment values"
     )
 
     return ImportResult(
       accountCount: data.accounts.count,
+      accountGroupCount: data.accountGroups.count,
       categoryCount: data.categories.count,
       earmarkCount: data.earmarks.count,
       budgetItemCount: budgetItemCount,
@@ -94,6 +96,10 @@ struct CloudKitDataImporter {
     try await registerInstruments(data: data)
     try await database.write { database in
       try Self.writeCategories(data: data, database: database)
+      // Groups before accounts so a member's `groupId` resolves to a
+      // present group row (the schema omits the FK constraint to allow
+      // out-of-order sync delivery, but a clean import writes parents first).
+      try Self.writeAccountGroups(data: data, database: database)
       try Self.writeAccountsAndEarmarks(data: data, database: database)
       try Self.writeTransactions(data: data, database: database)
       try Self.writeInvestmentValues(data: data, database: database)
@@ -116,6 +122,7 @@ struct CloudKitDataImporter {
       let hasNonFiat =
         data.instruments.contains { $0.kind != .fiatCurrency }
         || data.accounts.contains { $0.instrument.kind != .fiatCurrency }
+        || data.accountGroups.contains { $0.instrument.kind != .fiatCurrency }
         || data.transactions.contains { txn in
           txn.legs.contains { $0.instrument.kind != .fiatCurrency }
         }
@@ -138,6 +145,9 @@ struct CloudKitDataImporter {
     for account in data.accounts {
       try await register(account.instrument)
     }
+    for group in data.accountGroups {
+      try await register(group.instrument)
+    }
     for txn in data.transactions {
       for leg in txn.legs {
         try await register(leg.instrument)
@@ -150,6 +160,14 @@ struct CloudKitDataImporter {
   ) throws {
     for category in data.categories {
       try CategoryRow(domain: category).upsert(database)
+    }
+  }
+
+  nonisolated private static func writeAccountGroups(
+    data: ExportedData, database: Database
+  ) throws {
+    for group in data.accountGroups {
+      try AccountGroupRow(domain: group).upsert(database)
     }
   }
 

--- a/MoolahTests/Export/ExportImportAccountGroupsTests.swift
+++ b/MoolahTests/Export/ExportImportAccountGroupsTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Round-trips account groups through the JSON export/import pipeline.
+/// Groups are a synced, persisted entity; before this they were dropped
+/// on export, leaving imported accounts with dangling `groupId`
+/// references and no grouping in the sidebar.
+@Suite("Export/Import Account Groups")
+@MainActor
+struct ExportImportAccountGroupsTests {
+
+  private let instrument = Instrument.defaultTestInstrument
+
+  /// The seeded backend plus the two groups it contains, so each test can
+  /// assert against the exact group identities it expects to round-trip.
+  private struct Seed {
+    let backend: CloudKitBackend
+    let savings: AccountGroup
+    let bills: AccountGroup
+  }
+
+  /// Seeds two account groups in the `current` bucket and one account
+  /// assigned to the second group, so the round-trip can assert both the
+  /// group records and the `Account.groupId` membership survive.
+  private func makeSeed() async throws -> Seed {
+    let (backend, _) = try TestBackend.create(instrument: instrument)
+
+    let savings = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Savings", bucket: .current, instrument: instrument, position: 0,
+        isExpandedInSidebar: true)
+    )
+    let bills = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Bills", bucket: .current, instrument: instrument, position: 1)
+    )
+
+    _ = try await backend.accounts.create(
+      Account(
+        name: "Checking", type: .bank, instrument: instrument, groupId: bills.id
+      ),
+      openingBalance: InstrumentAmount(quantity: dec("500.00"), instrument: instrument)
+    )
+
+    return Seed(backend: backend, savings: savings, bills: bills)
+  }
+
+  private func makeTempFileURL() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("moolah-test-\(UUID().uuidString).json")
+  }
+
+  @Test("account groups are written to the export file")
+  func groupsAreExported() async throws {
+    let seed = try await makeSeed()
+    let tempURL = makeTempFileURL()
+    defer { try? FileManager.default.removeItem(at: tempURL) }
+
+    let profile = Profile(
+      label: "Test Profile", currencyCode: instrument.id, financialYearStartMonth: 1)
+    let coordinator = ExportCoordinator()
+    try await coordinator.exportToFile(url: tempURL, backend: seed.backend, profile: profile)
+
+    let data = try Data(contentsOf: tempURL)
+    let decoded = try JSONDecoder.exportDecoder.decode(ExportedData.self, from: data)
+
+    #expect(decoded.accountGroups.count == 2)
+    #expect(decoded.accountGroups.contains { $0.id == seed.savings.id })
+    #expect(decoded.accountGroups.contains { $0.id == seed.bills.id })
+    #expect(decoded.accounts.first?.groupId == seed.bills.id)
+  }
+
+  @Test("account groups and membership are restored on import")
+  func groupsRoundTrip() async throws {
+    let seed = try await makeSeed()
+    let tempURL = makeTempFileURL()
+    defer { try? FileManager.default.removeItem(at: tempURL) }
+
+    let profile = Profile(
+      label: "Test Profile", currencyCode: instrument.id, financialYearStartMonth: 1)
+    let coordinator = ExportCoordinator()
+    try await coordinator.exportToFile(url: tempURL, backend: seed.backend, profile: profile)
+
+    let freshDatabase = try ProfileDatabase.openInMemory()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let result = try await coordinator.importFromFile(
+      url: tempURL, database: freshDatabase, instrumentRegistrar: registry)
+
+    #expect(result.accountGroupCount == 2)
+
+    let cloudBackend = CloudKitBackend(
+      database: freshDatabase, instrument: instrument, profileLabel: "Test Profile",
+      conversionService: FixedConversionService(), instrumentRegistry: registry)
+
+    // Groups come back ordered by position, with all fields intact.
+    let groups = try await cloudBackend.accountGroups.fetchAll()
+    #expect(groups.map(\.id) == [seed.savings.id, seed.bills.id])
+    #expect(groups.map(\.name) == ["Savings", "Bills"])
+    #expect(groups.map(\.position) == [0, 1])
+    #expect(groups.allSatisfy { $0.bucket == .current })
+    #expect(groups.allSatisfy { $0.instrument == instrument })
+
+    // The account keeps its membership in the second group.
+    let accounts = try await cloudBackend.accounts.fetchAll()
+    #expect(accounts.first?.groupId == seed.bills.id)
+  }
+
+  /// A pre-existing export file predates the `accountGroups` key. Decoding
+  /// must tolerate its absence (defaulting to an empty list) rather than
+  /// failing the whole import.
+  @Test("legacy export without accountGroups key decodes to an empty list")
+  func legacyExportDecodesWithoutGroups() throws {
+    // UUID-keyed dictionaries (`earmarkBudgets`, `investmentValues`) are
+    // encoded by Foundation as flat arrays, not JSON objects — empty ones
+    // serialise as `[]`. The point of this fixture is the *absent*
+    // `accountGroups` key, which the custom decoder must tolerate.
+    let legacyJSON = """
+      {
+        "version": 1,
+        "exportedAt": "2026-01-01T00:00:00Z",
+        "profileLabel": "Legacy",
+        "currencyCode": "\(instrument.id)",
+        "financialYearStartMonth": 1,
+        "instruments": [],
+        "accounts": [],
+        "categories": [],
+        "earmarks": [],
+        "earmarkBudgets": [],
+        "transactions": [],
+        "investmentValues": []
+      }
+      """
+    let data = Data(legacyJSON.utf8)
+    let decoded = try JSONDecoder.exportDecoder.decode(ExportedData.self, from: data)
+    #expect(decoded.accountGroups.isEmpty)
+  }
+}

--- a/Shared/DataExporter.swift
+++ b/Shared/DataExporter.swift
@@ -44,6 +44,7 @@ actor DataExporter {
   /// the assembly to separate helpers.
   private struct StagedDownloads {
     let accounts: [Account]
+    let accountGroups: [AccountGroup]
     let categories: [Category]
     let earmarks: [Earmark]
     let earmarkBudgets: [UUID: [EarmarkBudgetItem]]
@@ -60,6 +61,13 @@ actor DataExporter {
       "accounts", signpost: "export.accounts", signpostID: signpostID
     ) {
       try await backend.accounts.fetchAll()
+    }
+
+    progress(.downloading(step: "account groups"))
+    let accountGroups = try await runStage(
+      "account groups", signpost: "export.accountGroups", signpostID: signpostID
+    ) {
+      try await backend.accountGroups.fetchAll()
     }
 
     progress(.downloading(step: "categories"))
@@ -100,7 +108,8 @@ actor DataExporter {
     }
 
     return StagedDownloads(
-      accounts: accounts, categories: categories, earmarks: earmarks, earmarkBudgets: budgets,
+      accounts: accounts, accountGroups: accountGroups, categories: categories,
+      earmarks: earmarks, earmarkBudgets: budgets,
       transactions: transactions, investmentValues: investmentValues)
   }
 
@@ -111,7 +120,10 @@ actor DataExporter {
     financialYearStartMonth: Int
   ) -> ExportedData {
     let instruments = collectInstruments(
-      currencyCode: currencyCode, transactions: stages.transactions)
+      currencyCode: currencyCode,
+      accounts: stages.accounts,
+      accountGroups: stages.accountGroups,
+      transactions: stages.transactions)
     return ExportedData(
       version: 1,
       exportedAt: Date(),
@@ -120,6 +132,7 @@ actor DataExporter {
       financialYearStartMonth: financialYearStartMonth,
       instruments: instruments,
       accounts: stages.accounts,
+      accountGroups: stages.accountGroups,
       categories: stages.categories,
       earmarks: stages.earmarks,
       earmarkBudgets: stages.earmarkBudgets,
@@ -147,10 +160,19 @@ actor DataExporter {
   }
 
   private func collectInstruments(
-    currencyCode: String, transactions: [Transaction]
+    currencyCode: String,
+    accounts: [Account],
+    accountGroups: [AccountGroup],
+    transactions: [Transaction]
   ) -> [Instrument] {
     let profileInstrument = Instrument.fiat(code: currencyCode)
     var instrumentsById: [String: Instrument] = [profileInstrument.id: profileInstrument]
+    for account in accounts {
+      instrumentsById[account.instrument.id] = account.instrument
+    }
+    for group in accountGroups {
+      instrumentsById[group.instrument.id] = group.instrument
+    }
     for txn in transactions {
       for leg in txn.legs {
         instrumentsById[leg.instrument.id] = leg.instrument

--- a/Shared/ExportedData.swift
+++ b/Shared/ExportedData.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// All data exported from a profile, ready for serialization or import into SwiftData.
-struct ExportedData: Codable, Sendable {
+struct ExportedData {
   let version: Int
   let exportedAt: Date
   let profileLabel: String
@@ -9,6 +9,10 @@ struct ExportedData: Codable, Sendable {
   let financialYearStartMonth: Int
   let instruments: [Instrument]
   let accounts: [Account]
+  /// Sidebar account groups. Accounts reference their group by
+  /// `Account.groupId`; without the group records here, imported
+  /// accounts would carry dangling references and lose their grouping.
+  let accountGroups: [AccountGroup]
   let categories: [Category]
   let earmarks: [Earmark]
   let earmarkBudgets: [UUID: [EarmarkBudgetItem]]
@@ -23,6 +27,7 @@ struct ExportedData: Codable, Sendable {
     financialYearStartMonth: Int = 1,
     instruments: [Instrument] = [],
     accounts: [Account],
+    accountGroups: [AccountGroup] = [],
     categories: [Category],
     earmarks: [Earmark],
     earmarkBudgets: [UUID: [EarmarkBudgetItem]],
@@ -36,11 +41,40 @@ struct ExportedData: Codable, Sendable {
     self.financialYearStartMonth = financialYearStartMonth
     self.instruments = instruments
     self.accounts = accounts
+    self.accountGroups = accountGroups
     self.categories = categories
     self.earmarks = earmarks
     self.earmarkBudgets = earmarkBudgets
     self.transactions = transactions
     self.investmentValues = investmentValues
+  }
+}
+
+extension ExportedData: Sendable {}
+
+extension ExportedData: Codable {
+  /// Custom decoding so export files written before `accountGroups`
+  /// existed still import: the key is optional and defaults to empty.
+  /// Every other field keeps its original required semantics. `encode`
+  /// and `CodingKeys` stay synthesised, so new exports always write the key.
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    version = try container.decode(Int.self, forKey: .version)
+    exportedAt = try container.decode(Date.self, forKey: .exportedAt)
+    profileLabel = try container.decode(String.self, forKey: .profileLabel)
+    currencyCode = try container.decode(String.self, forKey: .currencyCode)
+    financialYearStartMonth = try container.decode(Int.self, forKey: .financialYearStartMonth)
+    instruments = try container.decode([Instrument].self, forKey: .instruments)
+    accounts = try container.decode([Account].self, forKey: .accounts)
+    accountGroups =
+      try container.decodeIfPresent([AccountGroup].self, forKey: .accountGroups) ?? []
+    categories = try container.decode([Category].self, forKey: .categories)
+    earmarks = try container.decode([Earmark].self, forKey: .earmarks)
+    earmarkBudgets = try container.decode(
+      [UUID: [EarmarkBudgetItem]].self, forKey: .earmarkBudgets)
+    transactions = try container.decode([Transaction].self, forKey: .transactions)
+    investmentValues = try container.decode(
+      [UUID: [InvestmentValue]].self, forKey: .investmentValues)
   }
 }
 

--- a/Shared/ImportVerifier.swift
+++ b/Shared/ImportVerifier.swift
@@ -11,8 +11,9 @@ import Foundation
 // rather than feature business logic.
 import GRDB
 
-struct ImportEntityCounts: Sendable {
+struct ImportEntityCounts: Sendable, Equatable {
   let accounts: Int
+  let accountGroups: Int
   let categories: Int
   let earmarks: Int
   let transactions: Int
@@ -38,6 +39,7 @@ struct ImportVerifier {
     let actualCounts = try await database.read { database in
       try ImportEntityCounts(
         accounts: AccountRow.fetchCount(database),
+        accountGroups: AccountGroupRow.fetchCount(database),
         categories: CategoryRow.fetchCount(database),
         earmarks: EarmarkRow.fetchCount(database),
         transactions: TransactionRow.fetchCount(database),
@@ -48,20 +50,14 @@ struct ImportVerifier {
     let expectedInvestmentValueCount = exported.investmentValues.values.reduce(0) { $0 + $1.count }
     let expectedCounts = ImportEntityCounts(
       accounts: exported.accounts.count,
+      accountGroups: exported.accountGroups.count,
       categories: exported.categories.count,
       earmarks: exported.earmarks.count,
       transactions: exported.transactions.count,
       investmentValues: expectedInvestmentValueCount
     )
-    let countMatch =
-      actualCounts.accounts == expectedCounts.accounts
-      && actualCounts.categories == expectedCounts.categories
-      && actualCounts.earmarks == expectedCounts.earmarks
-      && actualCounts.transactions == expectedCounts.transactions
-      && actualCounts.investmentValues == expectedCounts.investmentValues
-
     return ImportVerificationResult(
-      countMatch: countMatch,
+      countMatch: actualCounts == expectedCounts,
       expectedCounts: expectedCounts,
       actualCounts: actualCounts
     )


### PR DESCRIPTION
## Problem

Account groups are a real, synced, persisted entity, but the JSON export/import feature dropped them entirely:

- `ExportedData` had no `accountGroups` field
- `DataExporter` never called `backend.accountGroups.fetchAll()`
- `CloudKitDataImporter` never wrote any group rows

The omission was symmetric, so it didn't crash — but it was **silent data loss**. Imported accounts kept their `Account.groupId` back-references while the groups those ids pointed at were never recreated. Unknown group ids degrade to "no group", so on import **all grouping, group ordering, and sidebar membership was lost**: a user who exported a profile with carefully organised account groups and re-imported it got a flat, ungrouped list back.

## Fix

Thread account groups through the whole pipeline:

- **`ExportedData`** gains `accountGroups: [AccountGroup]`. A custom `init(from:)` decodes the key with `decodeIfPresent ?? []` so **export files written before this key still import**; `encode`/`CodingKeys` stay synthesised. Conformances moved to extensions per CODE_GUIDE §2.
- **`DataExporter`** fetches groups as a new download stage and now includes account + group instruments in the exported instrument manifest (previously legs only).
- **`CloudKitDataImporter`** writes groups (before accounts, so members resolve to a present row), registers group instruments on the shared registry, and reports `accountGroupCount`.
- **`ImportVerifier`** counts groups so a partial import fails the verification gate. `ImportEntityCounts` is now `Equatable` for a clean structural compare instead of a hand-rolled conjunction.

### Compatibility

The export `version` stays at **1**: the change is backward- **and** forward-compatible. New exports still import into older builds (they ignore the unknown key), and new builds tolerate old exports (missing key → empty list). Bumping the version would have made older builds reject new files outright, which is strictly worse.

`isExpandedInSidebar` is intentionally not restored — it's a local-only preference with no GRDB sidecar, so all groups start collapsed after import, matching existing relaunch behaviour.

## Tests

New `ExportImportAccountGroupsTests` suite:
- groups are serialised into the export file
- full round-trip restores groups (id, name, position, bucket, instrument) **and** `Account.groupId` membership
- legacy export lacking the `accountGroups` key decodes to an empty list

Full export/import suite (12 tests across 6 suites) passes; `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)