### PR TITLE
docs: bring README, CLAUDE.md, guides, and .claude docs up to date

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -40,7 +40,7 @@ The only exception is scope the user has explicitly authorised in the conversati
 Architectural rules are the highest priority: these are the violations that make the codebase hard to test, change, or reason about.
 
 - **No SwiftLint baseline may be (re)introduced.** The `.swiftlint-baseline.yml` allowlist has been fully paid down and removed; `format-check` runs `swiftlint lint --strict` with zero suppression. Any PR that adds a `.swiftlint-baseline.yml`, adds a `--baseline` flag to a `swiftlint` invocation, runs `swiftlint --write-baseline`, silences a violation with `// swiftlint:disable` (absent a real, documented justification), or bumps a `.swiftlint.yml` threshold to dodge a failure is an automatic **Critical** finding — no exceptions unless the PR body explicitly quotes user authorisation. PRs fix newly-flagged violations in source, never launder them. Covered in `CLAUDE.md` > Pre-Commit Checklist.
-- **Domain isolation** -- `Domain/Models/` and `Domain/Repositories/` import nothing from `SwiftUI`, `SwiftData`, `URLSession`, `Backends/`, or any `Remote*` type.
+- **Domain isolation** -- `Domain/Models/` and `Domain/Repositories/` import nothing from `SwiftUI`, `GRDB`, `URLSession`, `Backends/`, or any `Remote*` type.
 - **Repository access** only via `@Environment(BackendProvider.self)` + repository protocols. Feature code must not import `Backends/` or reference `Remote*` types directly.
 - **Thin views** -- no multi-step async flows, no error formatting, no aggregations, no parsing in private view methods. Flag logic that should live in a store, model extension, or shared utility. Private view methods are not unit-testable.
 - **Critical — Searchable invariant for detail-column leaves.** The
@@ -67,7 +67,7 @@ Architectural rules are the highest priority: these are the violations that make
   to a diff that demonstrates intra-leaf shape variance — only the new
   invariant applies.
 - **Store shape** -- `@MainActor @Observable`, state rollback on failure (save old state, mutate, revert on error), error state surfaced for the UI.
-- **Currency sign convention** -- no `abs()` on monetary values; sign preserved through arithmetic; `MonetaryAmount.parseCents(from:)` is the single parser (don't duplicate `parseCurrency` in views).
+- **Currency sign convention** -- no `abs()` on monetary values; sign preserved through arithmetic; `InstrumentAmount.parseQuantity(from:decimals:)` is the single parser (don't duplicate amount parsing in views).
 - **Singleton / global sniffing** -- flag `UserDefaults.standard` outside a dedicated wrapper type; flag `Date()` in non-boundary business logic (tests need injection); flag static mutable state.
 
 ### B. Swift idiom quality (from CODE_GUIDE.md)
@@ -109,7 +109,7 @@ Architectural rules are the highest priority: these are the violations that make
 - **`UserDefaults.standard` inside a dedicated wrapper type** is fine -- the wrapper is the boundary.
 - **`Date()` in views for display-only formatting** is fine; only flag when used to compute business logic that a test would need to pin.
 - **`@unchecked Sendable` on `CloudKitBackend`** -- concurrency-review's exemption list covers this; don't flag here.
-- **`MonetaryAmount(cents: max(0, -serverAmount.cents))`** -- documented sign pattern from CLAUDE.md for expense displays; this is not an `abs()` violation.
+- **`InstrumentAmount(quantity: max(0, -serverAmount.quantity), instrument:)`** -- documented sign pattern from CLAUDE.md for expense displays; this is not an `abs()` violation.
 - **Large-file exemptions granted in `.swiftlint.yml`** (especially for test files) are valid -- don't demand they be revisited unless the context obviously changed.
 - **Empty / single-line trailing `private extension Self {}`** -- if the file genuinely has no private helpers, don't demand one.
 

--- a/.claude/agents/sync-review.md
+++ b/.claude/agents/sync-review.md
@@ -10,7 +10,7 @@ You are an expert CloudKit and CKSyncEngine specialist. Your role is to review c
 
 ## Architecture Context
 
-This project uses CKSyncEngine (not NSPersistentCloudKitContainer) with SwiftData for iCloud sync. Two sync layers exist:
+This project uses CKSyncEngine (not NSPersistentCloudKitContainer) over a per-profile GRDB/SQLite store for iCloud sync. Two sync layers exist:
 
 1. **ProfileIndexSyncEngine** -- syncs `ProfileRecord` via the `profile-index` zone
 2. **ProfileSyncEngine** (one per active profile) -- syncs per-profile data via `profile-{profileId}` zones

--- a/.claude/skills/interpret-benchmarks/SKILL.md
+++ b/.claude/skills/interpret-benchmarks/SKILL.md
@@ -35,14 +35,14 @@ grep -A2 "measured" .agent-tmp/benchmark-output.txt
 | Stddev | Interpretation |
 |---|---|
 | < 5% | Highly reliable. Safe to compare small differences. |
-| 5-10% | Reliable. Normal for SwiftData operations. |
+| 5-10% | Reliable. Normal for database (GRDB) operations. |
 | 10-20% | Marginal. Can detect large regressions but not subtle ones. |
 | > 20% | Unreliable. Do not draw conclusions. Fix the benchmark first. |
 
 If stddev is high, check:
 - Is other work running on the machine?
 - Is setup or teardown leaking into the measure block?
-- Is SwiftData's change tracker accumulating? (Add `context.reset()` between iterations)
+- Is the in-memory GRDB database growing across iterations? (Reset / recreate the database between iterations)
 - Is there autorelease pool buildup? (Add `autoreleasepool {}`)
 
 ## Step 4: Scaling Analysis
@@ -65,7 +65,7 @@ Ratio = (2x average) / (1x average)
 Look at the individual values array for each benchmark:
 
 - **One high outlier, rest consistent** — likely a one-time cost (cache miss, JIT warmup). Usually not actionable unless it happens on every app launch.
-- **Steadily increasing values** — SwiftData context accumulation or memory pressure. The benchmark setup may need fixing (context reset, autoreleasepool).
+- **Steadily increasing values** — database growth across iterations or memory pressure. The benchmark setup may need fixing (reset the in-memory database between iterations, autoreleasepool).
 - **Bimodal distribution** (some fast, some slow) — contention or a code path that sometimes hits a slow branch. Investigate with Instruments.
 
 ## Step 6: Compare Against Baselines

--- a/.claude/skills/modifying-cloudkit-schema/SKILL.md
+++ b/.claude/skills/modifying-cloudkit-schema/SKILL.md
@@ -76,7 +76,7 @@ Not allowed. Same as rename: add a new field with the new type, deprecate the ol
 
 1. Declare the type in `schema.ckdb` with the standard system-field block, `___recordID REFERENCE QUERYABLE`, and the standard grants.
 2. `just generate`. New wire struct exists.
-3. Add the domain type in `Domain/Models/` (and the SwiftData `@Model` in `Backends/CloudKit/Models/` if applicable).
+3. Add the domain type in `Domain/Models/` (and, if it needs local persistence, the GRDB row + schema under `Backends/GRDB/` per `guides/DATABASE_SCHEMA_GUIDE.md`).
 4. Create `Backends/CloudKit/Sync/<RecordType>+CloudKit.swift` with `CloudKitRecordConvertible` conformance using the wire struct.
 5. Register the type in `RecordTypeRegistry.allTypes` (in `Backends/CloudKit/Sync/CloudKitRecordConvertible.swift`).
 6. Add a round-trip test in `MoolahTests/Backends/CloudKit/RoundTripTests.swift`.

--- a/.claude/skills/profile-performance/SKILL.md
+++ b/.claude/skills/profile-performance/SKILL.md
@@ -55,7 +55,6 @@ These show up in Instruments under the "os_signpost" instrument:
 | Sync | `applyRemoteChanges` | Full batch processing (saves + deletes + balance + save) |
 | Sync | `applyBatchSaves` | Record upsert by type |
 | Sync | `applyBatchDeletions` | Record deletion by type |
-| Sync | `contextSave` | SwiftData context.save() |
 | Sync | `queueAllExistingRecords` | Initial record scanning for upload |
 | Sync | `nextRecordZoneChangeBatch` | Building upload batch |
 | Balance | `invalidateCachedBalances` | Clearing cached balances after sync |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ grep -B5 -A10 'testMethodName' .agent-tmp/test-output.txt
 - **Targeting:** iOS 26+ and macOS 26+ (Universal SwiftUI app).
 - **Domain Layer:** Strictly isolated. `Domain/Models/` and `Domain/Repositories/` must never import `SwiftUI`, `GRDB`, `URLSession`, or any backend module.
 - **Features:** Only talk to repository protocols via `@Environment(BackendProvider.self)`. No feature file may import `Backends/` directly.
-- **Currency:** All currency values are stored as `Int` (cents). Currency flows from `Profile.currency` → backend → `MonetaryAmount` on all domain objects. Views derive currency from loaded domain objects, never from a global constant. Tests use `Currency.defaultTestCurrency` (defined in `MoolahTests/Support/TestCurrency.swift`).
+- **Currency & instruments:** Monetary values are modelled as `InstrumentAmount` — a `Decimal` `quantity` paired with its `Instrument` (a fiat currency, stock, or crypto token), stored as `Int64` scaled by 10^8. A profile's base currency comes from `Profile.currencyCode` (exposed as the computed `Profile.instrument`). Domain objects carry their own `InstrumentAmount`s, and views derive the instrument/currency from loaded domain objects, never from a global constant. Arithmetic across mismatched instruments traps at runtime — see `guides/INSTRUMENT_CONVERSION_GUIDE.md`. Tests use `Instrument.defaultTestInstrument` (defined in `MoolahTests/Support/Instrument+TestInstrument.swift`).
 - **Monetary Sign Convention:** The sign of monetary amounts (positive or negative) is semantically important — avoid using `abs()` or otherwise discarding it. Expenses are typically negative values, but refunds are expenses with positive values. Any transaction type may have values with the opposite sign to normal. Preserve and propagate the original sign; display logic should handle both signs correctly.
 - **Backend:** `BackendProvider` is the injection point. `CloudKitBackend` is the production backend — it wraps the GRDB repositories (`Backends/GRDB/`) over a per-profile SQLite database and the CKSyncEngine sync layer. `TestBackend` (CloudKitBackend backed by an in-memory GRDB database) is used in tests; `PreviewBackend` is used in SwiftUI previews.
 - **CloudKit Schema:** `CloudKit/schema.ckdb` is the canonical CloudKit
@@ -143,8 +143,8 @@ Views must be thin wrappers that bind state, dispatch actions, and render. **All
 - Computed aggregations over domain data (e.g., available funds, filtered totals).
 
 **What belongs in a Model extension or Shared utility:**
-- Data transformation and validation (e.g., form fields → Transaction, currency text → cents).
-- Parsing logic (use `MonetaryAmount.parseCents(from:)` — never duplicate `parseCurrency` in views).
+- Data transformation and validation (e.g., form fields → Transaction, amount text → `Decimal` quantity).
+- Parsing logic (use `InstrumentAmount.parseQuantity(from:decimals:)` — never duplicate amount parsing in views).
 - Computed display properties that are reused across views.
 
 **What stays in the View:**
@@ -153,7 +153,7 @@ Views must be thin wrappers that bind state, dispatch actions, and render. **All
 - Passing the store's result to local UI state (e.g., updating `selectedTransaction` from a `PayResult`).
 - SwiftUI layout, styling, and modifiers.
 
-**Why:** Private view methods cannot be unit-tested. Logic in stores runs against `TestBackend` (CloudKitBackend + in-memory GRDB) in milliseconds with no simulator. See `plans/UI_TESTING_PLAN.md` for the full audit and refactoring roadmap.
+**Why:** Private view methods cannot be unit-tested. Logic in stores runs against `TestBackend` (CloudKitBackend + in-memory GRDB) in milliseconds with no simulator. See `plans/completed/UI_TESTING_PLAN.md` for the full audit and refactoring roadmap.
 
 ## Testing & TDD
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Moolah — Native iOS/macOS App
 
 A universal personal finance app for iPhone and Mac. Tracks accounts, transactions,
-categories, earmarks (savings goals), scheduled payments, and provides analysis and
-reporting. Data syncs across devices via iCloud/CloudKit — no server component required.
+categories, earmarks (savings goals), scheduled payments, and investment & crypto
+holdings, and provides analysis and reporting. Data syncs across devices via
+iCloud/CloudKit — no server component required.
 
 ## Requirements
 
@@ -53,9 +54,10 @@ press **Run** (⌘R).
 just test
 ```
 
-Runs the full test suite on both iPhone 17 Pro simulator and macOS. All feature and
-domain tests use `InMemoryBackend` — no network connection or server account is
-needed. See [`scripts/test.sh`](scripts/test.sh) for the platform-specific details.
+Runs the full test suite on both iPhone 17 Pro simulator and macOS. Feature and
+domain tests run against `TestBackend` (a `CloudKitBackend` backed by an in-memory
+GRDB database) — no network connection or server account is needed. See
+[`scripts/test.sh`](scripts/test.sh) for the platform-specific details.
 
 To run one platform manually:
 
@@ -73,26 +75,29 @@ moolah-native/
 │   ├── Models/             # Plain Swift structs: UserProfile, Account, Transaction, …
 │   └── Repositories/       # Protocol definitions only — no backend imports
 ├── Backends/
-│   └── CloudKit/           # iCloud/CloudKit backend (SwiftData, local-first sync)
+│   ├── CloudKit/           # Production backend: GRDB/SQLite repositories + CKSyncEngine iCloud sync
+│   ├── GRDB/               # SQLite schema, records, and repository implementations
+│   └── …                   # Price/rate providers (CoinGecko, CryptoCompare, Binance, YahooFinance, Frankfurter)
 ├── Features/               # One folder per screen/feature
-│   ├── Auth/               # AuthStore, AppRootView, WelcomeView, UserMenuView
+│   ├── Auth/               # AuthStore, AppRootView, SignedOutView, UserMenuView
 │   └── …
 ├── Shared/
 │   ├── Components/         # Reusable SwiftUI views
-│   └── Extensions/
-├── MoolahTests/
+│   ├── Extensions/
+│   └── PreviewBackend.swift # In-memory backend used by SwiftUI previews
+├── MoolahTests/            # Unit + store tests (MoolahTests_iOS, MoolahTests_macOS)
 │   ├── Domain/             # Pure logic and model tests
-│   ├── Features/           # Store tests using InMemoryBackend
-│   ├── Support/
-│   │   ├── InMemoryBackend/ # In-memory BackendProvider for tests
-│   │   └── Fixtures/        # JSON fixture files
-│   └── UI/                 # Snapshot and XCUITest
+│   ├── Features/           # Store tests using TestBackend
+│   └── Support/
+│       ├── TestBackend.swift # CloudKitBackend over an in-memory GRDB database
+│       └── Fixtures/         # JSON/CSV fixture files
+├── MoolahUITests_macOS/    # XCUITest UI tests (macOS only)
 ├── fastlane/               # Fastlane config for TestFlight/App Store builds
-├── prompts/                # Prompts for related server-side changes
 ├── plans/                  # Planning documents and feature specs
+├── guides/                 # Engineering guides (architecture, testing, sync, …)
 ├── justfile                # Common dev tasks (just build-mac, just test, …)
 ├── project.yml             # XcodeGen spec — edit this, not the .xcodeproj
-├── .github/workflows/      # CI, TestFlight, and monthly auto-tag workflows
+├── .github/workflows/      # CI, release (RC/final), and monthly-RC workflows
 └── scripts/
     └── test.sh             # Runs tests on both platforms
 ```
@@ -103,17 +108,20 @@ The app uses a **repository pattern** to decouple features from any specific bac
 
 ```
 Views / Stores  →  Repository protocols  →  Backend implementations
-                   (Domain layer)            CloudKit (SwiftData + iCloud sync)
+                   (Domain layer)            CloudKit (GRDB/SQLite + CKSyncEngine sync)
 ```
 
 - **Domain models** (`UserProfile`, `Account`, `Transaction`, etc.) are plain Swift
   structs in the `Domain` module. Features only ever see these types.
 - **Repository protocols** (`AuthProvider`, `AccountRepository`, ...) express
   operations in domain terms — no networking or persistence imports.
-- **`BackendProvider`** is the single injection point via `@Environment`. All profiles
-  use CloudKit (iCloud) for storage and sync — no server component required.
-- **`InMemoryBackend`** (test target only) is a full in-memory implementation used in
-  all tests. It is never compiled into the app binary.
+- **`BackendProvider`** is the single injection point via `@Environment`. The
+  production implementation, **`CloudKitBackend`**, wraps the GRDB repositories
+  (`Backends/GRDB/`) over a per-profile SQLite database plus a CKSyncEngine iCloud
+  sync layer — no server component required.
+- **`TestBackend`** (test target only) is a `CloudKitBackend` backed by an in-memory
+  GRDB database, used by every test. **`PreviewBackend`** is the equivalent for
+  SwiftUI previews. Neither is compiled into the app binary.
 
 ## Code Signing
 
@@ -125,25 +133,35 @@ Views / Stores  →  Repository protocols  →  Backend implementations
 
 ## Release & TestFlight
 
-Releases are automated via GitHub Actions and Fastlane:
+Releases ship in two stages — release candidate, then final — both driven by `just`
+targets and GitHub Actions:
 
-- **Tag push** (`v1.0.0`) triggers `.github/workflows/testflight.yml` which builds and
-  uploads to TestFlight.
-- **Monthly auto-tag** (`.github/workflows/monthly-tag.yml`) creates a tag on the 1st
-  of each month to keep TestFlight builds within the 90-day expiry.
-- **Manual trigger** via `workflow_dispatch` on either workflow.
+- **RC tag** (`vX.Y.Z-rc.N`) fires `.github/workflows/release-rc.yml`, which builds and
+  notarises the macOS zip (attached to the GitHub pre-release) and uploads the iOS build
+  to TestFlight.
+- **Final tag** (`vX.Y.Z`) fires `.github/workflows/release-final.yml` at the same commit
+  as the promoted RC: it submits to the App Store and publishes the notarised Mac zip on
+  the GitHub Release.
+- **Monthly RC** (`.github/workflows/monthly-tag.yml`) cuts a fresh RC on the 1st of each
+  month so TestFlight builds stay within the 90-day expiry. `workflow_dispatch` triggers
+  it manually.
+
+The flow is orchestrated by the release scripts — never push a release tag by hand:
 
 ```bash
-just bump-version 1.2.0   # update MARKETING_VERSION in project.yml
-git tag v1.2.0 && git push origin v1.2.0   # triggers TestFlight build
+just release-preflight                 # verify a clean, in-sync, green-CI HEAD
+just release-next-version rc            # compute the next RC version + notes base
+just release-create-rc 1.2.0-rc.1 notes.md   # tag + create the GH pre-release
+just release-wait v1.2.0-rc.1           # follow the workflow to completion
 ```
 
-Local shortcuts:
+Local Fastlane shortcuts:
 
 ```bash
 just certificates   # sync signing certs via Fastlane Match
-just testflight     # build and upload to TestFlight locally
+just testflight     # build and upload to TestFlight locally (fastlane ios beta)
+just bump-version 1.2.0   # update MARKETING_VERSION in project.yml
 ```
 
-See [`plans/IOS_RELEASE_AUTOMATION_PLAN.md`](plans/IOS_RELEASE_AUTOMATION_PLAN.md) for
-the full setup guide including Apple Developer account configuration and GitHub secrets.
+See [`guides/RELEASE_GUIDE.md`](guides/RELEASE_GUIDE.md) for the full procedure,
+recovery steps, and the CloudKit schema-deploy gate.

--- a/guides/BENCHMARKING_GUIDE.md
+++ b/guides/BENCHMARKING_GUIDE.md
@@ -109,7 +109,7 @@ Examples:
 
 2. **Use 10 iterations** (`options.iterationCount = 10`). XCTest's default of 5 is too few for noisy operations.
 
-3. **No per-iteration store reset is needed for fetch benchmarks.** GRDB decodes a fresh value-type row on every fetch and keeps no cross-fetch identity map or change tracker, so later iterations don't drift the way SwiftData's accumulated objects did. Reuse the same in-memory database from `TestBackend.create()` across iterations:
+3. **No per-iteration store reset is needed for fetch benchmarks.** GRDB decodes a fresh value-type row on every fetch and keeps no cross-fetch identity map or change tracker, so later iterations don't drift the way a change-tracked object graph would. Reuse the same in-memory database from `TestBackend.create()` across iterations:
 
    ```swift
    measure(metrics: metrics, options: options) {

--- a/guides/BRAND_GUIDE.md
+++ b/guides/BRAND_GUIDE.md
@@ -261,8 +261,8 @@ Use these when writing about the app. Do not invent features.
 | Sync | Optional iCloud sync (user's own iCloud, end-to-end) |
 | Accounts | No sign-up required, no user accounts |
 | Cloud servers | None — no third-party servers touch user data |
-| Key features | Transaction tracking, custom categories, split transactions, notes, search, recurring transactions, multiple accounts, budgets, reports, charts (spending trends, income vs expenses, category breakdowns), filters, export |
-| What it's not | Not a bank, not a payment processor, no bank-sync/open-banking, no investment tracking |
+| Key features | Transaction tracking, custom categories, split transactions, notes, search, recurring transactions, multiple accounts, earmarks (savings goals) & budgets, investment & crypto holdings tracking, reports, charts (spending trends, income vs expenses, category breakdowns, net worth & forecast), filters, CSV import, export |
+| What it's not | Not a bank, not a payment processor, no bank-sync/open-banking |
 
 ---
 

--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -212,12 +212,12 @@ Apple's [Choosing Between Structures and Classes](https://developer.apple.com/do
   ```swift
   enum CurrencyFormat {                          // Good
     static let maxFractionDigits = 2
-    static func parseCents(from text: String) -> Int? { … }
+    static func parseQuantity(from text: String, decimals: Int) -> Decimal? { … }
   }
 
   struct CurrencyFormat {                        // Bad — use a case-less enum
     static let maxFractionDigits = 2
-    static func parseCents(from text: String) -> Int? { … }
+    static func parseQuantity(from text: String, decimals: Int) -> Decimal? { … }
   }
   ```
 
@@ -472,9 +472,9 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
 
 Cross-references — these rules are normative and live in `CLAUDE.md`:
 
-- **`Int` cents are the canonical representation.** All monetary values are stored as integer cents. See `CLAUDE.md` "Currency" section.
+- **`InstrumentAmount` is the canonical representation.** Monetary values are a `Decimal` `quantity` paired with their `Instrument` (stored as `Int64` scaled by 10^8 at the persistence layer). See `CLAUDE.md` "Currency & instruments" section.
 - **Preserve the sign** of monetary amounts. Expenses are typically negative, but a refund is an expense with a positive value — any transaction type may carry the opposite sign to its norm. **Do not use `abs()`** or otherwise discard the sign. Display logic must handle both signs correctly. See `CLAUDE.md` "Monetary Sign Convention."
-- **Parse via `MonetaryAmount.parseCents(from:)`.** Never duplicate `parseCurrency` in views or reimplement cent parsing anywhere else.
+- **Parse via `InstrumentAmount.parseQuantity(from:decimals:)`.** Never duplicate amount parsing in views or reimplement quantity parsing anywhere else.
 - **Conversion correctness** — all multi-currency aggregation rules live in `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
 
 ---

--- a/guides/CONCURRENCY_GUIDE.md
+++ b/guides/CONCURRENCY_GUIDE.md
@@ -69,7 +69,7 @@ All domain models are `struct` conforming to `Sendable`. They are the data that 
 struct Transaction: Identifiable, Codable, Sendable, Hashable {
     let id: UUID
     var payee: String
-    var amount: MonetaryAmount
+    var amount: InstrumentAmount
     // ...
 }
 ```
@@ -627,7 +627,7 @@ All store tests are `@MainActor` because the stores themselves are `@MainActor`:
 @MainActor
 final class AccountStoreTests: XCTestCase {
     func testLoad() async throws {
-        let (backend, _, _) = try TestBackend.create()
+        let (backend, _) = try TestBackend.create()
         let store = AccountStore(repository: backend.accounts)
 
         await store.load()

--- a/guides/DATABASE_CODE_GUIDE.md
+++ b/guides/DATABASE_CODE_GUIDE.md
@@ -62,21 +62,21 @@ Construction sites are `Backends/GRDB/`, `ProfileSession`, and test targets. The
 
 ### Repository pattern
 
-Repositories live under `Backends/GRDB/Repositories/`, are `Sendable` structs, and hold a `DatabaseWriter`:
+Repositories live under `Backends/GRDB/Repositories/`, are `final class`es marked `@unchecked Sendable`, and hold a `DatabaseWriter`:
 
 ```swift
-struct GRDBAccountRepository: AccountRepository {
-    let writer: any DatabaseWriter
+final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
+    let database: any DatabaseWriter
 
     func accounts() async throws -> [Account] {
-        try await writer.read { db in
-            try AccountRecord.fetchAll(db).map(\.domain)
+        try await database.read { db in
+            try AccountRow.fetchAll(db).map(\.domain)
         }
     }
 
     func upsert(_ account: Account) async throws {
-        try await writer.write { db in
-            try AccountRecord(domain: account).upsert(db)
+        try await database.write { db in
+            try AccountRow(domain: account).upsert(db)
         }
     }
 }
@@ -88,7 +88,7 @@ struct GRDBAccountRepository: AccountRepository {
 
 ### `InferSendableFromCaptures`
 
-Closure-shorthand uses (`writer.read(Type.fetchAll)`) compile cleanly without `@Sendable` ceremony because the project ships at `SWIFT_VERSION: "6.0"` — and `InferSendableFromCaptures` ([SE-0418](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md)) is enabled by default in Swift 6 mode.
+Closure-shorthand uses (`database.read(Type.fetchAll)`) compile cleanly without `@Sendable` ceremony because the project ships at `SWIFT_VERSION: "6.0"` — and `InferSendableFromCaptures` ([SE-0418](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md)) is enabled by default in Swift 6 mode.
 
 **Do not** add `-enable-upcoming-feature InferSendableFromCaptures` to `OTHER_SWIFT_FLAGS` — Swift 6 rejects it with `error: upcoming feature 'InferSendableFromCaptures' is already enabled as of Swift version 6`. The feature is only an opt-in flag for Swift 5 mode codebases.
 
@@ -98,7 +98,7 @@ In GRDB 7, async `read` / `write` honour task cancellation: cancelling the surro
 
 ### Non-reentrancy
 
-`writer.write { writer.write { … } }` traps. Compose work inside one closure; don't nest.
+`database.write { database.write { … } }` traps. Compose work inside one closure; don't nest.
 
 ### `unsafeRead` / `writeWithoutTransaction` / `unsafeReentrant*`
 
@@ -113,7 +113,7 @@ Conventions, all enforced by `database-code-review`:
 1. **Tracking closure form.** Use `ValueObservation.tracking { db in … }` for queries that fetch concrete data; GRDB infers the region from the SQL/table accesses. **Empty-table caveat:** region inference only registers a table if at least one row is touched during the first fetch (SQLite's `SQLITE_READ` authorizer fires on row access, not on `SELECT 1 FROM empty_table LIMIT 1` returning zero rows). For tracking closures that may run against empty tables — most notably `Void`-emitting tick streams over cache tables — use the explicit-region form `ValueObservation.tracking(regions: [Table("name1"), Table("name2"), ...]) { _ in () }` so the regions are registered unconditionally.
    - **`WITHOUT ROWID` caveat.** SQLite's `sqlite3_update_hook` (the mechanism `ValueObservation` relies on to detect writes) does **not** fire for `WITHOUT ROWID` tables — a documented SQLite limitation. Any write site that targets a `WITHOUT ROWID` table whose region is being observed MUST call `db.notifyChanges(in: Table("name"))` inside the same `db.write { ... }` block, **after** the insert / update / delete. Without the notify the observation registers the region correctly and emits the initial value, but never re-fires on subsequent writes — every subscriber hangs. The rate-cache helper at `Backends/GRDB/Observation/RateCacheTable.swift` (`db.notifyRateCacheChange(.exchangeRate | .stockPrice | .cryptoPrice)`) is the canonical example; production write sites in `ExchangeRateService+Persistence.swift`, `StockPriceService.swift`, and `CryptoPriceService+Persistence.swift` use it after every insert / delete against the three `WITHOUT ROWID` rate-cache tables.
 2. **`.removeDuplicates()` is the default** for every `observe…` method that emits a value type (relies on the row decoder being `Equatable`). **Carve-out:** streams that emit `Void` (e.g. `InstrumentConversionService.observeRates()`) MUST NOT apply `removeDuplicates` — `Void == Void` would suppress every emission.
-3. **Scheduling.** `.values(in: writer)` with no explicit `scheduling:` argument. The default `.task` scheduler (cooperative thread pool) is correct for `AsyncSequence` consumption inside a Swift `Task`. Do not override with a `DispatchQueue`-targeting scheduler (`.async(...)` factories on `DispatchQueue` or the `.mainActorQueued` style); those exist for the Combine `publisher(in:scheduling:)` and callback `start(in:scheduling:onError:onChange:)` paths, and using them with `.values(in:)` causes a redundant dispatch hop when the consuming `Task` is already actor-isolated.
+3. **Scheduling.** `.values(in: database)` with no explicit `scheduling:` argument. The default `.task` scheduler (cooperative thread pool) is correct for `AsyncSequence` consumption inside a Swift `Task`. Do not override with a `DispatchQueue`-targeting scheduler (`.async(...)` factories on `DispatchQueue` or the `.mainActorQueued` style); those exist for the Combine `publisher(in:scheduling:)` and callback `start(in:scheduling:onError:onChange:)` paths, and using them with `.values(in:)` causes a redundant dispatch hop when the consuming `Task` is already actor-isolated.
 4. **AsyncStream bridge.** All domain protocols return `AsyncStream<T>` (Foundation, `Sendable`). The bridge lives at `Backends/GRDB/Observation/AsyncValueObservation+AsyncStream.swift` and MUST wire `continuation.onTermination` to cancel the underlying observation `Task`. Without this, an `AsyncStream` consumer that cancels its `Task` would not propagate cancellation to GRDB and the observation would leak.
 5. **Errors — categorise at the repository, not the bridge.** The bridge is single-shot: it delivers the first error to `onError` and completes the stream (no retry, no categorisation, no logging — see the doc comment on `toAsyncStream(onError:)`). Repositories provide an `onError` callback that distinguishes:
    - **Programmer bugs** (`SQLITE_ERROR` from malformed SQL, missing tables) — `fatalError` in debug; in release, surface to the store via the repository's `observeErrors()` channel and let the stream complete (no restart).
@@ -135,14 +135,14 @@ Stores subscribe in `init` with strong `self` (the store is `@MainActor`; the ta
 
 ## 3. Records & Mapping
 
-Records are pure `Sendable` value types under `Backends/GRDB/Records/`, mapped to/from Domain models by extensions under `Backends/GRDB/Mapping/`.
+Records are pure `Sendable` value types under `Backends/GRDB/Records/`, named `<Name>Row`, mapped to/from Domain models by a sibling `<Name>Row+Mapping.swift` extension in the same directory. (The rate/price *cache* records — `ExchangeRateRecord`, `CryptoPriceRecord`, `StockPriceRecord` — keep the `Record` suffix; domain-mirroring records use `Row`.)
 
 ### Layout
 
 ```
-Domain/Models/Account.swift                       // Sendable; no GRDB import
-Backends/GRDB/Records/AccountRecord.swift         // Sendable; GRDB record protocols
-Backends/GRDB/Mapping/AccountRecord+Domain.swift  // init(domain:) + var domain: Account
+Domain/Models/Account.swift                      // Sendable; no GRDB import
+Backends/GRDB/Records/AccountRow.swift           // Sendable; GRDB record protocols
+Backends/GRDB/Records/AccountRow+Mapping.swift   // init(domain:) + var domain: Account
 ```
 
 ### Record protocols
@@ -162,7 +162,7 @@ Moolah uses UUID PKs throughout; records adopt `PersistableRecord` only.
 ```swift
 import GRDB
 
-struct AccountRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct AccountRow: Codable, Sendable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "account"
 
     enum Columns: String, ColumnExpression, CaseIterable {
@@ -196,7 +196,7 @@ static var databaseSelection: [any SQLSelectable] {
 ### Record ↔ Domain mapping lives in the extension
 
 ```swift
-extension AccountRecord {
+extension AccountRow {
     init(domain: Account) {
         self.init(
             id: domain.id,
@@ -232,7 +232,7 @@ Backend isolation. The reviewer treats either as Critical.
 
 ### `Decimal` is forbidden in record structs
 
-GRDB stores `Decimal` as TEXT — string comparisons sort lexically and aggregations through implicit numeric coercion lose precision. Money is integer cents (`InstrumentAmount`); rates are `Double` stored as REAL. Any `Decimal` property in a record struct under `Backends/GRDB/Records/` is flagged.
+GRDB stores `Decimal` as TEXT — string comparisons sort lexically and aggregations through implicit numeric coercion lose precision. Money is stored as a scaled `Int64` (the `Int64 × 10^8` representation behind `InstrumentAmount`); rates are `Double` stored as REAL. Any `Decimal` property in a record struct under `Backends/GRDB/Records/` is flagged.
 
 ### Date encoding
 
@@ -244,7 +244,7 @@ The project default is GRDB's Codable default: ISO-8601 TEXT. `databaseDateEncod
 
 ### Query interface vs raw SQL
 
-Default to GRDB's **query interface** (`AccountRecord.filter(Column.id == accountId).fetchOne(db)`) for simple lookups. Reach for **raw SQL** when:
+Default to GRDB's **query interface** (`AccountRow.filter(Column.id == accountId).fetchOne(db)`) for simple lookups. Reach for **raw SQL** when:
 
 - The query uses a SQL feature the interface can't express (window functions, recursive CTEs, complex aggregates).
 - Performance demands a hand-tuned join or covering-index lookup.
@@ -258,7 +258,7 @@ There is **exactly one unsafe shape**: a Swift `String` (built with `\()`, `Stri
 | `db.execute(sql: "UPDATE x SET n = ? WHERE id = ?", arguments: [n, id])` | Safe (positional bind) |
 | `db.execute(sql: "UPDATE x SET n = :n WHERE id = :id", arguments: ["n": n, "id": id])` | Safe (named bind) |
 | `db.execute(literal: "UPDATE x SET n = \(n) WHERE id = \(id)")` | Safe (`SQL` literal interpolation parameterises) |
-| `AccountRecord.filter(Column("id") == id).fetchOne(db)` | Safe (query interface) |
+| `AccountRow.filter(Column("id") == id).fetchOne(db)` | Safe (query interface) |
 | `db.execute(sql: "UPDATE x SET n = '\(n)' WHERE id = \(id)")` | **Critical: SQL injection** |
 | `db.execute(sql: someStringVariable)` (not a string literal) | **Critical: dynamic SQL** |
 | `db.execute(sql: String(format: "SELECT %@", x))` | **Critical** |
@@ -272,10 +272,10 @@ For dynamic SQL composition use the `SQL` literal type (`db.execute(literal: "..
 SQLite cannot parameterise identifiers. For dynamic identifier substitution, validate against an allowlist before concatenation, in the same expression as the use:
 
 ```swift
-guard let sortColumn = AccountRecord.Columns(rawValue: userInput) else {
+guard let sortColumn = AccountRow.Columns(rawValue: userInput) else {
     throw RepositoryError.invalidSortColumn
 }
-let request = AccountRecord.order(Column(sortColumn.rawValue))  // safe: closed set
+let request = AccountRow.order(Column(sortColumn.rawValue))  // safe: closed set
 ```
 
 Dynamic ORDER BY / table / column name from outside the data layer without an immediately-preceding allowlist assertion is Critical.
@@ -291,7 +291,7 @@ The `quote()` SQL function is for administrative dumping, never for substituting
 let rows = Array(try Row.fetchCursor(db, sql: "SELECT * FROM account"))
 
 // Right — fetch as records, or copy:
-let records = try AccountRecord.fetchAll(db)
+let records = try AccountRow.fetchAll(db)
 let rows = try Row.fetchCursor(db, sql: "...").map { $0.copy() }
 ```
 
@@ -304,7 +304,7 @@ Record CRUD methods (`insert`, `update`, `upsert`, `delete`, `fetchAll`, `fetchO
 For raw SQL inside a tight loop (e.g. CKSyncEngine batch upsert), use `db.cachedStatement(sql:)` instead of `db.makeStatement(sql:)` to skip re-preparation:
 
 ```swift
-try writer.write { db in
+try database.write { db in
     let statement = try db.cachedStatement(sql: "INSERT INTO leg (id, ...) VALUES (?, ...)")
     for leg in legs {
         try statement.execute(arguments: [leg.id, ...])
@@ -317,11 +317,11 @@ try writer.write { db in
 ```swift
 // Wrong — opens N transactions, N fsyncs:
 for record in records {
-    try await writer.write { db in try record.insert(db) }
+    try await database.write { db in try record.insert(db) }
 }
 
 // Right — one transaction, one fsync:
-try await writer.write { db in
+try await database.write { db in
     for record in records { try record.insert(db) }
 }
 ```
@@ -335,21 +335,20 @@ try await writer.write { db in
 
 ## 5. Transactions
 
-- `writer.write { ... }` opens an `IMMEDIATE` transaction. Default deferred transactions are not used — they fail with `SQLITE_BUSY` on first write under any concurrent writer.
+- `database.write { ... }` opens an `IMMEDIATE` transaction. Default deferred transactions are not used — they fail with `SQLITE_BUSY` on first write under any concurrent writer.
 - Every multi-statement write must be inside the same `write` closure (one transaction, one rollback boundary).
 - Every multi-statement write must have a paired test asserting that a thrown error inside the closure leaves the database unchanged.
-- `writer.read { ... }` opens a deferred read transaction with snapshot isolation. Compiler refuses mutating methods inside.
+- `database.read { ... }` opens a deferred read transaction with snapshot isolation. Compiler refuses mutating methods inside.
 
 ```swift
 func payScheduledTransaction(_ tx: Transaction) async throws -> PayResult {
-    try await writer.write { db in
-        let saved = try TransactionRecord(domain: tx).insert(db)
-        try ScheduledRecord
+    try await database.write { db in
+        let saved = try TransactionRow(domain: tx).insert(db)
+        // Clear the recurrence on the scheduled template (recurrence is
+        // stored as fields on TransactionRow, not a separate table).
+        try TransactionRow
             .filter(Column("id") == tx.scheduledId)
-            .deleteAll(db)
-        try AccountRecord
-            .filter(Column("id") == tx.accountId)
-            .updateAll(db, Column("balance") += saved.amount)
+            .updateAll(db, Columns.recurPeriod.set(to: nil))
         return PayResult(...)
     }
 }
@@ -422,7 +421,7 @@ final class GRDBAccountRepositoryTests {
 
     @Test
     func upsertAndFetchRoundTrip() async throws {
-        let repo = GRDBAccountRepository(writer: queue)
+        let repo = GRDBAccountRepository(database: queue)
         let account = Account(name: "Checking", ...)
         try await repo.upsert(account)
         let loaded = try await repo.accounts()
@@ -465,7 +464,7 @@ Production stores expose only their public API. Test seams (counters, fixture lo
 ```swift
 extension GRDBAccountRepository {
     func accountCountForTesting() async throws -> Int {
-        try await writer.read { db in try AccountRecord.fetchCount(db) }
+        try await database.read { db in try AccountRow.fetchCount(db) }
     }
 }
 ```
@@ -486,7 +485,7 @@ See §6.
 
 The full sync model lives in `guides/SYNC_GUIDE.md`. Code-side specifics:
 
-- Each apply-remote-changes batch is a single `writer.write` transaction. A partial apply must roll back; the next sync cycle re-delivers the failed batch.
+- Each apply-remote-changes batch is a single `database.write` transaction. A partial apply must roll back; the next sync cycle re-delivers the failed batch.
 - `encoded_system_fields` bytes are bit-for-bit copies; never decode or interpret them outside the `Backends/CloudKit/Sync/` boundary.
 - Use `db.cachedStatement(sql:)` for the per-record upsert in batch-apply loops.
 
@@ -496,10 +495,10 @@ The full sync model lives in `guides/SYNC_GUIDE.md`. Code-side specifics:
 
 When adding a new table to the profile DB:
 
-- [ ] One record type under `Backends/GRDB/Records/<Name>Record.swift`, `Sendable`, `Codable`, conforms to `FetchableRecord, PersistableRecord`.
+- [ ] One record type under `Backends/GRDB/Records/<Name>Row.swift`, `Sendable`, `Codable`, conforms to `FetchableRecord, PersistableRecord`.
 - [ ] `enum Columns: String, ColumnExpression, CaseIterable` matching the SQL columns.
-- [ ] Domain ↔ Record mapping under `Backends/GRDB/Mapping/<Name>Record+Domain.swift`.
-- [ ] Repository in `Backends/GRDB/Repositories/<Name>Repository.swift`, `Sendable`, async-only.
+- [ ] Domain ↔ Row mapping under `Backends/GRDB/Records/<Name>Row+Mapping.swift`.
+- [ ] Repository in `Backends/GRDB/Repositories/GRDB<Name>Repository.swift`, a `final class` marked `@unchecked Sendable`, async-only.
 - [ ] No `Decimal` properties on the record.
 - [ ] `databaseSelection` (if overridden) is `static var`.
 - [ ] No `import GRDB` outside `Backends/GRDB/`; no record types referenced from `Domain/`, `Features/`, `App/`.

--- a/guides/SYNC_GUIDE.md
+++ b/guides/SYNC_GUIDE.md
@@ -564,7 +564,7 @@ Verify that repository mutations trigger the sync closures with the correct IDs:
 ```swift
 @MainActor
 func testCreateQueuesSync() async throws {
-    let (backend, _, _) = try TestBackend.create()
+    let (backend, _) = try TestBackend.create()
     let repo = backend.accounts as! CloudKitAccountRepository
 
     var changedIds: [UUID] = []

--- a/guides/TEST_GUIDE.md
+++ b/guides/TEST_GUIDE.md
@@ -166,7 +166,7 @@ This convention is also documented in `CLAUDE.md` and the Capturing Test Output 
 | --- | --- | --- |
 | `MoolahTests_macOS` | Store, contract, repository, model tests on native macOS | `TestBackend` (in-memory `CloudKitBackend`) |
 | `MoolahTests_iOS` | Same suite on iOS Simulator | `TestBackend` |
-| `MoolahBenchmarks` | Performance benchmarks on macOS only | `TestBackend` |
+| `MoolahBenchmarks_macOS` | Performance benchmarks on macOS only | `TestBackend` |
 | `MoolahUITests_macOS` | XCUITest end-to-end tests on macOS only | App launched with `--ui-testing` + seeded `TestBackend` |
 
 Every test target uses `TestBackend` — the production `CloudKitBackend` initialised against an in-memory GRDB database. No mocks at the repository layer. UI tests additionally seed the backend through fixed-UUID fixtures.

--- a/guides/UI_GUIDE.md
+++ b/guides/UI_GUIDE.md
@@ -173,7 +173,7 @@ Moolah uses semantic colors to communicate financial meaning at a glance.
 
 #### Transaction Amount Colors
 ```swift
-// Current implementation in MonetaryAmountView.swift
+// Current implementation in InstrumentAmountView.swift
 .foregroundStyle(amount.isPositive ? .green : amount.isNegative ? .red : .primary)
 ```
 
@@ -185,12 +185,14 @@ Moolah uses semantic colors to communicate financial meaning at a glance.
 | Balances (neutral) | `.secondary` | Use `colorOverride: .secondary` |
 
 #### Expense Amount Display Convention
-Expenses are stored internally as **negative cents** (they reduce the account balance). However, when displaying expense totals to the user (e.g., in category breakdowns, analysis summaries), **negate them to positive** values. Users expect "an expense of $20" — not "$-20". A negative expense (e.g., a refund) should display as a negative value.
+Expenses are stored internally as **negative quantities** (they reduce the account balance). However, when displaying expense totals to the user (e.g., in category breakdowns, analysis summaries), **negate them to positive** values. Users expect "an expense of $20" — not "$-20". A negative expense (e.g., a refund) should display as a negative value.
 
 ```swift
-// Server returns -5000 cents for a $50 expense
+// Server returns a -50.00 quantity for a $50 expense
 // Display as: $50.00 (positive)
-let displayAmount = MonetaryAmount(cents: max(0, -serverAmount.cents), currency: serverAmount.currency)
+let displayAmount = InstrumentAmount(
+  quantity: max(0, -serverAmount.quantity),
+  instrument: serverAmount.instrument)
 ```
 
 This matches the web app's `Math.max(0, -totalExpenses)` pattern. This convention applies to both aggregated expense summaries **and** expense amount fields in forms/editors — users enter and see positive values (e.g., "$50"), and the sign is applied internally based on transaction type. Transaction lists that show the raw signed amount (with income positive and expenses negative) are the exception.
@@ -280,9 +282,9 @@ HStack(alignment: .firstTextBaseline, spacing: 12) {
   Spacer()
 
   VStack(alignment: .trailing, spacing: 4) {
-    MonetaryAmountView(amount: amount, font: .body)
+    InstrumentAmountView(amount: amount, font: .body)
     if let balance = balance {
-      MonetaryAmountView(amount: balance, colorOverride: .secondary, font: .caption)
+      InstrumentAmountView(amount: balance, colorOverride: .secondary, font: .caption)
     }
   }
 }
@@ -738,11 +740,11 @@ Chart(categoryTotals) { category in
 Gauge(value: spent, in: 0...budgeted) {
   Text(category.name)
 } currentValueLabel: {
-  MonetaryAmountView(amount: spentAmount, font: .body)
+  InstrumentAmountView(amount: spentAmount, font: .body)
 } minimumValueLabel: {
   Text("$0")
 } maximumValueLabel: {
-  MonetaryAmountView(amount: budgetedAmount, font: .caption)
+  InstrumentAmountView(amount: budgetedAmount, font: .caption)
 }
 .gaugeStyle(.accessoryCircularCapacity)
 .tint(spent > budgeted ? .red : .green)
@@ -824,7 +826,7 @@ Image(systemName: "chart.pie.fill")
 HStack {
   Text(transaction.payee)
   Spacer()
-  MonetaryAmountView(amount: transaction.amount)
+  InstrumentAmountView(amount: transaction.amount)
 }
 .accessibilityElement(children: .combine)
 .accessibilityLabel("\(transaction.payee), \(transaction.amount.decimalValue.formatted(.currency(code: transaction.amount.currency.code)))")


### PR DESCRIPTION
Corrects factual staleness across the developer/AI-agent documentation. Three migrations had outrun the docs: **SwiftData → GRDB/SQLite**, **`MonetaryAmount`/`Currency` → `InstrumentAmount`/`Instrument`**, and the **TestFlight tag flow → the RC/final release pipeline**. Every change was verified against the current code.

## Changes

**README.md**
- Architecture: SwiftData → GRDB/SQLite + CKSyncEngine; `InMemoryBackend` → `TestBackend` / `PreviewBackend`.
- Project tree: dropped the nonexistent `prompts/` dir and `MoolahTests/UI` / `Support/InMemoryBackend/`; added `MoolahUITests_macOS`, `guides/`, the price/rate provider backends.
- Rewrote **Release & TestFlight**: the old `testflight.yml` / `git tag v1.0.0` flow no longer exists — it's `release-rc.yml` / `release-final.yml` driven by `just release-*`, with a monthly **RC** cron. Fixed the dead `plans/IOS_RELEASE_AUTOMATION_PLAN.md` link → `guides/RELEASE_GUIDE.md`.

**CLAUDE.md**
- Rewrote the Currency constraint for `InstrumentAmount` (Decimal quantity + `Instrument`, stored as `Int64 × 10^8`), `Profile.currencyCode` / `.instrument`, `Instrument.defaultTestInstrument`, and `InstrumentAmount.parseQuantity(from:decimals:)`.
- Fixed the `plans/UI_TESTING_PLAN.md` link (now under `completed/`).

**guides/** (8 files)
- `MonetaryAmount` → `InstrumentAmount` (CODE, CONCURRENCY, UI) and `MonetaryAmountView` → `InstrumentAmountView` (UI).
- `TestBackend.create()` 3-tuple → 2-tuple (CONCURRENCY, SYNC).
- Benchmark target `MoolahBenchmarks` → `MoolahBenchmarks_macOS` (TEST).
- DATABASE_CODE_GUIDE: records are `*Row` (not `*Record`), mapping lives at `Records/<Name>Row+Mapping.swift` (no `Mapping/` dir), repositories are `final class … @unchecked Sendable` (not `Sendable` structs), property `database` (not `writer`); removed a fictional `ScheduledRecord` example.
- BRAND_GUIDE: removed the false "no investment tracking"; expanded the feature facts.

**.claude/** (5 files)
- SwiftData → GRDB in `interpret-benchmarks`, `profile-performance` (dropped the dead `contextSave` signpost), `modifying-cloudkit-schema`; SwiftData → GRDB and `MonetaryAmount` → `InstrumentAmount` in `code-review` and `sync-review`.

Genuinely *historical* SwiftData references (e.g. past-bug notes, the legacy `CD_`-prefix contrast) were left intact — the project really did migrate from SwiftData.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9KVzbpWPpM3UxBiUWiDgf)_