### PR TITLE
fix(automation): authoritative repository reads for earmark/category resolvers

### DIFF
--- a/Automation/AppleScript/Commands/DeleteCommand.swift
+++ b/Automation/AppleScript/Commands/DeleteCommand.swift
@@ -98,7 +98,7 @@
       target: DeleteTarget, profileName: String, service: AutomationService
     ) async throws {
       guard let name = target.name else { throw AutomationError.earmarkNotFound("unknown") }
-      let earmark = try service.resolveEarmark(named: name, profileIdentifier: profileName)
+      let earmark = try await service.resolveEarmark(named: name, profileIdentifier: profileName)
       try await service.deleteEarmark(profileIdentifier: profileName, earmarkId: earmark.id)
     }
 
@@ -107,7 +107,7 @@
       target: DeleteTarget, profileName: String, service: AutomationService
     ) async throws {
       guard let name = target.name else { throw AutomationError.categoryNotFound("unknown") }
-      let category = try service.resolveCategory(named: name, profileIdentifier: profileName)
+      let category = try await service.resolveCategory(named: name, profileIdentifier: profileName)
       try await service.deleteCategory(profileIdentifier: profileName, categoryId: category.id)
     }
   }

--- a/Automation/AutomationService+Earmarks.swift
+++ b/Automation/AutomationService+Earmarks.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// Earmark / category / investment / analysis / refresh handlers. All
-// members are `@MainActor` via the containing class.
+// Earmark / category / investment / analysis / refresh / crypto-sync
+// handlers. All members are `@MainActor` via the containing class.
 extension AutomationService {
 
   // MARK: - Earmark Operations
@@ -13,12 +13,34 @@ extension AutomationService {
   }
 
   /// Resolves an earmark by name (case-insensitive) within a profile.
-  func resolveEarmark(named name: String, profileIdentifier: String) throws -> Earmark {
+  ///
+  /// Reads the authoritative repository snapshot (`fetchAll()`) rather than
+  /// the reactive `EarmarkStore.earmarks` — see
+  /// `resolveAccount(named:profileIdentifier:)` for why automation needs a
+  /// repository-direct read. A script (or single intent) creates an earmark
+  /// and references it by name in the very next operation; the reactive store
+  /// is only eventually consistent with a committed write, so under load it
+  /// can throw `.earmarkNotFound` for an earmark that is already persisted.
+  /// `fetchAll()` reflects the committed write immediately, making resolution
+  /// deterministic.
+  func resolveEarmark(named name: String, profileIdentifier: String) async throws -> Earmark {
+    let earmarks = try await fetchEarmarks(profileIdentifier: profileIdentifier)
+    return try Self.earmark(named: name, in: earmarks)
+  }
+
+  /// Authoritative earmark snapshot for a profile, read straight from the
+  /// repository so it reflects every committed write immediately. Mirrors
+  /// `fetchAccounts` — callers that resolve several names (e.g. `resolveLegs`)
+  /// fetch once and match in-memory rather than re-reading per name.
+  func fetchEarmarks(profileIdentifier: String) async throws -> [Earmark] {
     let session = try resolveSession(for: profileIdentifier)
+    return try await session.backend.earmarks.fetchAll()
+  }
+
+  /// Case-insensitive name lookup within an already-fetched earmark list.
+  static func earmark(named name: String, in earmarks: [Earmark]) throws -> Earmark {
     let lowered = name.lowercased()
-    guard
-      let earmark = session.earmarkStore.earmarks.first(where: { $0.name.lowercased() == lowered })
-    else {
+    guard let earmark = earmarks.first(where: { $0.name.lowercased() == lowered }) else {
       throw AutomationError.earmarkNotFound(name)
     }
     return earmark
@@ -102,10 +124,34 @@ extension AutomationService {
 
   /// Resolves a category by name or path (case-insensitive) within a profile.
   /// Matches either the category name or the full path (e.g., "Food:Groceries").
-  func resolveCategory(named name: String, profileIdentifier: String) throws -> Category {
+  ///
+  /// Reads the authoritative repository snapshot (`fetchAll()`) rather than the
+  /// reactive `CategoryStore.categories` — see
+  /// `resolveAccount(named:profileIdentifier:)` for the read-after-write
+  /// rationale. The repository returns a flat `[Category]`, so the hierarchy is
+  /// rebuilt with `Categories(from:)` to keep full-path matching working.
+  /// `fetchAll()` reflects the committed write immediately, making resolution
+  /// deterministic.
+  func resolveCategory(named name: String, profileIdentifier: String) async throws -> Category {
+    let categories = try await fetchCategories(profileIdentifier: profileIdentifier)
+    return try Self.category(named: name, in: categories)
+  }
+
+  /// Authoritative category hierarchy for a profile, rebuilt from the flat
+  /// repository snapshot so it reflects every committed write immediately.
+  /// Mirrors `fetchAccounts` — callers that resolve several names (e.g.
+  /// `resolveLegs`) fetch once and match in-memory rather than re-reading
+  /// per name.
+  func fetchCategories(profileIdentifier: String) async throws -> Categories {
     let session = try resolveSession(for: profileIdentifier)
+    return Categories(from: try await session.backend.categories.fetchAll())
+  }
+
+  /// Case-insensitive path-then-name lookup within an already-fetched
+  /// category hierarchy.
+  static func category(named name: String, in categories: Categories) throws -> Category {
     let lowered = name.lowercased()
-    let entries = session.categoryStore.categories.flattenedByPath()
+    let entries = categories.flattenedByPath()
 
     // Try matching by path first, then by name
     if let entry = entries.first(where: { $0.path.lowercased() == lowered }) {
@@ -126,7 +172,8 @@ extension AutomationService {
   ) async throws -> Category {
     let parentId: UUID?
     if let parentName {
-      parentId = try resolveCategory(named: parentName, profileIdentifier: profileIdentifier).id
+      parentId = try await resolveCategory(named: parentName, profileIdentifier: profileIdentifier)
+        .id
     } else {
       parentId = nil
     }
@@ -150,7 +197,7 @@ extension AutomationService {
 
     let replacementId: UUID?
     if let replacementName {
-      replacementId = try resolveCategory(
+      replacementId = try await resolveCategory(
         named: replacementName, profileIdentifier: profileIdentifier
       ).id
     } else {

--- a/Automation/AutomationService+Legs.swift
+++ b/Automation/AutomationService+Legs.swift
@@ -86,9 +86,9 @@ extension AutomationService {
       named: draft.accountName, profileIdentifier: profileIdentifier)
     let instrument = try await resolveInstrument(draft.instrumentId, session: session)
     let legType = try Self.transactionType(draft.type)
-    let categoryId = try resolveOptionalCategory(
+    let categoryId = try await resolveOptionalCategory(
       draft.categoryName, profileIdentifier: profileIdentifier)
-    let earmarkId = try resolveOptionalEarmark(
+    let earmarkId = try await resolveOptionalEarmark(
       draft.earmarkName, profileIdentifier: profileIdentifier)
 
     let newLeg = TransactionLeg(
@@ -134,10 +134,10 @@ extension AutomationService {
     let resolvedType: TransactionType =
       if let type = changes.type { try Self.transactionType(type) } else { located.leg.type }
     let resolvedCategoryId: UUID? =
-      try resolveOptionalCategory(changes.categoryName, profileIdentifier: profileIdentifier)
+      try await resolveOptionalCategory(changes.categoryName, profileIdentifier: profileIdentifier)
       ?? located.leg.categoryId
     let resolvedEarmarkId: UUID? =
-      try resolveOptionalEarmark(changes.earmarkName, profileIdentifier: profileIdentifier)
+      try await resolveOptionalEarmark(changes.earmarkName, profileIdentifier: profileIdentifier)
       ?? located.leg.earmarkId
 
     // Rebuild the leg keeping id / externalId / counterpartyAddress.
@@ -251,17 +251,17 @@ extension AutomationService {
   /// Resolves an optional category name to its id, or `nil` when unset.
   private func resolveOptionalCategory(
     _ name: String?, profileIdentifier: String
-  ) throws -> UUID? {
+  ) async throws -> UUID? {
     guard let name else { return nil }
-    return try resolveCategory(named: name, profileIdentifier: profileIdentifier).id
+    return try await resolveCategory(named: name, profileIdentifier: profileIdentifier).id
   }
 
   /// Resolves an optional earmark name to its id, or `nil` when unset.
   private func resolveOptionalEarmark(
     _ name: String?, profileIdentifier: String
-  ) throws -> UUID? {
+  ) async throws -> UUID? {
     guard let name else { return nil }
-    return try resolveEarmark(named: name, profileIdentifier: profileIdentifier).id
+    return try await resolveEarmark(named: name, profileIdentifier: profileIdentifier).id
   }
 
   /// Resolves an `instrumentId` string to an `Instrument`.

--- a/Automation/AutomationService.swift
+++ b/Automation/AutomationService.swift
@@ -92,10 +92,14 @@ final class AutomationService {
   private func resolveLegs(
     _ legs: [LegSpec], profileIdentifier: String, instrument: Instrument
   ) async throws -> (legs: [TransactionLeg], accountIds: Set<UUID>) {
-    // Fetch the authoritative account snapshot once and resolve every leg
-    // against it (see `resolveAccount(named:)` for why this is a
-    // repository read rather than a reactive-store read).
+    // Fetch the authoritative account / category / earmark snapshots once and
+    // resolve every leg against them in-memory (see `resolveAccount(named:)`
+    // for why these are repository reads rather than reactive-store reads).
+    // Hoisting out of the loop keeps a many-legged transaction to one read per
+    // store rather than one per leg.
     let accounts = try await fetchAccounts(profileIdentifier: profileIdentifier)
+    let categories = try await fetchCategories(profileIdentifier: profileIdentifier)
+    let earmarks = try await fetchEarmarks(profileIdentifier: profileIdentifier)
     var resolvedLegs: [TransactionLeg] = []
     var accountIds = Set<UUID>()
     for spec in legs {
@@ -104,14 +108,14 @@ final class AutomationService {
 
       let categoryId: UUID? =
         if let categoryName = spec.categoryName {
-          try resolveCategory(named: categoryName, profileIdentifier: profileIdentifier).id
+          try Self.category(named: categoryName, in: categories).id
         } else {
           nil
         }
 
       let earmarkId: UUID? =
         if let earmarkName = spec.earmarkName {
-          try resolveEarmark(named: earmarkName, profileIdentifier: profileIdentifier).id
+          try Self.earmark(named: earmarkName, in: earmarks).id
         } else {
           nil
         }

--- a/Automation/Intents/GetEarmarkBalanceIntent.swift
+++ b/Automation/Intents/GetEarmarkBalanceIntent.swift
@@ -15,7 +15,7 @@ struct GetEarmarkBalanceIntent: AppIntent {
     guard let service = AutomationServiceLocator.shared.service else {
       throw AutomationError.operationFailed("App not ready")
     }
-    let resolved = try service.resolveEarmark(
+    let resolved = try await service.resolveEarmark(
       named: earmark.name, profileIdentifier: profile.id.uuidString)
     return .result(value: InstrumentAmount.zero(instrument: resolved.instrument).formatted)
   }

--- a/MoolahTests/Automation/AutomationServiceCategoryTests.swift
+++ b/MoolahTests/Automation/AutomationServiceCategoryTests.swift
@@ -62,24 +62,39 @@ struct AutomationServiceCategoryTests {
       parentName: nil
     )
 
-    await expectEventually("created category resolves case-insensitively") {
-      (try? service.resolveCategory(named: "transport", profileIdentifier: "Test"))?.name
-        == "Transport"
-    }
+    // Authoritative read — resolves deterministically, no expectEventually.
+    let resolved = try await service.resolveCategory(
+      named: "transport", profileIdentifier: "Test")
+    #expect(resolved.name == "Transport")
+  }
+
+  @Test("resolveCategory matches by full path after authoritative read")
+  func resolveCategoryByPath() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    _ = try await service.createCategory(profileIdentifier: "Test", name: "Food")
+    let child = try await service.createCategory(
+      profileIdentifier: "Test", name: "Groceries", parentName: "Food")
+
+    // The repository returns a flat list; resolveCategory rebuilds the
+    // hierarchy so a full "Food:Groceries" path still resolves.
+    let resolved = try await service.resolveCategory(
+      named: "food:groceries", profileIdentifier: "Test")
+    #expect(resolved.id == child.id)
   }
 
   @Test("resolveCategory throws when not found")
   func resolveCategoryNotFound() async throws {
     let (service, _) = try await makeServiceWithSession()
 
-    #expect(throws: AutomationError.self) {
-      try service.resolveCategory(named: "NonExistent", profileIdentifier: "Test")
+    await #expect(throws: AutomationError.self) {
+      try await service.resolveCategory(named: "NonExistent", profileIdentifier: "Test")
     }
   }
 
   @Test("createCategory with parent creates subcategory")
   func createSubcategory() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     let parent = try await service.createCategory(
       profileIdentifier: "Test",
@@ -87,14 +102,9 @@ struct AutomationServiceCategoryTests {
       parentName: nil
     )
 
-    // The subsequent createCategory call resolves "Food" against the
-    // store's `categories` cache — wait for the first create to land
-    // there before issuing the second.
-    try await session.categoryStore.waitForNextEmission(
-      matching: { $0.categories.roots.contains { $0.name == "Food" } },
-      description: "parent category observable"
-    )
-
+    // createCategory resolves the parent via the authoritative repository
+    // snapshot, so the second create sees "Food" deterministically without
+    // waiting on the reactive store.
     let child = try await service.createCategory(
       profileIdentifier: "Test",
       name: "Groceries",

--- a/MoolahTests/Automation/AutomationServiceEarmarkTests.swift
+++ b/MoolahTests/Automation/AutomationServiceEarmarkTests.swift
@@ -61,18 +61,18 @@ struct AutomationServiceEarmarkTests {
       name: "Emergency Fund"
     )
 
-    await expectEventually("created earmark resolves case-insensitively") {
-      (try? service.resolveEarmark(named: "emergency fund", profileIdentifier: "Test"))?.name
-        == "Emergency Fund"
-    }
+    // Authoritative read — resolves deterministically, no expectEventually.
+    let resolved = try await service.resolveEarmark(
+      named: "emergency fund", profileIdentifier: "Test")
+    #expect(resolved.name == "Emergency Fund")
   }
 
   @Test("resolveEarmark throws when not found")
   func resolveEarmarkNotFound() async throws {
     let (service, _) = try await makeServiceWithSession()
 
-    #expect(throws: AutomationError.self) {
-      try service.resolveEarmark(named: "NonExistent", profileIdentifier: "Test")
+    await #expect(throws: AutomationError.self) {
+      try await service.resolveEarmark(named: "NonExistent", profileIdentifier: "Test")
     }
   }
 }


### PR DESCRIPTION
Fixes #1057.

## Problem

`AutomationService.resolveEarmark(named:)` and `resolveCategory(named:)` read the **eventually-consistent reactive stores** (`EarmarkStore.earmarks` / `CategoryStore.categories`). Automation is a scripted read-after-write context — a script (or single intent) creates an earmark/category and references it by name in the very next operation. The reactive store is only eventually consistent with a committed write, so under load `observeAll()` can deliver the new snapshot *after* the reference reads it, intermittently throwing `.earmarkNotFound` / `.categoryNotFound` for an item that is already persisted.

This is the same hazard the [`resolveAccount` flake fix](https://github.com/moolah-rocks/moolah-native/pull/new/fix/automation-account-resolve-flake) addressed; #1057 was deferred from that PR to keep its scope tight.

## Fix

Mirror the `resolveAccount` pattern: read the authoritative repository snapshot via `fetchAll()`, which reflects the committed write immediately. Both resolvers become `async`, threaded through every caller (`resolveLegs`, `resolveOptionalCategory`/`resolveOptionalEarmark`, `createCategory`, `deleteCategory`, the AppleScript `DeleteCommand`, and `GetEarmarkBalanceIntent`).

- `resolveCategory` rebuilds the hierarchy from the flat `fetchAll()` result via `Categories(from:)` so full-path matching (`"Food:Groceries"`) still works.
- Following the accounts pattern, the snapshots are **hoisted out of the per-leg loop** in `resolveLegs` (one read per store, not one per leg) via new `fetchEarmarks` / `fetchCategories` helpers and `Self.earmark` / `Self.category` static matchers.

## Tests

- `resolveEarmark` / `resolveCategory` tests drop the `expectEventually` polling that papered over the race and assert deterministic resolution directly.
- New `resolveCategoryByPath` test covers path resolution rebuilt from the flat repository snapshot.
- Full Automation suite green (`AutomationServiceCategoryTests`, `AutomationServiceEarmarkTests`, `AutomationServiceTransactionTests`, `AutomationServiceMergeTransactionsTests`, `AutomationServiceInvestmentsTests`, `AutomationServiceProfileTests`, `AutomationServiceRemoveLegTests`, `AutomationLegEditSyncIdentityTests`).

## Out of scope (follow-ups noted by concurrency review)

These are pre-existing and orthogonal to the resolver migration — not bundled here:

- `NSScriptCommand+ScriptHelpers.swift` / `ScriptingBridge.swift` use `DispatchSemaphore` + `@unchecked Sendable` boxes in the AppleScript blocking bridge.
- `GetEarmarkBalanceIntent.perform()` always returns a **zero** balance (resolves the earmark only for its instrument). The resolver call is now correct/async, but actually reading the balance from the store is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)