### PR TITLE
feat(instrument-picker): rank exact and currency matches first

### DIFF
--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -238,10 +238,48 @@ struct InstrumentSearchServiceTests {
     let results = await service.search(query: "BHP", kinds: [.stock])
     let bhpResult = try #require(results.first { $0.instrument.id == "ASX:BHP.AX" })
     #expect(bhpResult.isRegistered == true)
-    let registeredIdx = results.firstIndex { $0.instrument.id == "ASX:BHP.AX" } ?? 0
+    let registeredIdx = try #require(
+      results.firstIndex { $0.instrument.id == "ASX:BHP.AX" })
     let providerIdx =
       results.firstIndex { $0.instrument.kind == .stock && !$0.isRegistered } ?? Int.max
     #expect(registeredIdx < providerIdx)
+  }
+
+  @Test("exact currency code match ranks first")
+  func exactCurrencyCodeRanksFirst() async throws {
+    // A crypto hit that also matches "usd" by name must not displace the
+    // exact ISO-code match: typing "USD" puts US Dollar first.
+    let usdc = CatalogEntry(
+      coingeckoId: "usd-coin",
+      symbol: "USDC",
+      name: "USD Coin",
+      platforms: [
+        PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xusdc")
+      ]
+    )
+    let service = makeSubject(catalogEntries: [usdc])
+    let results = await service.search(query: "usd", kinds: [.fiatCurrency, .cryptoToken])
+    let first = try #require(results.first)
+    #expect(first.instrument.id == "USD")
+    #expect(first.instrument.kind == .fiatCurrency)
+  }
+
+  @Test("currency results rank before crypto tokens")
+  func currencyResultsRankBeforeCrypto() async throws {
+    // "dollar" matches several fiat currencies by localized name and the
+    // crypto entry by name; every currency must precede every crypto token.
+    let dollarCoin = CatalogEntry(
+      coingeckoId: "dollar-coin",
+      symbol: "DLR",
+      name: "Dollar Coin",
+      platforms: []
+    )
+    let service = makeSubject(catalogEntries: [dollarCoin])
+    let results = await service.search(
+      query: "dollar", kinds: [.fiatCurrency, .cryptoToken])
+    let lastFiat = results.lastIndex { $0.instrument.kind == .fiatCurrency } ?? -1
+    let firstCrypto = results.firstIndex { $0.instrument.kind == .cryptoToken } ?? Int.max
+    #expect(lastFiat < firstCrypto)
   }
 }
 

--- a/Shared/InstrumentSearchService.swift
+++ b/Shared/InstrumentSearchService.swift
@@ -54,7 +54,8 @@ struct InstrumentSearchService: Sendable {
     let provider = await (fiatResults + cryptoResults + stockResults)
     let registeredMatches = registeredMatches(
       query: trimmed, all: filteredRegistered, cryptoMappings: cryptoRegistrations)
-    return merge(registered: registeredMatches, provider: provider)
+    let merged = merge(registered: registeredMatches, provider: provider)
+    return rank(merged, query: trimmed)
   }
 
   private func loadRegisteredOrLog() async -> [Instrument] {
@@ -299,5 +300,54 @@ struct InstrumentSearchService: Sendable {
       out.append(result)
     }
     return out
+  }
+}
+
+// MARK: - Ranking
+
+extension InstrumentSearchService {
+  /// Orders the merged results by relevance. The primary signal is an exact
+  /// ticker/code match against the query — typing "USD" puts US Dollar first;
+  /// the secondary signal favours fiat currencies over every other kind so
+  /// currency matches lead crypto tokens. Within a bucket the merge order is
+  /// preserved (registered rows already lead their provider counterparts), so
+  /// the original index is the final, stability-preserving tiebreaker.
+  private func rank(
+    _ results: [InstrumentSearchResult],
+    query: String
+  ) -> [InstrumentSearchResult] {
+    let lowered = query.lowercased()
+    return
+      results
+      .enumerated()
+      .sorted { lhs, rhs in
+        RankKey(lhs.element, lowered: lowered, index: lhs.offset)
+          < RankKey(rhs.element, lowered: lowered, index: rhs.offset)
+      }
+      .map(\.element)
+  }
+
+  /// Sort key for a single search result. Lower values rank earlier: exact
+  /// ticker/code matches before inexact ones, fiat currencies before every
+  /// other kind, and the original merge index as a stable final tiebreaker.
+  private struct RankKey: Comparable {
+    let exactRank: Int
+    let kindRank: Int
+    let index: Int
+
+    init(_ result: InstrumentSearchResult, lowered: String, index: Int) {
+      let instrument = result.instrument
+      let isExact =
+        instrument.id.lowercased() == lowered
+        || instrument.ticker?.lowercased() == lowered
+      self.exactRank = isExact ? 0 : 1
+      self.kindRank = instrument.kind == .fiatCurrency ? 0 : 1
+      self.index = index
+    }
+
+    static func < (lhs: RankKey, rhs: RankKey) -> Bool {
+      (lhs.exactRank, lhs.kindRank, lhs.index)
+        < (rhs.exactRank, rhs.kindRank, rhs.index)
+    }
   }
 }


### PR DESCRIPTION
## What

In the instrument picker, search results were ordered registered-first, then provider results (fiat + crypto + stock) in source order — with no exact-match boost and no guarantee a currency would lead a crypto token across the registered/provider boundary. Typing **USD** could surface crypto tokens ahead of US Dollar.

This adds a ranking pass after the existing merge step, keyed on (in order):

1. **Exact match** — query equals the instrument's ticker/id (case-insensitive). Typing `USD` puts **US Dollar** first.
2. **Currency before crypto** — fiat currencies rank ahead of every other kind, so currency matches always precede crypto tokens.
3. **Original merge index** — stable tiebreaker, so registered rows still lead their provider counterparts within a bucket (preserves the existing registered-first behaviour).

## How

- `InstrumentSearchService.search(...)` now calls a new `rank(_:query:)` after `merge(...)`.
- Ranking is expressed as a `private RankKey: Comparable` whose `<` decomposes into a tuple comparison `(exactRank, kindRank, index)` — easy to extend with further tiebreakers.

## Tests

- `exactCurrencyCodeRanksFirst` — a crypto hit matching "usd" by name does not displace the exact ISO-code match.
- `currencyResultsRankBeforeCrypto` — every currency precedes every crypto token for a shared query.
- Hardened the pre-existing `registeredRankFirst` test (`?? 0` → `try #require`) so a missing registered row fails loudly instead of passing spuriously.

All `InstrumentSearchServiceTests` and `InstrumentPickerStoreTests` pass; `just format-check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)