### PR TITLE
fix(analysis): hide redundant chart legends on expense breakdown charts

### DIFF
--- a/Features/Analysis/Views/CategoriesOverTimeCard.swift
+++ b/Features/Analysis/Views/CategoriesOverTimeCard.swift
@@ -117,6 +117,9 @@ struct CategoriesOverTimeCard: View {
       }
     }
     .chartXSelection(value: $selectedDate)
+    // The legend below already lists each category with its colour swatch
+    // and total, so the chart's built-in legend is redundant.
+    .chartLegend(.hidden)
     .frame(height: 400)
     .accessibilityLabel(chartAccessibilityLabel)
   }

--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -71,6 +71,9 @@ struct ExpenseBreakdownCard: View {
         }
       }
     }
+    // The legendGrid below already lists each category with its colour
+    // swatch and total, so the chart's built-in legend is redundant.
+    .chartLegend(.hidden)
     .frame(height: 250)
     .accessibilityLabel("Expense breakdown pie chart")
   }


### PR DESCRIPTION
## Summary

The **Expenses by Category** pie chart and **Expenses by Category Over Time** stacked-area chart on the analysis dashboard each already render a custom table of values below the chart — listing every category with its colour swatch and total. SwiftUI's built-in `Chart` legend repeated that same information, making it redundant.

This adds `.chartLegend(.hidden)` to both charts so only the table of values remains. The colour mapping is unaffected (the table draws its own swatches).

## Changes
- `Features/Analysis/Views/ExpenseBreakdownCard.swift` — hide legend on the pie chart.
- `Features/Analysis/Views/CategoriesOverTimeCard.swift` — hide legend on the stacked-area chart.

## Testing
- `just build-mac` — **BUILD SUCCEEDED**
- `just format-check` — all files correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)