### PR TITLE
fix(automation): return real earmark balance from Get Earmark Balance intent

### DIFF
--- a/Automation/Intents/GetEarmarkBalanceIntent.swift
+++ b/Automation/Intents/GetEarmarkBalanceIntent.swift
@@ -15,8 +15,8 @@ struct GetEarmarkBalanceIntent: AppIntent {
     guard let service = AutomationServiceLocator.shared.service else {
       throw AutomationError.operationFailed("App not ready")
     }
-    let resolved = try await service.resolveEarmark(
-      named: earmark.name, profileIdentifier: profile.id.uuidString)
-    return .result(value: InstrumentAmount.zero(instrument: resolved.instrument).formatted)
+    let session = try service.resolveSession(for: profile.id.uuidString)
+    let balance = try await session.earmarkStore.displayBalance(for: earmark.id)
+    return .result(value: balance.formatted)
   }
 }

--- a/Features/Earmarks/EarmarkStore+Queries.swift
+++ b/Features/Earmarks/EarmarkStore+Queries.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension EarmarkStore {
+  // The members below are module-internal (not `private`) only because
+  // `EarmarkStore.swift` and the SwiftUI views need them across file
+  // boundaries. Treat them as the store's read-only query surface.
+
+  func convertedBalance(for earmarkId: UUID) -> InstrumentAmount? {
+    convertedBalances[earmarkId]
+  }
+
+  func convertedSaved(for earmarkId: UUID) -> InstrumentAmount? {
+    convertedSavedAmounts[earmarkId]
+  }
+
+  func convertedSpent(for earmarkId: UUID) -> InstrumentAmount? {
+    convertedSpentAmounts[earmarkId]
+  }
+
+  /// The balance for an earmark, converted to the earmark's own instrument.
+  /// Recomputes from the earmark's positions on demand rather than reading
+  /// the eventually-consistent `convertedBalances` dictionary, so callers
+  /// (e.g. the "Get Earmark Balance" App Intent) get a correct value
+  /// without waiting for the next conversion pass to settle. Throws on a
+  /// real conversion failure rather than reporting a misleading zero.
+  /// Returns zero in the reporting instrument when the earmark is unknown.
+  func displayBalance(for earmarkId: UUID) async throws -> InstrumentAmount {
+    guard let earmark = earmarks.by(id: earmarkId) else {
+      return .zero(instrument: targetInstrument)
+    }
+    return try await convertEarmarkPositions(earmark).balance
+  }
+}

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -201,18 +201,6 @@ final class EarmarkStore {
     showHiddenTask = nil
   }
 
-  func convertedBalance(for earmarkId: UUID) -> InstrumentAmount? {
-    convertedBalances[earmarkId]
-  }
-
-  func convertedSaved(for earmarkId: UUID) -> InstrumentAmount? {
-    convertedSavedAmounts[earmarkId]
-  }
-
-  func convertedSpent(for earmarkId: UUID) -> InstrumentAmount? {
-    convertedSpentAmounts[earmarkId]
-  }
-
   /// Recompute task spawned by the `showHidden` `didSet`. Tracked (not
   /// fire-and-forget) so `stopObserving()` and `deinit` can cancel an
   /// in-flight recompute. A rapid double-toggle cancels the prior task
@@ -386,6 +374,7 @@ final class EarmarkStore {
     return anyFailed
   }
 
+  // Read-only query accessors live in `EarmarkStore+Queries.swift`.
   // Per-earmark conversion helpers live in `EarmarkStore+Conversion.swift`.
   // Mutation methods live in `EarmarkStore+Mutations.swift`.
   // Budget CRUD lives in `EarmarkStore+Budget.swift`.

--- a/MoolahTests/Features/EarmarkStoreConvertedBalanceTests.swift
+++ b/MoolahTests/Features/EarmarkStoreConvertedBalanceTests.swift
@@ -173,4 +173,51 @@ struct EarmarkStoreConvertedBalanceTests {
         && store.convertedSpent(for: earmarkId)?.quantity == 100
     }
   }
+
+  // MARK: - displayBalance (authoritative on-demand)
+
+  @Test
+  func testDisplayBalanceComputesAuthoritativeBalance() async throws {
+    let earmarkId = UUID()
+    let accountId = UUID()
+    let instrument = Instrument.defaultTestInstrument
+    let (backend, database) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "Test", type: .bank, instrument: .defaultTestInstrument)
+      ], in: database)
+    TestBackend.seedWithTransactions(
+      earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
+      amounts: [earmarkId: (saved: 500, spent: 0)],
+      accountId: accountId, in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    // Only wait for the earmark to be observed — `displayBalance` recomputes
+    // from positions on demand, so it must not depend on the converted-balance
+    // dictionary having settled first.
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: earmarkId) != nil },
+      description: "seeded earmark observed"
+    )
+
+    let balance = try await store.displayBalance(for: earmarkId)
+
+    #expect(balance.quantity == 500)
+    #expect(balance.instrument == instrument)
+  }
+
+  @Test
+  func testDisplayBalanceReturnsZeroForUnknownEarmark() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+
+    let balance = try await store.displayBalance(for: UUID())
+
+    #expect(balance.quantity == 0)
+    #expect(balance.instrument == .defaultTestInstrument)
+  }
 }


### PR DESCRIPTION
## Problem

`GetEarmarkBalanceIntent.perform()` is named "Get Earmark Balance" and described as "Returns the balance of a specific earmark," but it **unconditionally returned zero** — the earmark was resolved only to obtain its `.instrument`, and the returned value was always `InstrumentAmount.zero(...)`. The intent was non-functional.

## Fix

- Add `EarmarkStore.displayBalance(for:)` — an authoritative, on-demand read that recomputes from the earmark's positions (mirroring `AccountStore.displayBalance(for:)`) rather than reading the eventually-consistent `convertedBalances` dictionary. This means the intent returns a correct value without waiting for the next conversion pass to settle, and it throws on a real conversion failure rather than reporting a misleading zero. Returns zero in the reporting instrument for an unknown earmark.
- Wire `GetEarmarkBalanceIntent` to call it with the entity's stable `id`, matching `GetAccountBalanceIntent`'s shape (no redundant `resolveEarmark` `fetchAll`).
- Extract the read-only query accessors (`convertedBalance`/`convertedSaved`/`convertedSpent` + the new `displayBalance`) into `EarmarkStore+Queries.swift`, mirroring `AccountStore+Queries.swift`, to keep `EarmarkStore.swift` under the 400-line limit.

## Tests

- `testDisplayBalanceComputesAuthoritativeBalance` — seeds an earmark with a balance, waits only for the earmark to be observed (not for the converted-balance dict to settle), and asserts `displayBalance(for:)` returns the correct value in the earmark's instrument.
- `testDisplayBalanceReturnsZeroForUnknownEarmark` — asserts the zero-with-reporting-instrument fallback for an unknown id.

Build, the earmark store + automation earmark test suites, and `just format-check` all pass. Reviewed with the `code-review` agent (both findings applied).

Fixes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)