### PR TITLE
feat(instrument-picker): rank search results by match quality

### DIFF
--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -6,7 +6,6 @@ import Testing
 @Suite("InstrumentSearchService")
 @MainActor
 struct InstrumentSearchServiceTests {
-  @MainActor
   func makeSubject(
     registered: [Instrument] = [],
     cryptoRegistrations: [CryptoRegistration] = [],
@@ -245,6 +244,11 @@ struct InstrumentSearchServiceTests {
     #expect(registeredIdx < providerIdx)
   }
 
+}
+
+// MARK: - Ranking
+
+extension InstrumentSearchServiceTests {
   @Test("exact currency code match ranks first")
   func exactCurrencyCodeRanksFirst() async throws {
     // A crypto hit that also matches "usd" by name must not displace the
@@ -280,6 +284,56 @@ struct InstrumentSearchServiceTests {
     let lastFiat = results.lastIndex { $0.instrument.kind == .fiatCurrency } ?? -1
     let firstCrypto = results.firstIndex { $0.instrument.kind == .cryptoToken } ?? Int.max
     #expect(lastFiat < firstCrypto)
+  }
+
+  @Test("exact ticker outranks a ticker-prefix match")
+  func exactTickerOutranksPrefix() async throws {
+    let uni = cryptoEntry(symbol: "UNI", name: "Uniswap", address: "0xaaa")
+    let unibright = cryptoEntry(symbol: "UNIB", name: "Unibright", address: "0xbbb")
+    let service = makeSubject(catalogEntries: [unibright, uni])
+    let results = await service.search(query: "uni", kinds: [.cryptoToken])
+    let exactIdx = try #require(results.firstIndex { $0.instrument.ticker == "UNI" })
+    let prefixIdx = try #require(results.firstIndex { $0.instrument.ticker == "UNIB" })
+    #expect(exactIdx < prefixIdx)
+  }
+
+  @Test("ticker prefix outranks a name word-prefix match")
+  func tickerPrefixOutranksNamePrefix() async throws {
+    // "comp" prefixes the COMP ticker (tier 2) but only word-prefixes the
+    // "Cosmos" name (tier 3); the ticker match must lead.
+    let comp = cryptoEntry(symbol: "COMP", name: "Compound", address: "0xaaa")
+    let cosmos = cryptoEntry(symbol: "ATOM", name: "Cosmos Network", address: "0xbbb")
+    let service = makeSubject(catalogEntries: [cosmos, comp])
+    let results = await service.search(query: "co", kinds: [.cryptoToken])
+    let tickerIdx = try #require(results.firstIndex { $0.instrument.ticker == "COMP" })
+    let nameIdx = try #require(results.firstIndex { $0.instrument.ticker == "ATOM" })
+    #expect(tickerIdx < nameIdx)
+  }
+
+  @Test("name word-prefix outranks a mid-word substring match")
+  func nameWordPrefixOutranksSubstring() async throws {
+    // "eth" word-prefixes "Ethereal" (tier 3) but only appears mid-word in
+    // "Tether" (tier 4); neither ticker matches, so the word-prefix wins.
+    let ethereal = cryptoEntry(symbol: "ETL", name: "Ethereal", address: "0xaaa")
+    let tether = cryptoEntry(symbol: "USDT", name: "Tether", address: "0xbbb")
+    let service = makeSubject(catalogEntries: [tether, ethereal])
+    let results = await service.search(query: "eth", kinds: [.cryptoToken])
+    let wordPrefixIdx = try #require(results.firstIndex { $0.instrument.ticker == "ETL" })
+    let substringIdx = try #require(results.firstIndex { $0.instrument.ticker == "USDT" })
+    #expect(wordPrefixIdx < substringIdx)
+  }
+
+  private func cryptoEntry(
+    symbol: String, name: String, address: String
+  ) -> CatalogEntry {
+    CatalogEntry(
+      coingeckoId: symbol.lowercased(),
+      symbol: symbol,
+      name: name,
+      platforms: [
+        PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: address)
+      ]
+    )
   }
 }
 

--- a/Shared/InstrumentSearchResult.swift
+++ b/Shared/InstrumentSearchResult.swift
@@ -4,12 +4,35 @@ import Foundation
 /// already-registered instrument (pulled from `InstrumentRegistryRepository`),
 /// a crypto provider hit that still needs resolution before it can be
 /// persisted, a validated stock ticker, or an ambient fiat currency.
-struct InstrumentSearchResult: Sendable, Identifiable {
+struct InstrumentSearchResult: Sendable {
   let instrument: Instrument
   let cryptoMapping: CryptoProviderMapping?
   let isRegistered: Bool
   let requiresResolution: Bool
 
+  /// The human-readable name the query was matched against for relevance
+  /// ranking. For fiat this is the locale-localized currency name (e.g.
+  /// "US Dollar") because `Instrument.fiat` stores only the ISO code as `name`.
+  let matchName: String
+
+  /// Custom init so `matchName` can default to `instrument.name`; the
+  /// synthesized memberwise init cannot derive a default from another argument.
+  init(
+    instrument: Instrument,
+    cryptoMapping: CryptoProviderMapping?,
+    isRegistered: Bool,
+    requiresResolution: Bool,
+    matchName: String? = nil
+  ) {
+    self.instrument = instrument
+    self.cryptoMapping = cryptoMapping
+    self.isRegistered = isRegistered
+    self.requiresResolution = requiresResolution
+    self.matchName = matchName ?? instrument.name
+  }
+}
+
+extension InstrumentSearchResult: Identifiable {
   var id: String { instrument.id }
 }
 

--- a/Shared/InstrumentSearchService.swift
+++ b/Shared/InstrumentSearchService.swift
@@ -96,15 +96,15 @@ struct InstrumentSearchService: Sendable {
     return Locale.Currency.isoCurrencies.compactMap { currency in
       let code = currency.identifier
       let lowerCode = code.lowercased()
-      let localizedName =
-        Locale.current.localizedString(forCurrencyCode: code)?.lowercased() ?? ""
-      guard lowerCode.hasPrefix(lowered) || localizedName.contains(lowered)
+      let localizedName = Locale.current.localizedString(forCurrencyCode: code) ?? ""
+      guard lowerCode.hasPrefix(lowered) || localizedName.lowercased().contains(lowered)
       else { return nil }
       return InstrumentSearchResult(
         instrument: Instrument.fiat(code: code),
         cryptoMapping: nil,
         isRegistered: true,
-        requiresResolution: false
+        requiresResolution: false,
+        matchName: localizedName
       )
     }
   }
@@ -306,12 +306,15 @@ struct InstrumentSearchService: Sendable {
 // MARK: - Ranking
 
 extension InstrumentSearchService {
-  /// Orders the merged results by relevance. The primary signal is an exact
-  /// ticker/code match against the query — typing "USD" puts US Dollar first;
-  /// the secondary signal favours fiat currencies over every other kind so
-  /// currency matches lead crypto tokens. Within a bucket the merge order is
-  /// preserved (registered rows already lead their provider counterparts), so
-  /// the original index is the final, stability-preserving tiebreaker.
+  /// Orders the merged results by relevance, best match first. The dominant
+  /// signal is *how* the query matched (exact ticker/code → exact name →
+  /// ticker prefix → name word-prefix → loose substring), applied uniformly
+  /// across fiat, crypto, and stock so the likeliest target leads regardless
+  /// of kind. Equal-quality matches break ties on, in order: already-registered
+  /// rows (fiat is always registered, so currencies lead unregistered tokens of
+  /// the same quality); a light fiat nudge; then the original merge index, which
+  /// preserves the provider's own ranking (CoinGecko market cap, Yahoo
+  /// relevance, ISO order for fiat).
   private func rank(
     _ results: [InstrumentSearchResult],
     query: String
@@ -321,33 +324,60 @@ extension InstrumentSearchService {
       results
       .enumerated()
       .sorted { lhs, rhs in
-        RankKey(lhs.element, lowered: lowered, index: lhs.offset)
-          < RankKey(rhs.element, lowered: lowered, index: rhs.offset)
+        RankKey(lhs.element, query: lowered, index: lhs.offset)
+          < RankKey(rhs.element, query: lowered, index: rhs.offset)
       }
       .map(\.element)
   }
 
-  /// Sort key for a single search result. Lower values rank earlier: exact
-  /// ticker/code matches before inexact ones, fiat currencies before every
-  /// other kind, and the original merge index as a stable final tiebreaker.
+  /// Sort key for a single search result. Every member is "lower ranks earlier".
   private struct RankKey: Comparable {
-    let exactRank: Int
-    let kindRank: Int
+    let quality: Int
+    let registeredRank: Int
+    let fiatRank: Int
     let index: Int
 
-    init(_ result: InstrumentSearchResult, lowered: String, index: Int) {
+    /// `query` is expected pre-lowercased.
+    init(_ result: InstrumentSearchResult, query: String, index: Int) {
       let instrument = result.instrument
-      let isExact =
-        instrument.id.lowercased() == lowered
-        || instrument.ticker?.lowercased() == lowered
-      self.exactRank = isExact ? 0 : 1
-      self.kindRank = instrument.kind == .fiatCurrency ? 0 : 1
+      self.quality = Self.matchQuality(
+        query: query,
+        id: instrument.id,
+        ticker: instrument.ticker,
+        name: result.matchName
+      )
+      self.registeredRank = result.isRegistered ? 0 : 1
+      self.fiatRank = instrument.kind == .fiatCurrency ? 0 : 1
       self.index = index
     }
 
+    /// Lower is a better match. The result is already known to match the query
+    /// somehow (it survived the per-kind filter), so the loosest tier is the
+    /// catch-all default.
+    static func matchQuality(query: String, id: String, ticker: String?, name: String)
+      -> Int
+    {
+      let loweredId = id.lowercased()
+      let loweredTicker = ticker?.lowercased()
+      let loweredName = name.lowercased()
+      if loweredId == query || loweredTicker == query { return 0 }
+      if loweredName == query { return 1 }
+      if loweredId.hasPrefix(query) || loweredTicker?.hasPrefix(query) == true { return 2 }
+      if hasWordPrefix(loweredName, prefix: query) { return 3 }
+      return 4
+    }
+
+    /// True when any whitespace/punctuation-delimited word in `text` starts with
+    /// `prefix` — so "dollar" word-matches "US Dollar" but "rusd" does not.
+    static func hasWordPrefix(_ text: String, prefix: String) -> Bool {
+      text
+        .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        .contains { $0.hasPrefix(prefix) }
+    }
+
     static func < (lhs: RankKey, rhs: RankKey) -> Bool {
-      (lhs.exactRank, lhs.kindRank, lhs.index)
-        < (rhs.exactRank, rhs.kindRank, rhs.index)
+      (lhs.quality, lhs.registeredRank, lhs.fiatRank, lhs.index)
+        < (rhs.quality, rhs.registeredRank, rhs.fiatRank, rhs.index)
     }
   }
 }


### PR DESCRIPTION
Follow-up to #1127 (which landed the first cut while this was in review).

## What

#1127 ordered results exact-match-first, then fiat-before-crypto. That's coarse — it's pure bucketing with no "best match" notion. This replaces it with a **relevance score applied uniformly across fiat, crypto, and stock**, so the likeliest target leads regardless of kind. Each hit is scored by *how* the query matched:

| Tier | Match | Example |
|------|-------|---------|
| 0 | exact ticker/code | `USD` → US Dollar, `ETH` → Ethereum |
| 1 | exact name | |
| 2 | ticker/code prefix | `usd` → USDC, USDT |
| 3 | name word-prefix | `dollar` → "US **Dollar**", `bit` → **Bit**coin |
| 4 | loose substring | |

Equal-quality matches break ties on, in order:
1. **registered-first** — fiat is always registered, so currencies still lead unregistered tokens of the same quality;
2. a light **fiat nudge**;
3. the **original merge index**, preserving the provider's own ranking (CoinGecko market cap, Yahoo relevance, ISO order for fiat).

So currencies no longer need a hard kind rule to win — they win on match quality and the registered tiebreaker, but a genuinely better token match (e.g. exact `ETH`) is allowed to lead.

## How

- `RankKey: Comparable` now scores via `matchQuality(...)` + `hasWordPrefix(...)` instead of the exact/fiat two-key sort.
- Ranking needs the localized currency name, which `Instrument.fiat` doesn't store (its `name` is the ISO code), so `InstrumentSearchResult` now carries `matchName` — defaulting to `instrument.name` for every non-fiat kind, set to the localized name on the fiat path.

## Tests

Added tier-ordering tests: exact-ticker > ticker-prefix, ticker-prefix > name-word-prefix, name-word-prefix > mid-word-substring, plus the carried-over exact-currency and currency-before-crypto cases. `InstrumentSearchServiceTests`, `InstrumentPickerStoreTests`, `InstrumentPickerStoreCryptoSelectTests` all pass; `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)