### PR TITLE
feat(crypto): flag homoglyph (mixed-script) tickers as spam

### DIFF
--- a/MoolahTests/Shared/CryptoImport/CryptoSpamHeuristicsTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoSpamHeuristicsTests.swift
@@ -50,6 +50,38 @@ struct CryptoSpamHeuristicsTests {
     #expect(CryptoSpamHeuristics.spamSignal(name: name, symbol: nil) == .scamKeyword)
   }
 
+  // MARK: - Mixed-script (homoglyph) symbols
+
+  /// A spam contract spoofs a popular ASCII ticker by swapping one Latin
+  /// letter for a visually identical character from another script — e.g.
+  /// `USD` + Cyrillic `Es` (U+0421) renders as "USDC" but is not byte-equal
+  /// to it, so the canonical-registry impersonation check misses it. A ticker
+  /// that mixes Latin with another script is therefore itself a spam signal.
+  @Test(
+    "A symbol mixing Latin with another script (homoglyph spoof) is flagged",
+    arguments: [
+      "USD\u{0421}",  // USD + Cyrillic Es — spoofs USDC
+      "\u{0410}AVE",  // Cyrillic A + Latin AVE — spoofs AAVE
+      "L\u{0406}NK",  // Cyrillic Byelorussian-Ukrainian I — spoofs LINK
+    ])
+  func flagsMixedScriptSymbol(symbol: String) {
+    #expect(
+      CryptoSpamHeuristics.spamSignal(name: symbol, symbol: symbol) == .mixedScriptSymbol)
+  }
+
+  @Test("A mixed-script symbol is flagged even when the name is plain ASCII")
+  func flagsMixedScriptSymbolWithCleanName() {
+    #expect(
+      CryptoSpamHeuristics.spamSignal(name: "USD Coin", symbol: "USD\u{0421}")
+        == .mixedScriptSymbol)
+  }
+
+  @Test("Pure-ASCII symbols are never flagged as mixed-script")
+  func pureASCIISymbolNotMixedScript() {
+    #expect(CryptoSpamHeuristics.spamSignal(name: "USDC", symbol: "USDC") == nil)
+    #expect(CryptoSpamHeuristics.spamSignal(name: "Chainlink", symbol: "LINK") == nil)
+  }
+
   // MARK: - Legitimate tokens are not flagged
 
   @Test(

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryHomoglyphTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryHomoglyphTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// End-to-end coverage for the mixed-script (homoglyph) spam path through
+/// `CryptoTokenDiscoveryService.resolveOrLoad`. Kept in its own `@Suite` so
+/// `CryptoTokenDiscoveryServiceTests` stays under the `type_body_length` limit.
+@Suite("CryptoTokenDiscoveryService homoglyph spam")
+struct CryptoTokenDiscoveryHomoglyphTests {
+  @Test("Unpriced token with a mixed-script (homoglyph) symbol → .spam via local heuristic")
+  func unpricedWithHomoglyphSymbolIsSpam() async throws {
+    struct ProviderFailed: Error {}
+    // A non-canonical address claiming "USD" + Cyrillic Es (U+0421). It
+    // renders as "USDC" but is not byte-equal, so the exact-match
+    // impersonation check misses it; the mixed-script heuristic catches it.
+    let fakeAddress = "0xdeadbeef00000000000000000000000000000003"
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: fakeAddress),
+      .failure(ProviderFailed()))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: fakeAddress,
+      symbol: "USD\u{0421}",
+      name: "USD\u{0421}",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .spam)
+    #expect(!registration.mapping.hasProviderMapping)
+    let stored = try await subject.registry.cryptoRegistration(
+      byId: registration.instrument.id)
+    #expect(stored?.pricingStatus == .spam)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -155,6 +155,32 @@ struct CryptoTokenDiscoveryServiceTests {
     #expect(stored?.pricingStatus == .spam)
   }
 
+  @Test("Unpriced token with a mixed-script (homoglyph) symbol → .spam via local heuristic")
+  func unpricedWithHomoglyphSymbolIsSpam() async throws {
+    struct ProviderFailed: Error {}
+    // A non-canonical address claiming "USD" + Cyrillic Es (U+0421). It
+    // renders as "USDC" but is not byte-equal, so the exact-match
+    // impersonation check misses it; the mixed-script heuristic catches it.
+    let fakeAddress = "0xdeadbeef00000000000000000000000000000003"
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: fakeAddress),
+      .failure(ProviderFailed()))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: fakeAddress,
+      symbol: "USD\u{0421}",
+      name: "USD\u{0421}",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .spam)
+    #expect(!registration.mapping.hasProviderMapping)
+    let stored = try await subject.registry.cryptoRegistration(
+      byId: registration.instrument.id)
+    #expect(stored?.pricingStatus == .spam)
+  }
+
   // MARK: - Canonical-registry impersonation (#1102)
 
   @Test("Impersonating token is .spam even when a provider returns a price")

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -155,32 +155,6 @@ struct CryptoTokenDiscoveryServiceTests {
     #expect(stored?.pricingStatus == .spam)
   }
 
-  @Test("Unpriced token with a mixed-script (homoglyph) symbol → .spam via local heuristic")
-  func unpricedWithHomoglyphSymbolIsSpam() async throws {
-    struct ProviderFailed: Error {}
-    // A non-canonical address claiming "USD" + Cyrillic Es (U+0421). It
-    // renders as "USDC" but is not byte-equal, so the exact-match
-    // impersonation check misses it; the mixed-script heuristic catches it.
-    let fakeAddress = "0xdeadbeef00000000000000000000000000000003"
-    let subject = makeDiscoverySubject()
-    subject.resolver.script(
-      .init(chainId: 1, contractAddress: fakeAddress),
-      .failure(ProviderFailed()))
-
-    let registration = try await subject.service.resolveOrLoad(
-      chain: .ethereum,
-      contractAddress: fakeAddress,
-      symbol: "USD\u{0421}",
-      name: "USD\u{0421}",
-      decimals: 18)
-
-    #expect(registration.pricingStatus == .spam)
-    #expect(!registration.mapping.hasProviderMapping)
-    let stored = try await subject.registry.cryptoRegistration(
-      byId: registration.instrument.id)
-    #expect(stored?.pricingStatus == .spam)
-  }
-
   // MARK: - Canonical-registry impersonation (#1102)
 
   @Test("Impersonating token is .spam even when a provider returns a price")

--- a/Shared/CryptoImport/CryptoSpamHeuristics.swift
+++ b/Shared/CryptoImport/CryptoSpamHeuristics.swift
@@ -21,6 +21,9 @@ enum CryptoSpamHeuristics {
     case embeddedURL
     /// The name or symbol contains airdrop / invitation / voucher phrasing.
     case scamKeyword
+    /// The symbol mixes Latin with another script (a homoglyph spoof of a
+    /// popular ASCII ticker, e.g. `USD` + Cyrillic `Es`).
+    case mixedScriptSymbol
   }
 
   /// Returns the heuristic that classifies `(name, symbol)` as spam, or `nil`
@@ -33,6 +36,7 @@ enum CryptoSpamHeuristics {
     guard !haystack.allSatisfy(\.isWhitespace) else { return nil }
     if containsURLOrDomain(haystack) { return .embeddedURL }
     if containsScamKeyword(haystack) { return .scamKeyword }
+    if let symbol, isMixedScript(symbol) { return .mixedScriptSymbol }
     return nil
   }
 
@@ -86,6 +90,44 @@ enum CryptoSpamHeuristics {
 
   private static func containsScamKeyword(_ haystack: String) -> Bool {
     matches(scamKeywordRegex, in: haystack)
+  }
+
+  // MARK: - Mixed-script (homoglyph) detection
+
+  /// Returns `true` when `symbol` mixes a Latin letter with a letter from
+  /// another script. Legitimate tickers are pure ASCII/Latin; a spam contract
+  /// spoofs a popular ticker by swapping one Latin letter for a visually
+  /// identical character from another script — e.g. Cyrillic `Es` (U+0421)
+  /// for Latin `C` to fake "USDC". Such a symbol renders as the target ticker
+  /// but is not byte-equal to it, so the canonical-registry impersonation
+  /// check (exact match) misses it; this signal closes that gap.
+  ///
+  /// Pure single-script symbols are intentionally not flagged: an all-Latin
+  /// ticker is the normal case, and an all-non-Latin ticker cannot read as a
+  /// Latin target (the spoof must keep the Latin letters that lack a
+  /// convincing confusable, so the result is always mixed).
+  private static func isMixedScript(_ symbol: String) -> Bool {
+    var hasLatin = false
+    var hasNonLatin = false
+    for scalar in symbol.unicodeScalars where scalar.properties.isAlphabetic {
+      if isLatinLetter(scalar) { hasLatin = true } else { hasNonLatin = true }
+      if hasLatin && hasNonLatin { return true }
+    }
+    return false
+  }
+
+  /// Whether `scalar` is a letter in the Latin script: Basic Latin, Latin-1
+  /// Supplement, and Latin Extended-A/B/Additional. Any alphabetic scalar
+  /// outside these blocks counts as another script for mixed-script detection.
+  private static func isLatinLetter(_ scalar: Unicode.Scalar) -> Bool {
+    switch scalar.value {
+    case 0x41...0x5A, 0x61...0x7A,  // A–Z, a–z
+      0xC0...0x24F,  // Latin-1 Supplement + Latin Extended-A/B
+      0x1E00...0x1EFF:  // Latin Extended Additional
+      return true
+    default:
+      return false
+    }
   }
 
   // MARK: - Regex plumbing


### PR DESCRIPTION
## Problem

A discovered token at a non-canonical address claiming a protected ticker via a **Unicode homoglyph** evades spam detection and sits `.unpriced` forever.

Found on the prod profile: a "USDC" at `0xe78f0d3e8d5aff5a8be2be436c9947f472564648` (Ethereum) whose ticker is `USD` + **Cyrillic Es (U+0421)** — bytes `555344D0A1`. It renders identically to `USDC` but isn't byte-equal, so `CanonicalTokenRegistry.isImpersonation` (exact, case-folded match) misses `bundled[1]["USDC"]` (Latin) and returns "not impersonation". The token then fails provider resolution and lands `.unpriced` instead of `.spam`. Plain-ASCII fake USDCs *were* correctly flagged.

## Fix

New `CryptoSpamHeuristics.SpamSignal.mixedScriptSymbol`: a ticker mixing a Latin letter with a letter from another script is itself a spam signal. This is the textbook homoglyph spoof — a legit ticker is pure ASCII/Latin.

Wired into the existing `.unpriced` branch of `CryptoTokenDiscoveryService.performResolution`, so (consistent with the URL/keyword heuristics) it only ever turns an otherwise-`.unpriced` token into `.spam` and never demotes a token that resolved to a price provider.

## Tests (TDD)

- Unit: `flagsMixedScriptSymbol` (Cyrillic/homoglyph args), `flagsMixedScriptSymbolWithCleanName`, `pureASCIISymbolNotMixedScript` — watched fail (returned `nil`) before the impl, pass after.
- Integration: `unpricedWithHomoglyphSymbolIsSpam` exercises the real `resolveOrLoad` path end-to-end.
- `CryptoSpamHeuristicsTests` + `CryptoTokenDiscoveryServiceTests` green; `just format-check` clean.

Relates to #1102. Existing `.unpriced` homoglyph tokens flip to spam on their next re-resolve (daily auto, or the manual button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)