### PR TITLE
feat(crypto): price known tokens offline from the local catalog

### DIFF
--- a/App/ProfileSession+CatalogFactory.swift
+++ b/App/ProfileSession+CatalogFactory.swift
@@ -1,0 +1,71 @@
+// App/ProfileSession+CatalogFactory.swift
+
+import Foundation
+import GRDB
+import OSLog
+
+extension ProfileSession {
+  /// Builds the per-profile CoinGecko catalog and kicks off a background
+  /// `refreshIfStale()` so the SQLite snapshot is brought up to date once per
+  /// session without blocking init. Returns `(nil, nil)` (and logs) when the
+  /// SQLite file can't be opened — the caller treats that as a degraded
+  /// search path. The returned `refreshTask` handle is stored on
+  /// `ProfileSession` so it can be cancelled on teardown.
+  @MainActor
+  static func makeCoinGeckoCatalog(
+    apiKey: String?,
+    networking: NetworkingServices
+  ) -> (catalog: (any CoinGeckoCatalog)?, refreshTask: Task<Void, Never>?) {
+    let directory = URL.moolahScopedApplicationSupport
+      .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
+    do {
+      let host = (apiKey ?? "").isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
+      let catalog = try SQLiteCoinGeckoCatalog.make(
+        directory: directory,
+        http: networking.client(forHost: host))
+      // `SQLiteCoinGeckoCatalog` is an actor, so `await catalog.refreshIfStale()`
+      // hops to the catalog's executor regardless of the enclosing Task's
+      // isolation — no `Task.detached` needed (CONCURRENCY_GUIDE §8).
+      let refreshTask = Task(priority: .background) { [catalog] in
+        await catalog.refreshIfStale()
+      }
+      return (catalog, refreshTask)
+    } catch {
+      Logger(subsystem: "com.moolah.app", category: "ProfileSession")
+        .error("CoinGecko catalog init failed: \(error.localizedDescription, privacy: .public)")
+      return (nil, nil)
+    }
+  }
+
+  /// Opens a read-only handle to the shared CoinGecko catalog for offline
+  /// `(chain, contract) → CoinGecko id` resolution by the discovery token
+  /// resolver. Unlike `makeCoinGeckoCatalog` it starts no `refreshIfStale()`
+  /// task — the registry-wiring catalog owns that refresh; this handle reads
+  /// the same on-disk snapshot (WAL lets a separate connection see those
+  /// writes). Returns `nil` on open failure, or under UI testing where the
+  /// discovery flow runs against seeded data rather than the live catalog.
+  ///
+  /// Not `@MainActor`: `makeMarketDataServices` (its caller) runs both on the
+  /// `@MainActor` `ProfileSession.init` path and the non-isolated app-boot
+  /// `bootstrapSyncCoordinator` path, and `currentUITestSeed()` reads only
+  /// `CommandLine` / `ProcessInfo`.
+  static func makeLookupCatalog(
+    apiKey: String?,
+    networking: NetworkingServices
+  ) -> (any LocalContractResolver)? {
+    guard currentUITestSeed() == nil else { return nil }
+    let directory = URL.moolahScopedApplicationSupport
+      .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
+    do {
+      let host = (apiKey ?? "").isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
+      return try SQLiteCoinGeckoCatalog.make(
+        directory: directory,
+        http: networking.client(forHost: host))
+    } catch {
+      Logger(subsystem: "com.moolah.app", category: "ProfileSession")
+        .error(
+          "CoinGecko lookup catalog init failed: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
+  }
+}

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -36,6 +36,10 @@ extension ProfileSession {
       service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true
     )
     let coinGeckoApiKey = try? apiKeyStore.restoreString()
+    // Read-only handle to the shared CoinGecko catalog so the discovery token
+    // resolver can price a known token offline (see `makeLookupCatalog`).
+    let lookupCatalog = Self.makeLookupCatalog(
+      apiKey: coinGeckoApiKey, networking: networking)
     return MarketDataServices(
       exchangeRate: ExchangeRateService(
         client: FrankfurterClient(
@@ -43,7 +47,8 @@ extension ProfileSession {
         database: database),
       stockPrice: StockPriceService(client: yahooClient, database: database),
       cryptoPrice: Self.makeCryptoPriceService(
-        coinGeckoApiKey: coinGeckoApiKey, database: database, networking: networking),
+        coinGeckoApiKey: coinGeckoApiKey, database: database, networking: networking,
+        localResolver: lookupCatalog),
       yahooPriceFetcher: yahooClient,
       coinGeckoApiKey: coinGeckoApiKey
     )
@@ -58,7 +63,8 @@ extension ProfileSession {
   static func makeCryptoPriceService(
     coinGeckoApiKey: String?,
     database: any DatabaseWriter,
-    networking: NetworkingServices
+    networking: NetworkingServices,
+    localResolver: (any LocalContractResolver)? = nil
   ) -> CryptoPriceService {
     // Empty key → CoinGeckoClient targets the free public host;
     // non-empty key → Pro host with `x_cg_pro_api_key`. Always included
@@ -93,7 +99,8 @@ extension ProfileSession {
       clients: priceClients,
       database: database,
       resolutionClient: CompositeTokenResolutionClient(
-        networking: networking, coinGeckoApiKey: resolverApiKey)
+        networking: networking, coinGeckoApiKey: resolverApiKey,
+        localResolver: localResolver)
     )
   }
 
@@ -262,38 +269,6 @@ extension ProfileSession {
     }
 
   #endif
-
-  /// Builds the per-profile CoinGecko catalog and kicks off a background
-  /// `refreshIfStale()` so the SQLite snapshot is brought up to date once per
-  /// session without blocking init. Returns `(nil, nil)` (and logs) when the
-  /// SQLite file can't be opened — the caller treats that as a degraded
-  /// search path. The returned `refreshTask` handle is stored on
-  /// `ProfileSession` so it can be cancelled on teardown.
-  @MainActor
-  private static func makeCoinGeckoCatalog(
-    apiKey: String?,
-    networking: NetworkingServices
-  ) -> (catalog: (any CoinGeckoCatalog)?, refreshTask: Task<Void, Never>?) {
-    let directory = URL.moolahScopedApplicationSupport
-      .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
-    do {
-      let host = (apiKey ?? "").isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
-      let catalog = try SQLiteCoinGeckoCatalog.make(
-        directory: directory,
-        http: networking.client(forHost: host))
-      // `SQLiteCoinGeckoCatalog` is an actor, so `await catalog.refreshIfStale()`
-      // hops to the catalog's executor regardless of the enclosing Task's
-      // isolation — no `Task.detached` needed (CONCURRENCY_GUIDE §8).
-      let refreshTask = Task(priority: .background) { [catalog] in
-        await catalog.refreshIfStale()
-      }
-      return (catalog, refreshTask)
-    } catch {
-      Logger(subsystem: "com.moolah.app", category: "ProfileSession")
-        .error("CoinGecko catalog init failed: \(error.localizedDescription, privacy: .public)")
-      return (nil, nil)
-    }
-  }
 
   // MARK: - Domain Stores
 

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+ContractLookup.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+ContractLookup.swift
@@ -1,0 +1,59 @@
+// Backends/CoinGecko/SQLiteCoinGeckoCatalog+ContractLookup.swift
+import Foundation
+import SQLite3
+
+/// Offline `(chainId, contractAddress) → CoinGecko id` resolution over the
+/// cached catalog. Lets a known token (e.g. canonical USDC) be priced
+/// immediately without a network round-trip. Hosted in its own file so the
+/// actor's primary body stays focused (see `guides/CODE_GUIDE.md` §7).
+extension SQLiteCoinGeckoCatalog: LocalContractResolver {
+  /// Resolves the CoinGecko id, symbol, and name for a token identified by its
+  /// on-chain `(chainId, contractAddress)`, or `nil` when the catalog has no
+  /// such deployment. Matching is case-insensitive on the contract (addresses
+  /// are stored lowercased). Infallible by design — any SQLite failure is
+  /// logged and swallowed to `nil`, mirroring `search(query:limit:)`.
+  func localContractMatch(
+    chainId: Int, contractAddress: String
+  ) async -> LocalContractMatch? {
+    do {
+      return try Self.fetchContractMatch(
+        database: database,
+        chainId: chainId,
+        contractAddress: contractAddress.lowercased())
+    } catch {
+      Self.log.error(
+        "localContractMatch failed: \(String(describing: error), privacy: .public)")
+      return nil
+    }
+  }
+
+  private static func fetchContractMatch(
+    database: OpaquePointer?,
+    chainId: Int,
+    contractAddress: String
+  ) throws -> LocalContractMatch? {
+    var statement: OpaquePointer?
+    try prepare(
+      database: database,
+      sql: """
+        SELECT c.coingecko_id, c.symbol, c.name
+        FROM coin_platform cp
+        JOIN platform p ON p.slug = cp.platform_slug
+        JOIN coin c ON c.coingecko_id = cp.coingecko_id
+        WHERE p.chain_id = ? AND cp.contract_address = ?
+        LIMIT 1;
+        """,
+      into: &statement
+    )
+    defer { sqlite3_finalize(statement) }
+    try bind(statement, at: 1, to: chainId)
+    try bind(statement, at: 2, to: contractAddress)
+    guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+    let id = readText(statement, column: 0) ?? ""
+    guard !id.isEmpty else { return nil }
+    return LocalContractMatch(
+      coingeckoId: id,
+      symbol: readText(statement, column: 1) ?? "",
+      name: readText(statement, column: 2) ?? "")
+  }
+}

--- a/MoolahTests/Backends/CoinGeckoCatalogContractLookupTests.swift
+++ b/MoolahTests/Backends/CoinGeckoCatalogContractLookupTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Offline resolution of a token's CoinGecko id from its on-chain
+/// `(chainId, contractAddress)` against the bundled / cached catalog. This is
+/// what lets a known token (e.g. canonical USDC) be priced immediately without
+/// a network round-trip. Class-based suite so `deinit` removes the temp dir.
+@Suite("SQLiteCoinGeckoCatalog contract lookup")
+final class CoinGeckoCatalogContractLookupTests {
+  private let tempDir: URL
+  private let catalog: SQLiteCoinGeckoCatalog
+
+  init() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("contract-lookup-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir,
+      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+  }
+
+  deinit {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func seedFixture() async throws {
+    let coins: [SQLiteCoinGeckoCatalog.RawCoin] = [
+      .init(
+        id: "usd-coin", symbol: "USDC", name: "USDC",
+        platforms: [
+          "ethereum": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "polygon-pos": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+        ]
+      ),
+      .init(
+        id: "uniswap", symbol: "UNI", name: "Uniswap",
+        platforms: ["ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"]
+      ),
+    ]
+    let platforms: [SQLiteCoinGeckoCatalog.RawPlatform] = [
+      .init(slug: "ethereum", chainId: 1, name: "Ethereum"),
+      .init(slug: "polygon-pos", chainId: 137, name: "Polygon"),
+    ]
+    try await catalog.replaceAllForTesting(coins: coins, platforms: platforms)
+  }
+
+  @Test("Resolves the CoinGecko mapping for a known (chain, contract)")
+  func resolvesKnownContract() async throws {
+    try await seedFixture()
+    let match = await catalog.localContractMatch(
+      chainId: 1, contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(match?.coingeckoId == "usd-coin")
+    #expect(match?.symbol == "USDC")
+    #expect(match?.name == "USDC")
+  }
+
+  @Test("Contract matching is case-insensitive")
+  func contractMatchIsCaseInsensitive() async throws {
+    try await seedFixture()
+    let match = await catalog.localContractMatch(
+      chainId: 1, contractAddress: "0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48")
+    #expect(match?.coingeckoId == "usd-coin")
+  }
+
+  @Test("The same contract on a different chain does not match")
+  func differentChainDoesNotMatch() async throws {
+    try await seedFixture()
+    // USDC's Ethereum address queried on Polygon (137) must not resolve.
+    let match = await catalog.localContractMatch(
+      chainId: 137, contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(match == nil)
+  }
+
+  @Test("An unknown contract resolves to nil")
+  func unknownContractIsNil() async throws {
+    try await seedFixture()
+    let match = await catalog.localContractMatch(
+      chainId: 1, contractAddress: "0xdeadbeef00000000000000000000000000000001")
+    #expect(match == nil)
+  }
+}

--- a/MoolahTests/Shared/CompositeTokenResolutionLocalFirstTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionLocalFirstTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Counting test double for `LocalContractResolver`. An actor so the call
+/// count is race-free under the `Sendable` protocol requirement.
+private actor StubLocalContractResolver: LocalContractResolver {
+  private let match: LocalContractMatch?
+  private(set) var calls = 0
+
+  init(match: LocalContractMatch?) { self.match = match }
+
+  func localContractMatch(chainId: Int, contractAddress: String) async -> LocalContractMatch? {
+    calls += 1
+    return match
+  }
+}
+
+/// Local-first resolution: a token known to the bundled / cached catalog is
+/// priced from local data, ahead of (and without) any network provider call.
+@Suite("CompositeTokenResolutionClient local-first", .serialized)
+final class CompositeTokenResolutionLocalFirstTests {
+  deinit {
+    StubURLProtocol.handlers = [:]
+  }
+
+  private func noHandlerNetworking() -> NetworkingServices {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return NetworkingServices(session: URLSession(configuration: config))
+  }
+
+  @Test("A catalog hit resolves the CoinGecko id from local data")
+  func localHitResolvesId() async throws {
+    let local = StubLocalContractResolver(
+      match: LocalContractMatch(coingeckoId: "usd-coin", symbol: "USDC", name: "USDC"))
+    let client = CompositeTokenResolutionClient(
+      coinListData: Data(#"{"Data":{}}"#.utf8),
+      exchangeInfoData: Data(#"{"symbols":[]}"#.utf8),
+      coinGeckoApiKey: nil,
+      localResolver: local
+    )
+
+    let result = try await client.resolve(
+      chainId: 1,
+      contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      symbol: "USDC",
+      isNative: false
+    )
+
+    #expect(result.coingeckoId == "usd-coin")
+    #expect(result.resolvedSymbol == "USDC")
+    #expect(result.hasAnyProviderId)
+  }
+
+  @Test("A catalog hit short-circuits ahead of any network call")
+  func localHitSkipsNetwork() async throws {
+    // No StubURLProtocol handlers are registered, so any outbound request
+    // throws. The resolution must still succeed, proving no network was hit.
+    let local = StubLocalContractResolver(
+      match: LocalContractMatch(coingeckoId: "usd-coin", symbol: "USDC", name: "USDC"))
+    let client = CompositeTokenResolutionClient(
+      networking: noHandlerNetworking(),
+      coinGeckoApiKey: "",
+      localResolver: local
+    )
+
+    let result = try await client.resolve(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC",
+      isNative: false
+    )
+
+    #expect(result.coingeckoId == "usd-coin")
+    #expect(await local.calls == 1)
+  }
+
+  @Test("A native token bypasses the local contract lookup")
+  func nativeBypassesLocal() async throws {
+    let local = StubLocalContractResolver(match: nil)
+    let client = CompositeTokenResolutionClient(
+      coinListData: Data(#"{"Data":{}}"#.utf8),
+      exchangeInfoData: Data(#"{"symbols":[]}"#.utf8),
+      coinGeckoApiKey: nil,
+      localResolver: local
+    )
+
+    _ = try await client.resolve(
+      chainId: 1, contractAddress: nil, symbol: "ETH", isNative: true)
+
+    #expect(await local.calls == 0)
+  }
+}

--- a/Shared/CompositeTokenResolutionClient.swift
+++ b/Shared/CompositeTokenResolutionClient.swift
@@ -5,14 +5,23 @@ import Foundation
 struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
   private let networking: NetworkingServices
   private let coinGeckoApiKey: String?
+  /// Offline `(chainId, contract) → CoinGecko id` source, consulted before any
+  /// network provider so a token already known to the bundled / cached catalog
+  /// is priced immediately. `nil` disables the local-first path (e.g. tests).
+  private let localResolver: LocalContractResolver?
 
   // For testing: inject pre-parsed reference data
   private let preloadedCoinList: Data?
   private let preloadedExchangeInfo: Data?
 
-  init(networking: NetworkingServices, coinGeckoApiKey: String? = nil) {
+  init(
+    networking: NetworkingServices,
+    coinGeckoApiKey: String? = nil,
+    localResolver: LocalContractResolver? = nil
+  ) {
     self.networking = networking
     self.coinGeckoApiKey = coinGeckoApiKey
+    self.localResolver = localResolver
     self.preloadedCoinList = nil
     self.preloadedExchangeInfo = nil
   }
@@ -24,10 +33,12 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
     coinListData: Data,
     exchangeInfoData: Data,
     coinGeckoApiKey: String?,
-    networking: NetworkingServices = NetworkingServices()
+    networking: NetworkingServices = NetworkingServices(),
+    localResolver: LocalContractResolver? = nil
   ) {
     self.networking = networking
     self.coinGeckoApiKey = coinGeckoApiKey
+    self.localResolver = localResolver
     self.preloadedCoinList = coinListData
     self.preloadedExchangeInfo = exchangeInfoData
   }
@@ -36,6 +47,23 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
     chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
   ) async throws -> TokenResolutionResult {
     var result = TokenResolutionResult()
+
+    // Local-first: a contract-addressed token already known to the bundled /
+    // cached catalog is priced from local data, short-circuiting ahead of any
+    // network provider call. Natives are identified by symbol below, not by
+    // contract, so they skip this path. The discovery service persists the
+    // on-chain instrument (correct decimals), so only the provider id is
+    // needed here.
+    if !isNative, let contractAddress,
+      let local = await localResolver?.localContractMatch(
+        chainId: chainId, contractAddress: contractAddress)
+    {
+      result.coingeckoId = local.coingeckoId
+      result.resolvedSymbol = local.symbol
+      result.resolvedName = local.name
+      return result
+    }
+
     let coinListData = try await fetchCoinListData()
 
     resolveFromCryptoCompare(

--- a/Shared/CryptoImport/LocalContractResolver.swift
+++ b/Shared/CryptoImport/LocalContractResolver.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// A token's identity resolved offline from the bundled / cached CoinGecko
+/// catalog by its on-chain `(chainId, contractAddress)`. Carries just enough
+/// to mark a discovered token `.priced` without a network round-trip: the
+/// persisted instrument keeps its on-chain decimals (the discovery service
+/// builds it), so only the provider id is needed here.
+struct LocalContractMatch: Sendable, Equatable {
+  let coingeckoId: String
+  let symbol: String
+  let name: String
+}
+
+/// Offline `(chainId, contractAddress) → CoinGecko id` resolution. Lets the
+/// token resolver price a known token from local data before falling back to
+/// the network providers. `SQLiteCoinGeckoCatalog` is the production conformer.
+protocol LocalContractResolver: Sendable {
+  func localContractMatch(chainId: Int, contractAddress: String) async -> LocalContractMatch?
+}


### PR DESCRIPTION
## Problem

Real, canonical tokens sit `.unpriced` in *Discovered Tokens* indefinitely. Example from the prod profile: canonical USDC (`0xa0b8…eb48` on Ethereum) is `.unpriced`, and re-resolve never fixes it.

Root cause: the discovery resolver (`CompositeTokenResolutionClient`) is **network-only** and never consults local data:
- CryptoCompare's contract index omits USDC (chain-agnostic listing, no contract field).
- The CoinGecko step uses the anonymous free endpoint (`coinGeckoApiKey ?? ""`), which is rate-limited and swallowed as best-effort.
- Binance is gated on a contract provider confirming the symbol first.

Meanwhile the bundled/cached `catalog.sqlite` already maps `usd-coin / ethereum / 0xa0b8…` (and ~17k other tokens) — but the resolver doesn't look at it.

## Fix

Consult the local catalog **before** any network provider; on a hit, resolve from local data with no network call.

- `SQLiteCoinGeckoCatalog.localContractMatch(chainId:contractAddress:)` — offline `(chain, contract) → coingecko_id` via a `coin_platform`/`platform`/`coin` join (contract lowercased), behind a new `LocalContractResolver` protocol.
- `CompositeTokenResolutionClient` consults the local resolver first for contract-addressed tokens and short-circuits ahead of the network on a hit; natives still resolve by symbol. (The discovery service persists the on-chain instrument, so decimals stay correct — only the provider id comes from the catalog.)
- `makeMarketDataServices` opens a read-only lookup handle (no refresh task — the registry-wiring catalog owns the refresh; WAL lets this connection see the writes) and injects it as the discovery resolver's `localResolver`. Gated off under UI testing via the non-`@MainActor` `currentUITestSeed()`, leaving the app-boot DI ordering and isolation untouched.

## Tests (TDD)

- `CoinGeckoCatalogContractLookupTests` — known hit, case-insensitive, wrong-chain miss, unknown miss (RED→GREEN).
- `CompositeTokenResolutionLocalFirstTests` — local hit resolves the id, short-circuits with **no network call**, native bypasses (RED→GREEN).
- `ProfileSessionCatalogIntegrationTests` + `SharedInstrumentScopeTests` still green (wiring); `just format-check` clean.

Companion to the homoglyph-spam fix (#1132). Existing `.unpriced` tokens re-price on their next re-resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)