### PR TITLE
test(navigation): poll settled state in SidebarDropDispatch tests (kill emission flake)

### DIFF
--- a/MoolahTests/Navigation/SidebarDropDispatchCrossGroupTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchCrossGroupTests.swift
@@ -8,6 +8,15 @@ import Testing
 /// covers `dropOntoAccount` and `dropOntoGroup` cases where the source
 /// leaves its old group to join the destination's. Shared fixtures live
 /// in `SidebarDropDispatchTestSupport.swift`.
+///
+/// Post-mutation state is asserted with `expectEventually` (polls the
+/// exact asserted expression) rather than `waitForNextEmission` (awaits
+/// one tick, then reads). A store's `observationTicks` is a
+/// single-consumer `AsyncStream`; when one test feeds two sequential
+/// waits to the same store, the second iterator can miss the tick that
+/// carries the awaited state and then block until the deadline even
+/// though the steady-state value is already correct. Polling the value
+/// sidesteps the stream entirely.
 @Suite("SidebarDropDispatch — cross-group drops")
 @MainActor
 struct SidebarDropDispatchCrossGroupTests {
@@ -24,18 +33,16 @@ struct SidebarDropDispatchCrossGroupTests {
     let groupA = try await stores.accountGroupStore.createGroup(
       joining: aMember1, and: aMember2, name: "A",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: aMember1.id)?.groupId == groupA.id
-          && $0.accounts.by(id: aMember2.id)?.groupId == groupA.id
-      },
-      description: "group A members joined")
+    await expectEventually("group A members joined") {
+      stores.accountStore.accounts.by(id: aMember1.id)?.groupId == groupA.id
+        && stores.accountStore.accounts.by(id: aMember2.id)?.groupId == groupA.id
+    }
 
     let groupB = try await stores.accountGroupStore.createGroup(
       from: bMember, name: "B", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: bMember.id)?.groupId == groupB.id },
-      description: "B single-member group seeded")
+    await expectEventually("B single-member group seeded") {
+      stores.accountStore.accounts.by(id: bMember.id)?.groupId == groupB.id
+    }
 
     _ = try await SidebarDropDispatch.dropOntoAccount(
       sourceId: aMember1.id,
@@ -61,14 +68,14 @@ struct SidebarDropDispatchCrossGroupTests {
 
     let groupA = try await stores.accountGroupStore.createGroup(
       from: aSole, name: "A", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aSole.id)?.groupId == groupA.id },
-      description: "aSole joined group A")
+    await expectEventually("aSole joined group A") {
+      stores.accountStore.accounts.by(id: aSole.id)?.groupId == groupA.id
+    }
     let groupB = try await stores.accountGroupStore.createGroup(
       from: bMember, name: "B", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: bMember.id)?.groupId == groupB.id },
-      description: "bMember joined group B")
+    await expectEventually("bMember joined group B") {
+      stores.accountStore.accounts.by(id: bMember.id)?.groupId == groupB.id
+    }
 
     _ = try await SidebarDropDispatch.dropOntoAccount(
       sourceId: aSole.id,
@@ -77,12 +84,10 @@ struct SidebarDropDispatchCrossGroupTests {
       accountGroupStore: stores.accountGroupStore,
       groupUIStateStore: stores.groupUIStateStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aSole.id)?.groupId == groupB.id },
-      description: "aSole now in groupB")
-    try await stores.accountGroupStore.waitForNextEmission(
-      matching: { $0.by(id: groupA.id) == nil },
-      description: "group A auto-deleted")
+    await expectEventually("aSole now in groupB and group A auto-deleted") {
+      stores.accountStore.accounts.by(id: aSole.id)?.groupId == groupB.id
+        && stores.accountGroupStore.by(id: groupA.id) == nil
+    }
   }
 
   @Test("dropOntoGroup from a sole-member-group deletes the old group")
@@ -95,14 +100,14 @@ struct SidebarDropDispatchCrossGroupTests {
 
     let groupA = try await stores.accountGroupStore.createGroup(
       from: aSole, name: "A", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aSole.id)?.groupId == groupA.id },
-      description: "aSole joined group A")
+    await expectEventually("aSole joined group A") {
+      stores.accountStore.accounts.by(id: aSole.id)?.groupId == groupA.id
+    }
     let groupB = try await stores.accountGroupStore.createGroup(
       from: bMember, name: "B", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: bMember.id)?.groupId == groupB.id },
-      description: "bMember joined group B")
+    await expectEventually("bMember joined group B") {
+      stores.accountStore.accounts.by(id: bMember.id)?.groupId == groupB.id
+    }
 
     try await SidebarDropDispatch.dropOntoGroup(
       sourceId: aSole.id,
@@ -111,11 +116,9 @@ struct SidebarDropDispatchCrossGroupTests {
       accountGroupStore: stores.accountGroupStore,
       groupUIStateStore: stores.groupUIStateStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aSole.id)?.groupId == groupB.id },
-      description: "aSole now in groupB")
-    try await stores.accountGroupStore.waitForNextEmission(
-      matching: { $0.by(id: groupA.id) == nil },
-      description: "group A auto-deleted")
+    await expectEventually("aSole now in groupB and group A auto-deleted") {
+      stores.accountStore.accounts.by(id: aSole.id)?.groupId == groupB.id
+        && stores.accountGroupStore.by(id: groupA.id) == nil
+    }
   }
 }

--- a/MoolahTests/Navigation/SidebarDropDispatchReorderMembersTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchReorderMembersTests.swift
@@ -6,6 +6,17 @@ import Testing
 
 /// Tests for `SidebarDropDispatch.reorderMembers`. Shared fixtures live in
 /// `SidebarDropDispatchTestSupport.swift`.
+///
+/// Post-mutation state is asserted with `expectEventually` (polls the
+/// exact asserted expression) rather than `waitForNextEmission` (awaits
+/// one tick, then reads). A store's `observationTicks` is a
+/// single-consumer `AsyncStream`; when one test feeds two sequential
+/// waits to the same store, the second iterator can miss the tick that
+/// carries the awaited state and then block until the deadline even
+/// though the steady-state value is already correct. Polling the value
+/// sidesteps the stream entirely. The `didEmitWithin` absence check
+/// keeps `waitForNextEmission`'s stream — asserting an emission does not
+/// occur is its job.
 @Suite("SidebarDropDispatch — reorderMembers")
 @MainActor
 struct SidebarDropDispatchReorderMembersTests {
@@ -22,19 +33,17 @@ struct SidebarDropDispatchReorderMembersTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "A,B joined")
+    await expectEventually("A,B joined") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     let postC = try #require(stores.accountStore.accounts.by(id: memberC.id))
     try await stores.accountGroupStore.addAccount(
       postC, to: group, accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: memberC.id)?.groupId == group.id },
-      description: "C joined")
+    await expectEventually("C joined") {
+      stores.accountStore.accounts.by(id: memberC.id)?.groupId == group.id
+    }
 
     try await SidebarDropDispatch.reorderMembers(
       groupId: group.id,
@@ -63,12 +72,10 @@ struct SidebarDropDispatchReorderMembersTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "members joined")
+    await expectEventually("members joined") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     try await SidebarDropDispatch.reorderMembers(
       groupId: group.id,
@@ -77,12 +84,10 @@ struct SidebarDropDispatchReorderMembersTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        ($0.accounts.by(id: memberA.id)?.position ?? -1)
-          > ($0.accounts.by(id: memberB.id)?.position ?? -1)
-      },
-      description: "A clamped to end")
+    await expectEventually("A clamped to end") {
+      (stores.accountStore.accounts.by(id: memberA.id)?.position ?? -1)
+        > (stores.accountStore.accounts.by(id: memberB.id)?.position ?? -1)
+    }
   }
 
   @Test("reorderMembers is a no-op when the source id is unknown")
@@ -96,12 +101,10 @@ struct SidebarDropDispatchReorderMembersTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "members joined")
+    await expectEventually("members joined") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     await stores.accountStore.drainPendingEmissions()
     try await SidebarDropDispatch.reorderMembers(
@@ -137,9 +140,9 @@ struct SidebarDropDispatchReorderMembersTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: memberA.id)?.groupId == group.id },
-      description: "group seeded")
+    await expectEventually("group seeded") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+    }
 
     try await SidebarDropDispatch.reorderMembers(
       groupId: group.id,
@@ -169,14 +172,14 @@ struct SidebarDropDispatchReorderMembersTests {
 
     let groupA = try await stores.accountGroupStore.createGroup(
       joining: accA1, and: accA2, name: "A", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accA1.id)?.groupId == groupA.id },
-      description: "group A seeded")
+    await expectEventually("group A seeded") {
+      stores.accountStore.accounts.by(id: accA1.id)?.groupId == groupA.id
+    }
     let groupB = try await stores.accountGroupStore.createGroup(
       joining: accB1, and: accB2, name: "B", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accB1.id)?.groupId == groupB.id },
-      description: "group B seeded")
+    await expectEventually("group B seeded") {
+      stores.accountStore.accounts.by(id: accB1.id)?.groupId == groupB.id
+    }
 
     try await SidebarDropDispatch.reorderMembers(
       groupId: groupB.id,
@@ -210,14 +213,14 @@ struct SidebarDropDispatchReorderMembersTests {
 
     let groupA = try await stores.accountGroupStore.createGroup(
       from: aSole, name: "A", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aSole.id)?.groupId == groupA.id },
-      description: "aSole joined A")
+    await expectEventually("aSole joined A") {
+      stores.accountStore.accounts.by(id: aSole.id)?.groupId == groupA.id
+    }
     let groupB = try await stores.accountGroupStore.createGroup(
       joining: accB1, and: accB2, name: "B", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: accB1.id)?.groupId == groupB.id },
-      description: "group B seeded")
+    await expectEventually("group B seeded") {
+      stores.accountStore.accounts.by(id: accB1.id)?.groupId == groupB.id
+    }
 
     try await SidebarDropDispatch.reorderMembers(
       groupId: groupB.id,
@@ -226,11 +229,9 @@ struct SidebarDropDispatchReorderMembersTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: aSole.id)?.groupId == groupB.id },
-      description: "aSole now in group B")
-    try await stores.accountGroupStore.waitForNextEmission(
-      matching: { $0.by(id: groupA.id) == nil },
-      description: "group A auto-deleted")
+    await expectEventually("aSole now in group B; group A auto-deleted") {
+      stores.accountStore.accounts.by(id: aSole.id)?.groupId == groupB.id
+        && stores.accountGroupStore.by(id: groupA.id) == nil
+    }
   }
 }

--- a/MoolahTests/Navigation/SidebarDropDispatchReorderRootTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchReorderRootTests.swift
@@ -6,6 +6,20 @@ import Testing
 
 /// Tests for `SidebarDropDispatch.reorderRoot`. Shared fixtures live in
 /// `SidebarDropDispatchTestSupport.swift`.
+///
+/// Post-mutation state is asserted with `expectEventually` (polls the
+/// exact asserted expression) rather than `waitForNextEmission` (awaits
+/// one tick, then reads). A store's `observationTicks` is a
+/// single-consumer `AsyncStream`; when one test feeds two sequential
+/// waits to the same store, the second iterator can miss the tick that
+/// carries the awaited state and then block until the deadline even
+/// though the steady-state value is already correct. `reorderRoot`
+/// writes to both `accountStore` and `accountGroupStore`, so polling the
+/// cross-store invariant directly also avoids the ordering hazard that
+/// motivated #1000 (a single-store waiter reading the other store's
+/// not-yet-emitted state). The `didEmitWithin` absence check keeps
+/// `waitForNextEmission`'s stream — asserting an emission does not occur
+/// is its job.
 @Suite("SidebarDropDispatch — reorderRoot")
 @MainActor
 struct SidebarDropDispatchReorderRootTests {
@@ -48,12 +62,10 @@ struct SidebarDropDispatchReorderRootTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "members joined")
+    await expectEventually("members joined") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     // After the create the bucket entries (tie-break: account first on
     // equal position) are [standalone@0, group@0]. Drop the group at
@@ -67,23 +79,12 @@ struct SidebarDropDispatchReorderRootTests {
 
     // `reorderRoot` writes to BOTH stores: the group's new position on
     // `accountGroupStore`, and the shifted standalone's position on
-    // `accountStore`. The original waiter parked on `accountGroupStore`
-    // and read `accountStore` inside the predicate — if the watched
-    // store emitted first (still showing the pre-shift state on the
-    // other), the predicate was false, no further emission came on
-    // the watched store, and the waiter timed out (#1000). Wait on
-    // both stores' writes individually, then assert the cross-store
-    // invariant synchronously.
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: standalone.id)?.position == 1 },
-      description: "standalone shifted to position 1")
-    try await stores.accountGroupStore.waitForNextEmission(
-      matching: { $0.by(id: group.id)?.position == 0 },
-      description: "group landed at position 0")
-    await expectEventually("group ends up ahead of the standalone account") {
+    // `accountStore`. Poll the cross-store invariant directly so a
+    // not-yet-emitted write on either store can't strand the assertion.
+    await expectEventually("group ends up ahead of the shifted standalone account") {
       let groupPos = stores.accountGroupStore.by(id: group.id)?.position
       let standalonePos = stores.accountStore.accounts.by(id: standalone.id)?.position
-      return (groupPos ?? -1) < (standalonePos ?? -1)
+      return groupPos == 0 && standalonePos == 1
     }
   }
 
@@ -102,12 +103,10 @@ struct SidebarDropDispatchReorderRootTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        ($0.accounts.by(id: first.id)?.position ?? -1)
-          > ($0.accounts.by(id: second.id)?.position ?? -1)
-      },
-      description: "first clamped to after second")
+    await expectEventually("first clamped to after second") {
+      (stores.accountStore.accounts.by(id: first.id)?.position ?? -1)
+        > (stores.accountStore.accounts.by(id: second.id)?.position ?? -1)
+    }
   }
 
   @Test("reorderRoot preserves the standalone/group interleave (3-entry mixed)")
@@ -126,12 +125,10 @@ struct SidebarDropDispatchReorderRootTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "members joined")
+    await expectEventually("members joined") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     // Drag the group to the bottom of the bucket (insertionIndex 2 in
     // the 3-entry root: [standaloneA, group, standaloneB] → after the
@@ -191,12 +188,10 @@ struct SidebarDropDispatchReorderRootTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "members joined")
+    await expectEventually("members joined") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     // Drop memberA at root insertion index 0 (ahead of standalone + group).
     try await SidebarDropDispatch.reorderRoot(
@@ -225,9 +220,9 @@ struct SidebarDropDispatchReorderRootTests {
 
     let group = try await stores.accountGroupStore.createGroup(
       from: soleMember, name: "Lonely", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: soleMember.id)?.groupId == group.id },
-      description: "soleMember joined group")
+    await expectEventually("soleMember joined group") {
+      stores.accountStore.accounts.by(id: soleMember.id)?.groupId == group.id
+    }
 
     try await SidebarDropDispatch.reorderRoot(
       dragged: DraggableSidebarItem(kind: .account, id: soleMember.id),
@@ -236,11 +231,9 @@ struct SidebarDropDispatchReorderRootTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: soleMember.id)?.groupId == nil },
-      description: "soleMember back to root")
-    try await stores.accountGroupStore.waitForNextEmission(
-      matching: { $0.by(id: group.id) == nil },
-      description: "lonely group auto-deleted")
+    await expectEventually("soleMember back to root; lonely group auto-deleted") {
+      stores.accountStore.accounts.by(id: soleMember.id)?.groupId == nil
+        && stores.accountGroupStore.by(id: group.id) == nil
+    }
   }
 }

--- a/MoolahTests/Navigation/SidebarDropDispatchTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchTests.swift
@@ -12,6 +12,17 @@ import Testing
 /// the membership-change policy gate (same-bucket, no self-drop, no
 /// re-add). Shared fixtures live in
 /// `SidebarDropDispatchTestSupport.swift`.
+///
+/// Post-mutation state is asserted with `expectEventually` (polls the
+/// exact asserted expression) rather than `waitForNextEmission` (awaits
+/// one tick, then reads). A single store feeds two sequential
+/// observation waits in several of these tests, and a store's
+/// `observationTicks` is a single-consumer `AsyncStream`: a second
+/// iterator can miss the tick that carries the awaited state and then
+/// block until the deadline even though the steady-state value is
+/// already correct. Polling the value sidesteps the stream entirely.
+/// Absence-of-emission checks stay on `didEmitWithin` — polling cannot
+/// prove an event never occurs, so the stream is the right tool there.
 @Suite("SidebarDropDispatch — drop onto")
 @MainActor
 struct SidebarDropDispatchTests {
@@ -35,15 +46,13 @@ struct SidebarDropDispatchTests {
 
     let createdGroup = try #require(created)
     #expect(createdGroup.bucket == .current)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: target.id)?.groupId == createdGroup.id
-          && $0.accounts.by(id: source.id)?.groupId == createdGroup.id
-      },
-      description: "both accounts joined the new group")
-    try await stores.groupUIStateStore.waitForNextEmission(
-      matching: { $0.expandedGroupIds.contains(createdGroup.id) },
-      description: "new group auto-expanded")
+    await expectEventually("both accounts joined the new group") {
+      stores.accountStore.accounts.by(id: target.id)?.groupId == createdGroup.id
+        && stores.accountStore.accounts.by(id: source.id)?.groupId == createdGroup.id
+    }
+    await expectEventually("new group auto-expanded") {
+      stores.groupUIStateStore.expandedGroupIds.contains(createdGroup.id)
+    }
   }
 
   @Test("dropOntoAccount where target is already a member adds source to target's group")
@@ -58,9 +67,9 @@ struct SidebarDropDispatchTests {
     let preexisting = try await stores.accountGroupStore.createGroup(
       joining: seedMember, and: target, name: "Pre",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: target.id)?.groupId == preexisting.id },
-      description: "target observed as member")
+    await expectEventually("target observed as member") {
+      stores.accountStore.accounts.by(id: target.id)?.groupId == preexisting.id
+    }
 
     let result = try await SidebarDropDispatch.dropOntoAccount(
       sourceId: source.id,
@@ -70,9 +79,9 @@ struct SidebarDropDispatchTests {
       groupUIStateStore: stores.groupUIStateStore)
 
     #expect(result == nil, "no new group when joining target's existing group")
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: source.id)?.groupId == preexisting.id },
-      description: "source joined preexisting group")
+    await expectEventually("source joined preexisting group") {
+      stores.accountStore.accounts.by(id: source.id)?.groupId == preexisting.id
+    }
   }
 
   @Test("dropOntoAccount with cross-bucket source is a no-op")
@@ -146,9 +155,9 @@ struct SidebarDropDispatchTests {
 
     let group = try await stores.accountGroupStore.createGroup(
       from: seed, name: "G", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: seed.id)?.groupId == group.id },
-      description: "seed member observed")
+    await expectEventually("seed member observed") {
+      stores.accountStore.accounts.by(id: seed.id)?.groupId == group.id
+    }
 
     try await SidebarDropDispatch.dropOntoGroup(
       sourceId: source.id,
@@ -161,9 +170,9 @@ struct SidebarDropDispatchTests {
       let source = stores.accountStore.accounts.by(id: source.id)
       return source?.groupId == group.id && source?.position == 1
     }
-    try await stores.groupUIStateStore.waitForNextEmission(
-      matching: { $0.expandedGroupIds.contains(group.id) },
-      description: "target group auto-expanded after drop")
+    await expectEventually("target group auto-expanded after drop") {
+      stores.groupUIStateStore.expandedGroupIds.contains(group.id)
+    }
   }
 
   @Test("dropOntoGroup auto-expands the target group so the new member is visible")
@@ -176,14 +185,14 @@ struct SidebarDropDispatchTests {
 
     let group = try await stores.accountGroupStore.createGroup(
       from: seed, name: "G", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: seed.id)?.groupId == group.id },
-      description: "seed member observed")
+    await expectEventually("seed member observed") {
+      stores.accountStore.accounts.by(id: seed.id)?.groupId == group.id
+    }
     // Collapse the target group so the auto-expand effect is observable.
     await stores.groupUIStateStore.setExpanded(false, for: group.id)
-    try await stores.groupUIStateStore.waitForNextEmission(
-      matching: { !$0.expandedGroupIds.contains(group.id) },
-      description: "target group starts collapsed")
+    await expectEventually("target group starts collapsed") {
+      !stores.groupUIStateStore.expandedGroupIds.contains(group.id)
+    }
 
     try await SidebarDropDispatch.dropOntoGroup(
       sourceId: source.id,
@@ -208,12 +217,10 @@ struct SidebarDropDispatchTests {
     let group = try await stores.accountGroupStore.createGroup(
       joining: memberA, and: memberB, name: "G",
       accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: {
-        $0.accounts.by(id: memberA.id)?.groupId == group.id
-          && $0.accounts.by(id: memberB.id)?.groupId == group.id
-      },
-      description: "both members observed")
+    await expectEventually("both members observed") {
+      stores.accountStore.accounts.by(id: memberA.id)?.groupId == group.id
+        && stores.accountStore.accounts.by(id: memberB.id)?.groupId == group.id
+    }
 
     let originalA = try #require(stores.accountStore.accounts.by(id: memberA.id))
     await stores.accountStore.drainPendingEmissions()
@@ -242,9 +249,9 @@ struct SidebarDropDispatchTests {
 
     let group = try await stores.accountGroupStore.createGroup(
       from: seed, name: "Current Group", accountStore: stores.accountStore)
-    try await stores.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: seed.id)?.groupId == group.id },
-      description: "seed observed in group")
+    await expectEventually("seed observed in group") {
+      stores.accountStore.accounts.by(id: seed.id)?.groupId == group.id
+    }
 
     await stores.accountStore.drainPendingEmissions()
     try await SidebarDropDispatch.dropOntoGroup(


### PR DESCRIPTION
## Problem

The post-merge CI Test job on `main` (commit `96f16a46`) failed on a single test — `SidebarDropDispatchTests.dropOntoMemberJoinsGroup` — with a 10s timeout *"waiting for AccountStore emission matching source joined preexisting group"*. The merge-queue run for that same commit was green; only the push CI tripped. This is a flake, not a regression.

## Root cause

`waitForNextEmission(matching:)` blocks on `iterator.next()` and only re-evaluates the predicate when a tick arrives. Its polling fallback runs only if the stream *finishes* — which a long-lived store tick stream never does. A store's `observationTicks` is a **single-consumer `AsyncStream`**; when one test feeds two sequential waits to the same store (e.g. "target observed as member" then "source joined"), the second `makeAsyncIterator()` shares storage with the first and can miss the tick that carries the awaited state. The wait then strands until the 10s cap **even though `AccountStore.accounts` already holds the correct value** (mutations are pure pass-through — the `observeAll` emission *is* the state).

This is the same read-once race tracked in #1000 and started by commit `ead2da54`, which migrated these very files toward `expectEventually` but left the Navigation suite half-done.

## Fix

Migrate every post-mutation **state assertion** across all four Navigation test files to `expectEventually`, which polls the asserted expression directly and never touches the tick stream:

- `SidebarDropDispatchTests.swift`
- `SidebarDropDispatchCrossGroupTests.swift`
- `SidebarDropDispatchReorderRootTests.swift`
- `SidebarDropDispatchReorderMembersTests.swift`

For `reorderRoot` (which writes to **both** `accountStore` and `accountGroupStore`) the cross-store invariant is now polled directly, removing the per-store sequential waits that exposed the #1000 ordering hazard.

`didEmitWithin` absence checks are intentionally left on `waitForNextEmission`'s stream — polling cannot prove an event *never* occurs, so the stream is the right tool there.

Each converted closure reads exactly the same state expression the old predicate did; no assertion was weakened.

## Verification

- Failing class alone: **25× under load, 0 failures**.
- All four migrated classes together: **20× under load, 0 failures**.
- `just format-check` clean.

Reviewed with the `code-review` agent; the "fix all instances" finding (sibling files) is what expanded this from one file to four.