### PR TITLE
fix(crypto): fetch CoinGecko prices by date range, not days-from-now

### DIFF
--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -49,12 +49,8 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     guard let coinId = mapping.coingeckoId else {
       throw CryptoPriceError.noProviderMapping(tokenId: mapping.instrumentId, provider: "CoinGecko")
     }
-    let calendar = Calendar(identifier: .gregorian)
-    let days = max(
-      1,
-      calendar.dateComponents([.day], from: range.lowerBound, to: range.upperBound).day ?? 1
-    )
-    let url = Self.marketChartURL(coinId: coinId, days: days, apiKey: apiKey)
+    let url = Self.marketChartRangeURL(
+      coinId: coinId, from: range.lowerBound, to: range.upperBound, apiKey: apiKey)
     let (data, _) = try await http.data(for: URLRequest(url: url))
     return try Self.parseMarketChartResponse(data)
   }
@@ -84,15 +80,38 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
 
   // MARK: - URL builders (internal for testing)
 
-  static func marketChartURL(coinId: String, days: Int, apiKey: String) -> URL {
+  /// Builds the **date-anchored** `market_chart/range` URL for the
+  /// requested `[from, to]` window, using UNIX-second timestamps.
+  ///
+  /// The `market_chart?days=N` endpoint returns the last N days from
+  /// *now*, so it cannot fetch an arbitrary historical window;
+  /// `market_chart/range` fetches exactly the dates asked for, which is
+  /// what backfilling a gap in the price cache requires.
+  ///
+  /// `to` is extended by one day so the upper-bound day's prices are
+  /// included: the range endpoint is timestamp-inclusive, so a midnight
+  /// `to` returns no intraday points for that final day, and a single-day
+  /// `from == to` request would otherwise be an empty window.
+  ///
+  /// For windows of 90 days or less the endpoint returns hourly
+  /// granularity; `parseMarketChartResponse` keys by calendar day and
+  /// keeps the last point per day, so each day resolves to its latest
+  /// intraday price. Windows over 90 days return daily points directly.
+  ///
+  /// On the public/free tier CoinGecko serves only the last 365 days of
+  /// history and 401s for older `from` values; the price service then
+  /// falls through to the next provider in its chain.
+  static func marketChartRangeURL(coinId: String, from: Date, to: Date, apiKey: String) -> URL {
     let pathURL = baseURL(apiKey: apiKey).appendingPathComponent(
-      "coins/\(coinId)/market_chart")
+      "coins/\(coinId)/market_chart/range")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+    let fromTimestamp = Int(from.timeIntervalSince1970)
+    let toTimestamp = Int(to.timeIntervalSince1970) + 86_400
     var items: [URLQueryItem] = [
       URLQueryItem(name: "vs_currency", value: "usd"),
-      URLQueryItem(name: "days", value: String(days)),
-      URLQueryItem(name: "interval", value: "daily"),
+      URLQueryItem(name: "from", value: String(fromTimestamp)),
+      URLQueryItem(name: "to", value: String(toTimestamp)),
     ]
     if let auth = authQueryItem(apiKey: apiKey) { items.append(auth) }
     components.queryItems = items

--- a/MoolahTests/Backends/CoinGeckoClientTests.swift
+++ b/MoolahTests/Backends/CoinGeckoClientTests.swift
@@ -18,20 +18,40 @@ struct CoinGeckoClientTests {
   // MARK: - URL construction
 
   @Test
-  func marketChartURLIncludesCoinIdAndDays() throws {
-    let url = CoinGeckoClient.marketChartURL(
-      coinId: "ethereum", days: 10, apiKey: "test-key"
+  func marketChartRangeURLIncludesCoinIdAndDateRange() throws {
+    let from = try date("2024-01-10")
+    let to = try date("2024-01-20")
+    let url = CoinGeckoClient.marketChartRangeURL(
+      coinId: "ethereum", from: from, to: to, apiKey: "test-key"
     )
     let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
     #expect(components.host == "pro-api.coingecko.com")
-    #expect(components.path == "/api/v3/coins/ethereum/market_chart")
+    #expect(components.path == "/api/v3/coins/ethereum/market_chart/range")
     let items = try #require(components.queryItems)
     let queryItems = try Dictionary(
       uniqueKeysWithValues: items.map { try ($0.name, #require($0.value)) })
     #expect(queryItems["vs_currency"] == "usd")
-    #expect(queryItems["days"] == "10")
-    #expect(queryItems["interval"] == "daily")
+    #expect(queryItems["from"] == String(Int(from.timeIntervalSince1970)))
+    #expect(queryItems["to"] == String(Int(to.timeIntervalSince1970) + 86_400))
     #expect(queryItems["x_cg_pro_api_key"] == "test-key")
+  }
+
+  @Test
+  func marketChartRangeURLExtendsSingleDayRangeByOneDay() throws {
+    let day = try date("2024-03-15")
+    let url = CoinGeckoClient.marketChartRangeURL(
+      coinId: "bitcoin", from: day, to: day, apiKey: "k"
+    )
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = try #require(components.queryItems)
+    let queryItems = try Dictionary(
+      uniqueKeysWithValues: items.map { try ($0.name, #require($0.value)) })
+    let fromTimestamp = Int(day.timeIntervalSince1970)
+    // A single-day `from == to` window must not collapse to an empty
+    // range: `to` is pushed to the next-day boundary so the day's prices
+    // are returned.
+    #expect(queryItems["from"] == String(fromTimestamp))
+    #expect(queryItems["to"] == String(fromTimestamp + 86_400))
   }
 
   @Test
@@ -51,10 +71,14 @@ struct CoinGeckoClientTests {
   // MARK: - Public free-tier fallback (no API key)
 
   @Test
-  func marketChartURLUsesPublicHostWhenApiKeyIsEmpty() throws {
-    let url = CoinGeckoClient.marketChartURL(coinId: "ethereum", days: 1, apiKey: "")
+  func marketChartRangeURLUsesPublicHostWhenApiKeyIsEmpty() throws {
+    let from = try date("2024-01-10")
+    let to = try date("2024-01-11")
+    let url = CoinGeckoClient.marketChartRangeURL(
+      coinId: "ethereum", from: from, to: to, apiKey: "")
     let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
     #expect(components.host == "api.coingecko.com")
+    #expect(components.path == "/api/v3/coins/ethereum/market_chart/range")
     let names = Set((components.queryItems ?? []).map(\.name))
     #expect(!names.contains("x_cg_pro_api_key"))
   }


### PR DESCRIPTION
## Problem

In the production *Real Profile*, the net-worth graph showed **"No balance data available"** and Monthly Income & Expense was unavailable for certain months — symptoms of missing historical crypto prices for recently-imported tokens.

Root cause: **`CoinGeckoClient.dailyPrices(for:in:)` was now-anchored, not date-anchored.** It collapsed the requested `[from, to]` range to a day *count* and called `coins/{id}/market_chart?days=N`, which CoinGecko interprets as *"the last N days from today."* So when the price service tried to backfill a historical gap (e.g. USDC held since 2022, cached only from 2025), the fetch silently returned **recent** data instead of the requested window — the cache could never extend into the past, and the requested old date stayed missing.

Because the net-worth graph drops any day where a held *priced* token can't be valued, a single continuously-held token with an unfillable history blanked the whole recent chart; income/expense flagged each month whose transactions sat in such a token.

The lazy backfill trigger already existed (`CryptoPriceService.price()` calls `fetchAndExtendCache` for any out-of-range date, which the Analysis dashboard drives) — it just fetched the wrong dates. CryptoCompare (`histoday`) and Binance (`klines`) are already date-anchored, which is why tokens carrying those provider symbols backfilled correctly and only CoinGecko-only tokens were stuck.

## Fix

Switch to the date-anchored **`coins/{id}/market_chart/range?vs_currency=usd&from=<unix>&to=<unix>`** endpoint, passing the requested window directly. The upper bound is extended by one day so the (timestamp-inclusive) range endpoint returns the final day's prices and a single-day `from == to` request isn't an empty window. Response shape is identical, so `parseMarketChartResponse` is unchanged.

Throttling is untouched (`RateLimitGate` / `FailedRequestCache` still apply).

## Scope

This restores on-read backfill for any window the active CoinGecko tier serves — the free tier's **last 365 days**. All of the originally-reported symptoms fall within that window (HEX → Mar 2026; the USDC/PROVE swap → ~Aug 2025; the net-worth recent year), so this resolves them.

**Deliberately out of scope (follow-ups):**
- **Deep history (>365 days)** for CoinGecko-only tokens (USDC, DAI, SAITABIT, …) — they carry no `cryptocompare_symbol`/`binance_symbol`, so the 2021–2024 graph tail needs them re-resolved onto a full-history provider (CryptoCompare). Price-correctness-sensitive; deserves its own PR.
- **Explicit in-flight backfill coalescing** — current throttling is preserved; per-token request de-duplication is a separate enhancement.

## Granularity note

`market_chart/range` returns hourly granularity for windows ≤90 days (daily for longer). `parseMarketChartResponse` keys by calendar day and keeps the last point per day, so short-window days resolve to their latest intraday price rather than the 00:00 daily close. Acceptable for historical charting; documented in the builder's docstring.

## Tests

- Updated `CoinGeckoClientTests` to assert the date-anchored URL (path, `from`/`to` timestamps, the +1-day upper-bound extension, pro/public host).
- Added a single-day `from == to` edge-case test.
- 12/12 `CoinGeckoClient` tests pass; 61/61 across the price-service suites (`CryptoPriceService*`, `CryptoCompareClient`, `BinanceClient`) pass. `format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)