### PR TITLE
feat(crypto): price known tokens via CryptoCompare deep history

### DIFF
--- a/Backends/GRDB/Records/InstrumentRow+Mapping.swift
+++ b/Backends/GRDB/Records/InstrumentRow+Mapping.swift
@@ -93,8 +93,14 @@ extension InstrumentRow {
 
   /// `CryptoProviderMapping` reconstructed from the row's three provider
   /// columns. Returns `nil` when no mapping is recorded (matches the
-  /// `hasMapping` guard in `CloudKitInstrumentRegistryRepository`).
+  /// `hasMapping` guard in `GRDBInstrumentRegistryRepository.project(row:)`).
+  ///
+  /// A `.priced` token recognised in the bundled `CanonicalTokenRegistry`
+  /// whose `cryptocompare_symbol` column is nil is given its canonical
+  /// symbol so the otherwise CoinGecko-only token reaches CryptoCompare's
+  /// date-anchored deep-history endpoint — see `bundledPriceSymbol()`.
   func cryptoMapping() -> CryptoProviderMapping? {
+    let cryptocompareSymbol = self.cryptocompareSymbol ?? bundledPriceSymbol()
     let hasMapping =
       coingeckoId != nil
       || cryptocompareSymbol != nil
@@ -105,6 +111,20 @@ extension InstrumentRow {
       coingeckoId: coingeckoId,
       cryptocompareSymbol: cryptocompareSymbol,
       binanceSymbol: binanceSymbol)
+  }
+
+  /// The CryptoCompare `fsym` for a `.priced` token recognised in the
+  /// bundled `CanonicalTokenRegistry`, or `nil`. Lets a CoinGecko-only token
+  /// (e.g. USDC/DAI, which CryptoCompare omits from its contract-address
+  /// index) reach CryptoCompare's date-anchored deep-history endpoint. Gated
+  /// to `.priced` so `.unpriced` / `.spam` rows project unchanged, and keyed
+  /// on the canonical address so an impersonator at a different address
+  /// matches nothing.
+  private func bundledPriceSymbol() -> String? {
+    guard pricingStatus == TokenPricingStatus.priced.rawValue, let chainId else {
+      return nil
+    }
+    return CanonicalTokenRegistry.symbol(chainId: chainId, contractAddress: contractAddress)
   }
 
   /// All-nil `CryptoProviderMapping` for the row's id. Used by the

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
@@ -59,12 +59,11 @@ extension GRDBInstrumentRegistryRepository {
   static func project(row: InstrumentRow) throws -> CryptoRegistration? {
     let status =
       TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
-    let mapping = row.cryptoMapping() ?? row.emptyCryptoMapping()
-    let hasMapping = row.cryptoMapping() != nil
-    guard hasMapping || status != .priced else { return nil }
+    let mapping = row.cryptoMapping()
+    guard mapping != nil || status != .priced else { return nil }
     return CryptoRegistration(
       instrument: try row.toDomain(),
-      mapping: mapping,
+      mapping: mapping ?? row.emptyCryptoMapping(),
       pricingStatus: status)
   }
 }

--- a/MoolahTests/Backends/GRDB/InstrumentRowCryptoMappingTests.swift
+++ b/MoolahTests/Backends/GRDB/InstrumentRowCryptoMappingTests.swift
@@ -1,0 +1,134 @@
+import Testing
+
+@testable import Moolah
+
+/// `InstrumentRow.cryptoMapping()` fills in the CryptoCompare price symbol
+/// for recognised tokens whose resolution never recorded one — giving
+/// CoinGecko-only tokens (e.g. USDC, DAI) a date-anchored deep-history
+/// provider. The symbol comes from the bundled `CanonicalTokenRegistry`.
+@Suite("InstrumentRow.cryptoMapping")
+struct InstrumentRowCryptoMappingTests {
+  /// Builds a crypto `InstrumentRow` with the provider columns under test;
+  /// everything else is incidental.
+  private func row(
+    id: String,
+    chainId: Int?,
+    contractAddress: String?,
+    coingeckoId: String? = nil,
+    cryptocompareSymbol: String? = nil,
+    binanceSymbol: String? = nil,
+    ticker: String = "TKN",
+    pricingStatus: TokenPricingStatus = .priced
+  ) -> InstrumentRow {
+    InstrumentRow(
+      id: id,
+      recordName: id,
+      kind: "cryptoToken",
+      name: "Token",
+      decimals: 18,
+      ticker: ticker,
+      exchange: nil,
+      chainId: chainId,
+      contractAddress: contractAddress,
+      coingeckoId: coingeckoId,
+      cryptocompareSymbol: cryptocompareSymbol,
+      binanceSymbol: binanceSymbol,
+      encodedSystemFields: nil,
+      pricingStatus: pricingStatus.rawValue)
+  }
+
+  private static let usdcEthereum = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  @Test("A known token with no CryptoCompare symbol gets the bundled one")
+  func knownTokenGainsBundledSymbol() throws {
+    let mapping = try #require(
+      row(
+        id: "1:\(Self.usdcEthereum)",
+        chainId: 1,
+        contractAddress: Self.usdcEthereum,
+        coingeckoId: "usd-coin"
+      ).cryptoMapping())
+    #expect(mapping.coingeckoId == "usd-coin")
+    #expect(mapping.cryptocompareSymbol == "USDC")
+  }
+
+  @Test("An explicitly resolved CryptoCompare symbol is never overridden")
+  func resolvedSymbolWins() throws {
+    let mapping = try #require(
+      row(
+        id: "1:\(Self.usdcEthereum)",
+        chainId: 1,
+        contractAddress: Self.usdcEthereum,
+        coingeckoId: "usd-coin",
+        cryptocompareSymbol: "USDC-RESOLVED"
+      ).cryptoMapping())
+    #expect(mapping.cryptocompareSymbol == "USDC-RESOLVED")
+  }
+
+  @Test("An unrecognised token gains no CryptoCompare symbol")
+  func unknownTokenStaysNil() throws {
+    let mapping = try #require(
+      row(
+        id: "1:0x000000000000000000000000000000000000dead",
+        chainId: 1,
+        contractAddress: "0x000000000000000000000000000000000000dead",
+        coingeckoId: "obscure-token"
+      ).cryptoMapping())
+    #expect(mapping.cryptocompareSymbol == nil)
+  }
+
+  @Test("A known token with only the bundled symbol still yields a mapping")
+  func bundledSymbolAloneProducesMapping() throws {
+    // No coingecko / binance / stored cryptocompare symbol — the row would
+    // otherwise have no provider mapping, but its canonical address alone
+    // makes it priceable via CryptoCompare.
+    let mapping = try #require(
+      row(
+        id: "1:\(Self.usdcEthereum)",
+        chainId: 1,
+        contractAddress: Self.usdcEthereum
+      ).cryptoMapping())
+    #expect(mapping.cryptocompareSymbol == "USDC")
+  }
+
+  @Test("The bundled symbol is the canonical one, not the row's ticker")
+  func bundledSymbolIgnoresMisleadingTicker() throws {
+    let mapping = try #require(
+      row(
+        id: "1:\(Self.usdcEthereum)",
+        chainId: 1,
+        contractAddress: Self.usdcEthereum,
+        coingeckoId: "usd-coin",
+        ticker: "USDC-FAKE"
+      ).cryptoMapping())
+    #expect(mapping.cryptocompareSymbol == "USDC")
+  }
+
+  @Test("An unpriced known token gains no bundled symbol")
+  func unpricedTokenGainsNoBundledSymbol() throws {
+    // Coingecko mapping is still present, but the bundled fallback is gated
+    // to `.priced`, so `.unpriced` rows project exactly as before.
+    let mapping = try #require(
+      row(
+        id: "1:\(Self.usdcEthereum)",
+        chainId: 1,
+        contractAddress: Self.usdcEthereum,
+        coingeckoId: "usd-coin",
+        pricingStatus: .unpriced
+      ).cryptoMapping())
+    #expect(mapping.cryptocompareSymbol == nil)
+  }
+
+  @Test("A spam known token gains no bundled symbol")
+  func spamTokenGainsNoBundledSymbol() throws {
+    let mapping = try #require(
+      row(
+        id: "1:\(Self.usdcEthereum)",
+        chainId: 1,
+        contractAddress: Self.usdcEthereum,
+        coingeckoId: "usd-coin",
+        pricingStatus: .spam
+      ).cryptoMapping())
+    #expect(mapping.cryptocompareSymbol == nil)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CanonicalTokenRegistryTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CanonicalTokenRegistryTests.swift
@@ -96,6 +96,45 @@ struct CanonicalTokenRegistryTests {
         chainId: 10, contractAddress: nil, symbol: "OP"))
   }
 
+  // MARK: - Reverse lookup: (chain, address) → canonical symbol
+
+  @Test("Canonical USDC address on Ethereum resolves to the USDC symbol")
+  func symbolForCanonicalUsdc() {
+    #expect(
+      CanonicalTokenRegistry.symbol(chainId: 1, contractAddress: Self.usdcEthereum) == "USDC")
+  }
+
+  @Test("Canonical OP address on Optimism resolves to the OP symbol")
+  func symbolForCanonicalOp() {
+    #expect(
+      CanonicalTokenRegistry.symbol(chainId: 10, contractAddress: Self.opOptimism) == "OP")
+  }
+
+  @Test("A checksummed/uppercased address still resolves its symbol")
+  func symbolMatchesCaseInsensitively() {
+    #expect(
+      CanonicalTokenRegistry.symbol(
+        chainId: 1, contractAddress: Self.usdcEthereum.uppercased()) == "USDC")
+  }
+
+  @Test("An unknown address resolves to no symbol")
+  func symbolNilForUnknownAddress() {
+    #expect(
+      CanonicalTokenRegistry.symbol(
+        chainId: 1, contractAddress: "0x0000000000000000000000000000000000000bad") == nil)
+  }
+
+  @Test("A native (nil) address resolves to no symbol")
+  func symbolNilForNativeAddress() {
+    #expect(CanonicalTokenRegistry.symbol(chainId: 1, contractAddress: nil) == nil)
+  }
+
+  @Test("A canonical address looked up on the wrong chain resolves to no symbol")
+  func symbolNilForWrongChain() {
+    #expect(
+      CanonicalTokenRegistry.symbol(chainId: 137, contractAddress: Self.usdcEthereum) == nil)
+  }
+
   @Test("Bundled data covers all four supported chains with non-empty sets")
   func bundledDataIsWellFormed() {
     for chainId in [1, 10, 8453, 137] {

--- a/Shared/CryptoImport/CanonicalTokenRegistry.swift
+++ b/Shared/CryptoImport/CanonicalTokenRegistry.swift
@@ -31,4 +31,27 @@ enum CanonicalTokenRegistry {
     guard let canonical = bundled[chainId]?[key] else { return false }
     return !canonical.contains(contractAddress.lowercased())
   }
+
+  /// The canonical (uppercase) symbol for the token deployed at
+  /// `contractAddress` on `chainId`, or `nil` when the address is not a
+  /// known-legitimate deployment in the bundled registry. Native (`nil`)
+  /// addresses return `nil`.
+  ///
+  /// The bundled symbols are the standard tickers the major price providers
+  /// key on, so the result doubles as a CryptoCompare `fsym` for a
+  /// recognised token — used to give CoinGecko-only tokens (e.g. USDC, DAI,
+  /// which CryptoCompare omits from its contract-address index) a
+  /// date-anchored deep-history provider. This is the reverse of
+  /// `isImpersonation`: it returns a symbol only for an address the registry
+  /// recognises as legitimate, so a look-alike at a non-canonical address
+  /// yields `nil`.
+  static func symbol(chainId: Int, contractAddress: String?) -> String? {
+    guard let contractAddress else { return nil }
+    let needle = contractAddress.lowercased()
+    guard let symbolsForChain = bundled[chainId] else { return nil }
+    for (protectedSymbol, addresses) in symbolsForChain where addresses.contains(needle) {
+      return protectedSymbol
+    }
+    return nil
+  }
 }


### PR DESCRIPTION
## Problem

CoinGecko-only tokens — those with a `coingecko_id` but **no** `cryptocompare_symbol`/`binance_symbol` in the instrument registry (USDC, DAI, etc.) — could only be priced through CoinGecko. On the free/anonymous tier CoinGecko serves just the **last 365 days**, so these tokens' older history was permanently unfetchable. That blanked the net-worth graph's pre-365-day tail and flagged older income/expense months as unavailable.

Why these tokens lack a CryptoCompare symbol: CryptoCompare omits stablecoins from its contract-address index, and without a CoinGecko API key the resolver's by-symbol post-confirm step never runs — so resolution leaves `cryptocompare_symbol` nil. CryptoCompare *does* have these as price symbols (`fsym`); the mapping just never got one.

This is the deep-history follow-up to #1135 (which made CoinGecko's fetch date-anchored for the last 365 days).

## Fix

For a `.priced` token recognised in the bundled **`CanonicalTokenRegistry`** (the app's embedded known-token list, also used for impersonation detection), supply its canonical symbol as the CryptoCompare `fsym` when resolution recorded none. CryptoCompare's `histoday` is date-anchored and serves full history, so the token gains a deep-history provider.

- New **`CanonicalTokenRegistry.symbol(chainId:contractAddress:)`** — reverse lookup `(chain, address) → canonical symbol` (the inverse of `isImpersonation`).
- **`InstrumentRow.cryptoMapping()`** falls back to it via a `bundledPriceSymbol()` helper when `cryptocompareSymbol` is nil.

Safety properties (all tested):
- **Stored symbol always wins** — a resolved `cryptocompareSymbol` is never overridden.
- **Gated to `.priced`** — `.unpriced`/`.spam` rows project byte-identically to before; spam tokens are never queried via CryptoCompare.
- **Keyed on the canonical address** — an impersonator at a non-canonical address matches nothing in the registry, so it gains no symbol.
- **Read-time enrichment** — fixes already-registered tokens with **no migration**, and new tokens on read.

Composes with #1135: CoinGecko covers the recent 365 days, CryptoCompare the rest.

**WETH and other wrapped-natives need no symbol** — they're priced via the chain-native asset through `WrappedNativeContracts` (their own mapping is never used). Out of scope here.

**Scope note:** only tokens in the curated bundle (stablecoins / wrapped / blue-chips — USDC, DAI, USDT, LDO, ENS, UNI, …) gain the fallback, exactly matching "known tokens embedded in the app." Obscure/illiquid tokens (e.g. SAITABIT) stay CoinGecko-only.

## Tests

- `CanonicalTokenRegistryTests`: reverse-lookup resolves canonical USDC/OP, is case-insensitive, and returns nil for unknown address / native / wrong chain.
- `InstrumentRowCryptoMappingTests` (new): known token gains the bundled symbol; a stored symbol wins; an unknown token stays nil; bundled symbol alone still yields a mapping; the canonical symbol (not a misleading `ticker`) is used; `.unpriced`/`.spam` rows gain nothing.
- 64 tests across 10 suites pass (registry, projection, discovery, conversion, fallback). `format-check` clean. Code-reviewed; all findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)