### PR TITLE
perf(crypto): coalesce concurrent price-cache backfills per token

### DIFF
--- a/MoolahTests/Shared/CryptoPriceServiceCoalescingTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceCoalescingTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the in-flight coalescing of `CryptoPriceService.price(...)`:
+/// concurrent requests for the same token that all miss the cache share a
+/// single provider fetch instead of each hitting the network.
+@Suite("CryptoPriceService coalescing")
+struct CryptoPriceServiceCoalescingTests {
+  private let ethInstrument = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let ethMapping = CryptoProviderMapping(
+    instrumentId: "1:native", coingeckoId: "ethereum",
+    cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+  )
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test("Concurrent same-token requests share one fetch")
+  func concurrentRequestsCoalesceIntoOneFetch() async throws {
+    let frozen = try date("2024-02-01")
+    let utc = try #require(TimeZone(identifier: "UTC"))
+    let client = GatedCryptoPriceClient(prices: ["1:native": ["2024-01-20": dec("12")]])
+    let database = try ProfileIndexDatabase.openInMemory()
+    let service = CryptoPriceService(
+      clients: [client], database: database, resolutionClient: nil,
+      now: { frozen }, timeZone: utc)
+
+    // First request enters the provider and parks on the gate.
+    let first = Task {
+      try await service.price(
+        for: ethInstrument, mapping: ethMapping, on: try date("2024-01-20"))
+    }
+    await client.awaitFirstFetch()
+
+    // Second request for the same token+date arrives while the first fetch is
+    // still in flight; it should await the shared task, not start its own.
+    let second = Task {
+      try await service.price(
+        for: ethInstrument, mapping: ethMapping, on: try date("2024-01-20"))
+    }
+    // `second` coalesces as long as it runs before `openGate()`: the owner's
+    // in-flight entry persists for as long as its (gated) fetch is in flight,
+    // so `second` deterministically observes it on its `extensionTasks` check.
+    // The only requirement is that `second` is scheduled at all — these yields
+    // are a large margin over the handful of actor hops it needs to get there.
+    for _ in 0..<200 { await Task.yield() }
+
+    await client.openGate()
+    let firstPrice = try await first.value
+    let secondPrice = try await second.value
+
+    #expect(firstPrice == dec("12"))
+    #expect(secondPrice == dec("12"))
+    #expect(await client.fetchCount == 1)
+  }
+
+  @Test("Sequential requests after a fill do not refetch")
+  func sequentialRequestAfterFillUsesCache() async throws {
+    let frozen = try date("2024-02-01")
+    let utc = try #require(TimeZone(identifier: "UTC"))
+    let client = GatedCryptoPriceClient(prices: ["1:native": ["2024-01-20": dec("12")]])
+    await client.openGate()  // no gating for this case
+    let database = try ProfileIndexDatabase.openInMemory()
+    let service = CryptoPriceService(
+      clients: [client], database: database, resolutionClient: nil,
+      now: { frozen }, timeZone: utc)
+
+    let firstPrice = try await service.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-20"))
+    let secondPrice = try await service.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-20"))
+
+    #expect(firstPrice == dec("12"))
+    #expect(secondPrice == dec("12"))
+    #expect(await client.fetchCount == 1)
+  }
+}

--- a/MoolahTests/Support/GatedCryptoPriceClient.swift
+++ b/MoolahTests/Support/GatedCryptoPriceClient.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+@testable import Moolah
+
+/// Test double that lets a test hold the first `dailyPrices` fetch open while
+/// a second concurrent request arrives, so coalescing behaviour can be
+/// asserted deterministically. Counts every fetch; parks fetches on a gate
+/// until `openGate()` is called. Range-filters its stored prices the same way
+/// the live providers do.
+actor GatedCryptoPriceClient: CryptoPriceClient {
+  nonisolated let syncProvider: SyncProvider
+
+  private let prices: [String: [String: Decimal]]
+  private(set) var fetchCount = 0
+  private var open = false
+  private var gateWaiters: [CheckedContinuation<Void, Never>] = []
+  private var firstFetchObserved = false
+  private var firstFetchWaiter: CheckedContinuation<Void, Never>?
+
+  init(prices: [String: [String: Decimal]], syncProvider: SyncProvider = .coinGecko) {
+    self.prices = prices
+    self.syncProvider = syncProvider
+  }
+
+  /// Suspends until the first `dailyPrices` fetch has begun (and parked).
+  /// Single-waiter: calling twice before the first fetch is a test bug.
+  func awaitFirstFetch() async {
+    if firstFetchObserved { return }
+    await withCheckedContinuation { continuation in
+      precondition(firstFetchWaiter == nil, "awaitFirstFetch() already pending")
+      firstFetchWaiter = continuation
+    }
+  }
+
+  /// Releases every parked fetch and lets all later fetches pass straight
+  /// through.
+  func openGate() {
+    open = true
+    let waiters = gateWaiters
+    gateWaiters = []
+    for waiter in waiters { waiter.resume() }
+  }
+
+  func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
+    let dateString = dateFormatter.string(from: date)
+    let prices = try await dailyPrices(for: mapping, in: date...date)
+    guard let price = prices[dateString] else {
+      throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: dateString)
+    }
+    return price
+  }
+
+  func dailyPrices(
+    for mapping: CryptoProviderMapping, in range: ClosedRange<Date>
+  ) async throws -> [String: Decimal] {
+    fetchCount += 1
+    if !firstFetchObserved {
+      firstFetchObserved = true
+      firstFetchWaiter?.resume()
+      firstFetchWaiter = nil
+    }
+    if !open {
+      await withCheckedContinuation { gateWaiters.append($0) }
+    }
+    guard let tokenPrices = prices[mapping.instrumentId] else { return [:] }
+    let calendar = Calendar(identifier: .gregorian)
+    var filtered: [String: Decimal] = [:]
+    var current = range.lowerBound
+    while current <= range.upperBound {
+      let key = dateFormatter.string(from: current)
+      if let price = tokenPrices[key] { filtered[key] = price }
+      guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+      current = next
+    }
+    return filtered
+  }
+
+  func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
+    [:]
+  }
+
+  private let dateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return formatter
+  }()
+}

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -36,6 +36,11 @@ extension CryptoPriceService {
             return price
           }
         }
+      } catch is CancellationError {
+        // Cooperative cancellation must surface as `CancellationError`, not
+        // be wrapped into a provider outage — the coalescing owner cancels
+        // this shared task and aggregation callers special-case cancellation.
+        throw CancellationError()
       } catch CryptoPriceError.noProviderMapping {
         // Routing decision — this client has no symbol for the token
         // (e.g. USDT on Binance). Skip silently rather than attributing
@@ -84,6 +89,10 @@ extension CryptoPriceService {
           }
           return
         }
+      } catch is CancellationError {
+        // Surface cooperative cancellation unchanged rather than wrapping it
+        // into a provider outage. Mirrors `fetchAndExtendCache`.
+        throw CancellationError()
       } catch CryptoPriceError.noProviderMapping {
         // Routing decision — this client has no symbol for the token
         // (e.g. USDT on Binance). Skip silently rather than attributing

--- a/Shared/CryptoPriceService+Live.swift
+++ b/Shared/CryptoPriceService+Live.swift
@@ -34,4 +34,44 @@ extension CryptoPriceService {
     }
     return result
   }
+
+  // MARK: - Prefetch
+
+  func prefetchLatest(for registrations: [CryptoRegistration]) async {
+    let mappings = registrations.map(\.mapping)
+    let prices: [String: Decimal]
+    do {
+      prices = try await currentPrices(for: mappings)
+    } catch {
+      logger.warning(
+        "Prefetch failed (best-effort): \(error.localizedDescription, privacy: .public)"
+      )
+      return
+    }
+    // Tag the live tick as the local-yesterday calendar day; see
+    // `Shared/PriceCacheCap.swift`. The next forward `dailyPrices`
+    // extension overwrites this best-effort value with the finalised
+    // close.
+    let dateString = dateFormatter.string(
+      from: cappedToYesterday(now(), now: now, timeZone: timeZone))
+    for (tokenId, price) in prices {
+      let registration = registrations.first { $0.id == tokenId }
+      let symbol = registration?.instrument.ticker ?? registration?.instrument.name ?? ""
+      let delta = mergeReturningDelta(
+        tokenId: tokenId, symbol: symbol, newPrices: [dateString: price])
+      // Skip the disk write when the latest price is identical to the
+      // already-cached value — periodic "no change" polling would
+      // otherwise rewrite the partition on every tick.
+      guard !delta.isEmpty else { continue }
+      do {
+        try await persistDelta(tokenId: tokenId, deltaRecords: delta)
+      } catch {
+        logger.warning(
+          // Best-effort: continue the loop so a single bad token doesn't
+          // poison the rest of the prefetch.
+          "prefetchLatest: persistDelta failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+  }
 }

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -24,6 +24,12 @@ actor CryptoPriceService {
   /// Loaded token ids — set on first hydration so we don't re-read SQL when
   /// the cache is genuinely empty.
   var hydratedTokenIds: Set<String> = []
+  /// In-flight cache-extension fetches, keyed by token id, so concurrent
+  /// `price(...)` requests for the same token share one provider round-trip
+  /// instead of each issuing its own. The `id` tags the owning request so a
+  /// completing fetch only clears its own entry, never a successor's. See
+  /// `price(for:mapping:on:)`.
+  private var extensionTasks: [String: (id: UUID, task: Task<Decimal, Error>)] = [:]
   let database: any DatabaseWriter
   let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoPriceService")
@@ -151,13 +157,46 @@ actor CryptoPriceService {
     // each provider in order. Continues past providers that return
     // empty so a fallback chain (CoinGecko → CryptoCompare → Binance)
     // can collectively fill in the dates one of them has.
+    //
+    // Coalesce concurrent extensions for the same token: if a fetch is
+    // already in flight, await it and re-resolve from the freshly-extended
+    // cache rather than issuing a duplicate provider round-trip. Only fall
+    // through to our own fetch when the shared one didn't reach our date (a
+    // wider / older range), preserving each request's eventual coverage.
+    if let inFlight = extensionTasks[tokenId] {
+      _ = try? await inFlight.task.value
+      if let cached = lookupPrice(tokenId: tokenId, dateString: dateString) {
+        return cached
+      }
+      if let inRange = try inRangeFallback(tokenId: tokenId, dateString: dateString) {
+        return inRange
+      }
+    }
     let fetchInterval = extensionWindow(
       for: tokenId, requestedDate: date, dateString: dateString)
-    return try await fetchAndExtendCache(
-      instrument: instrument,
-      mapping: mapping,
-      fetchInterval: fetchInterval,
-      dateString: dateString)
+    let requestId = UUID()
+    let task = Task<Decimal, Error> { [self] in
+      try await self.fetchAndExtendCache(
+        instrument: instrument,
+        mapping: mapping,
+        fetchInterval: fetchInterval,
+        dateString: dateString)
+    }
+    extensionTasks[tokenId] = (requestId, task)
+    defer {
+      if extensionTasks[tokenId]?.id == requestId {
+        extensionTasks.removeValue(forKey: tokenId)
+      }
+    }
+    // Propagate the owner's cancellation into the shared fetch so a cancelled
+    // request doesn't block on a network round-trip it no longer needs. Any
+    // request still coalescing on this task observes the cancellation and
+    // re-fetches its own range above.
+    return try await withTaskCancellationHandler {
+      try await task.value
+    } onCancel: {
+      task.cancel()
+    }
   }
 
   /// Resolves the request from the in-memory cache when the requested
@@ -299,48 +338,9 @@ actor CryptoPriceService {
     return results
   }
 
-  // `currentPrices(for:)` (the live / spot endpoint) lives in
+  // `currentPrices(for:)` (the live / spot endpoint) and
+  // `prefetchLatest(for:)` (the live-tick writer) live in
   // `CryptoPriceService+Live.swift`.
-
-  // MARK: - Prefetch
-
-  func prefetchLatest(for registrations: [CryptoRegistration]) async {
-    let mappings = registrations.map(\.mapping)
-    let prices: [String: Decimal]
-    do {
-      prices = try await currentPrices(for: mappings)
-    } catch {
-      logger.warning(
-        "Prefetch failed (best-effort): \(error.localizedDescription, privacy: .public)"
-      )
-      return
-    }
-    // Tag the live tick as the local-yesterday calendar day; see
-    // `Shared/PriceCacheCap.swift`. The next forward `dailyPrices`
-    // extension overwrites this best-effort value with the finalised
-    // close.
-    let dateString = dateFormatter.string(
-      from: cappedToYesterday(now(), now: now, timeZone: timeZone))
-    for (tokenId, price) in prices {
-      let registration = registrations.first { $0.id == tokenId }
-      let symbol = registration?.instrument.ticker ?? registration?.instrument.name ?? ""
-      let delta = mergeReturningDelta(
-        tokenId: tokenId, symbol: symbol, newPrices: [dateString: price])
-      // Skip the disk write when the latest price is identical to the
-      // already-cached value — periodic "no change" polling would
-      // otherwise rewrite the partition on every tick.
-      guard !delta.isEmpty else { continue }
-      do {
-        try await persistDelta(tokenId: tokenId, deltaRecords: delta)
-      } catch {
-        logger.warning(
-          // Best-effort: continue the loop so a single bad token doesn't
-          // poison the rest of the prefetch.
-          "prefetchLatest: persistDelta failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
-        )
-      }
-    }
-  }
 }
 
 // MARK: - Cache lookup & merge


### PR DESCRIPTION
## Problem

When several views convert the same crypto position at once (the Analysis dashboard, the positions list, and the investment chart can all load together), each out-of-cache `CryptoPriceService.price(...)` request issued its **own** provider round-trip to backfill the same token's history. The per-host `RateLimitGate` serialised them, so the duplicates were redundant network work rather than a thundering herd — but redundant nonetheless. This is the in-flight de-duplication follow-up to #1135 / #1136.

## Fix

`CryptoPriceService` now tracks an **in-flight cache-extension task per token id** (`extensionTasks`). When a request misses the cache and needs to extend it:
- if a fetch for that token is already in flight, it **awaits the shared task** and re-resolves from the freshly-extended cache, only starting its own fetch if the shared one didn't reach its date (a wider/older range);
- otherwise it creates the task, tags it with a UUID, and stores it.

Correctness properties (concurrency-reviewed):
- **No double-initiation** — the `extensionTasks` nil-check and store have no `await` between them, so the actor can't let two requests both become the owner for a token.
- **UUID-guarded cleanup** — the `defer` clears the entry only when its UUID still matches, so a successor that overwrote the slot is never evicted.
- **Cancellation** — the owner propagates its cancellation into the shared fetch via `withTaskCancellationHandler`; awaiters fall through to their own fetch.

## Cancellation correctness (knock-on fix)

`fetchAndExtendCache` and `fetchRange` previously folded **`CancellationError`** into a `WalletSyncError` provider-outage via their broad `catch`. Now they rethrow `CancellationError` unchanged, so a cancelled request (or a cancelled coalescing owner) aborts promptly instead of trying every remaining provider, and the daily-balance/income-expense aggregations that special-case cancellation see it correctly.

## Refactor

`prefetchLatest` moves to `CryptoPriceService+Live.swift` (next to the live `currentPrices` endpoint it builds on) to keep the primary file under the 400-line limit. Verbatim move, same actor isolation.

## Tests

- New `CryptoPriceServiceCoalescingTests`: a `GatedCryptoPriceClient` holds the first fetch open while a second concurrent request for the same token arrives — asserts both resolve and **only one** provider fetch occurs; plus a sequential-after-fill case.
- 44 tests across 10 price-service suites pass (coalescing, attribution, fallback, warm-range, cap, persistence, boundary, price-lookup). `build-mac` succeeds, `format-check` clean. Concurrency-reviewed; all findings applied (cancellation propagation, test-double continuation guard, handshake documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)