### PR TITLE
Stablecoin $1 fallback + CryptoCompare API key + per-request CoinGecko key

### DIFF
--- a/App/ProfileSession+CatalogFactory.swift
+++ b/App/ProfileSession+CatalogFactory.swift
@@ -13,16 +13,16 @@ extension ProfileSession {
   /// `ProfileSession` so it can be cancelled on teardown.
   @MainActor
   static func makeCoinGeckoCatalog(
-    apiKey: String?,
+    coinGeckoApiKeyProvider: @Sendable @escaping () -> String?,
     networking: NetworkingServices
   ) -> (catalog: (any CoinGeckoCatalog)?, refreshTask: Task<Void, Never>?) {
     let directory = URL.moolahScopedApplicationSupport
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
-      let host = (apiKey ?? "").isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
       let catalog = try SQLiteCoinGeckoCatalog.make(
         directory: directory,
-        http: networking.client(forHost: host))
+        apiKeyProvider: coinGeckoApiKeyProvider,
+        networking: networking)
       // `SQLiteCoinGeckoCatalog` is an actor, so `await catalog.refreshIfStale()`
       // hops to the catalog's executor regardless of the enclosing Task's
       // isolation — no `Task.detached` needed (CONCURRENCY_GUIDE §8).
@@ -50,17 +50,17 @@ extension ProfileSession {
   /// `bootstrapSyncCoordinator` path, and `currentUITestSeed()` reads only
   /// `CommandLine` / `ProcessInfo`.
   static func makeLookupCatalog(
-    apiKey: String?,
+    coinGeckoApiKeyProvider: @Sendable @escaping () -> String?,
     networking: NetworkingServices
   ) -> (any LocalContractResolver)? {
     guard currentUITestSeed() == nil else { return nil }
     let directory = URL.moolahScopedApplicationSupport
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
-      let host = (apiKey ?? "").isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
       return try SQLiteCoinGeckoCatalog.make(
         directory: directory,
-        http: networking.client(forHost: host))
+        apiKeyProvider: coinGeckoApiKeyProvider,
+        networking: networking)
     } catch {
       Logger(subsystem: "com.moolah.app", category: "ProfileSession")
         .error(

--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -20,6 +20,18 @@ extension ProfileSession {
     return try? store.restoreString()
   }
 
+  /// Returns the live CryptoCompare API key from the keychain, or `nil` when
+  /// no key is configured. `nonisolated` so the `@Sendable` key-provider
+  /// closure passed to `CryptoCompareClient` can resolve it per request — a
+  /// key entered in Settings then takes effect on the next price fetch
+  /// without rebuilding the client. CryptoCompare's `min-api` host now 401s
+  /// keyless requests, so this key is what restores deep-history backfill.
+  nonisolated static func resolveCryptoCompareApiKey() -> String? {
+    let store = KeychainStore(
+      service: KeychainServices.apiKeys, account: "cryptocompare", synchronizable: true)
+    return try? store.restoreString()
+  }
+
   /// Output of `makeCryptoSyncWiring`. The discovery actor is plumbed
   /// out alongside the store so the Discovered Tokens inbox can drive
   /// `reResolve(_:chain:)` on the same actor instance the sync engine

--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -17,7 +17,13 @@ extension ProfileSession {
   nonisolated static func resolveAlchemyApiKey() -> String? {
     let store = KeychainStore(
       service: KeychainServices.apiKeys, account: "alchemy", synchronizable: true)
-    return try? store.restoreString()
+    do {
+      return try store.restoreString()
+    } catch {
+      logger.error(
+        "Alchemy keychain read failed: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
   }
 
   /// Returns the live CryptoCompare API key from the keychain, or `nil` when
@@ -29,7 +35,13 @@ extension ProfileSession {
   nonisolated static func resolveCryptoCompareApiKey() -> String? {
     let store = KeychainStore(
       service: KeychainServices.apiKeys, account: "cryptocompare", synchronizable: true)
-    return try? store.restoreString()
+    do {
+      return try store.restoreString()
+    } catch {
+      logger.error(
+        "CryptoCompare keychain read failed: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
   }
 
   /// Returns the live CoinGecko API key from the keychain, or `nil` when no
@@ -41,7 +53,13 @@ extension ProfileSession {
   nonisolated static func resolveCoinGeckoApiKey() -> String? {
     let store = KeychainStore(
       service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true)
-    return try? store.restoreString()
+    do {
+      return try store.restoreString()
+    } catch {
+      logger.error(
+        "CoinGecko keychain read failed: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
   }
 
   /// Output of `makeCryptoSyncWiring`. The discovery actor is plumbed

--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -32,6 +32,18 @@ extension ProfileSession {
     return try? store.restoreString()
   }
 
+  /// Returns the live CoinGecko API key from the keychain, or `nil` when no
+  /// key is configured. `nonisolated` so the `@Sendable` key-provider closure
+  /// threaded into the CoinGecko price client, token resolver, and discovery
+  /// catalog can resolve it per request — a Pro key entered in Settings then
+  /// flips every consumer from the free public host to the authenticated Pro
+  /// host on the next fetch without rebuilding the session.
+  nonisolated static func resolveCoinGeckoApiKey() -> String? {
+    let store = KeychainStore(
+      service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true)
+    return try? store.restoreString()
+  }
+
   /// Output of `makeCryptoSyncWiring`. The discovery actor is plumbed
   /// out alongside the store so the Discovered Tokens inbox can drive
   /// `reResolve(_:chain:)` on the same actor instance the sync engine

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -19,7 +19,7 @@ extension ProfileSession {
     let stockPrice: StockPriceService
     let cryptoPrice: CryptoPriceService
     let yahooPriceFetcher: any YahooFinancePriceFetcher
-    let coinGeckoApiKey: String?
+    let coinGeckoApiKeyProvider: @Sendable () -> String?
   }
 
   /// Builds the fiat/stock/crypto market-data services used throughout the
@@ -32,14 +32,15 @@ extension ProfileSession {
   ) -> MarketDataServices {
     let yahooClient = YahooFinanceClient(
       http: networking.client(forHost: "query2.finance.yahoo.com"))
-    let apiKeyStore = KeychainStore(
-      service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true
-    )
-    let coinGeckoApiKey = try? apiKeyStore.restoreString()
+    // Closure (not a resolved value): a CoinGecko Pro key entered in Settings
+    // after this wiring is built takes effect on the next price fetch / token
+    // resolution / catalog refresh without rebuilding the session — every
+    // consumer reads the key per request through this provider.
+    let cgKeyProvider: @Sendable () -> String? = { ProfileSession.resolveCoinGeckoApiKey() }
     // Read-only handle to the shared CoinGecko catalog so the discovery token
     // resolver can price a known token offline (see `makeLookupCatalog`).
     let lookupCatalog = Self.makeLookupCatalog(
-      apiKey: coinGeckoApiKey, networking: networking)
+      coinGeckoApiKeyProvider: cgKeyProvider, networking: networking)
     return MarketDataServices(
       exchangeRate: ExchangeRateService(
         client: FrankfurterClient(
@@ -47,10 +48,10 @@ extension ProfileSession {
         database: database),
       stockPrice: StockPriceService(client: yahooClient, database: database),
       cryptoPrice: Self.makeCryptoPriceService(
-        coinGeckoApiKey: coinGeckoApiKey, database: database, networking: networking,
+        coinGeckoApiKeyProvider: cgKeyProvider, database: database, networking: networking,
         localResolver: lookupCatalog),
       yahooPriceFetcher: yahooClient,
-      coinGeckoApiKey: coinGeckoApiKey
+      coinGeckoApiKeyProvider: cgKeyProvider
     )
   }
 
@@ -61,17 +62,16 @@ extension ProfileSession {
   /// client on any error, so an anonymous CoinGecko 429 still resolves
   /// via CryptoCompare/Binance.
   static func makeCryptoPriceService(
-    coinGeckoApiKey: String?,
+    coinGeckoApiKeyProvider: @Sendable @escaping () -> String?,
     database: any DatabaseWriter,
     networking: NetworkingServices,
     localResolver: (any LocalContractResolver)? = nil
   ) -> CryptoPriceService {
-    // Empty key → CoinGeckoClient targets the free public host;
-    // non-empty key → Pro host with `x_cg_pro_api_key`. Always included
-    // so users without a Pro key still get coverage for tokens like
-    // USDC that CryptoCompare omits from its contract index.
-    let resolverApiKey = coinGeckoApiKey ?? ""
-    let cgHost = resolverApiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
+    // `CoinGeckoClient` resolves the key per request: an empty key targets
+    // the free public host; a configured key targets the Pro host with
+    // `x_cg_pro_api_key`. Always included so users without a Pro key still
+    // get coverage for tokens like USDC that CryptoCompare omits from its
+    // contract index.
     let cryptoCompareClient = CryptoCompareClient(
       http: networking.client(forHost: "min-api.cryptocompare.com"),
       apiKeyProvider: { ProfileSession.resolveCryptoCompareApiKey() })
@@ -90,8 +90,8 @@ extension ProfileSession {
       })
     let priceClients: [CryptoPriceClient] = [
       CoinGeckoClient(
-        apiKey: resolverApiKey,
-        http: networking.client(forHost: cgHost)),
+        apiKeyProvider: coinGeckoApiKeyProvider,
+        networking: networking),
       cryptoCompareClient,
       binanceClient,
       // Last-resort $1 fallback for canonical USDC/USDT only (peg).
@@ -102,7 +102,10 @@ extension ProfileSession {
       clients: priceClients,
       database: database,
       resolutionClient: CompositeTokenResolutionClient(
-        networking: networking, coinGeckoApiKey: resolverApiKey,
+        networking: networking,
+        // Coalesce a missing keychain entry to `""` so the resolver always
+        // runs the free-tier CoinGecko path (it treats `nil` as opt-out).
+        coinGeckoApiKeyProvider: { coinGeckoApiKeyProvider() ?? "" },
         localResolver: localResolver)
     )
   }
@@ -166,7 +169,7 @@ extension ProfileSession {
     backend: BackendProvider,
     cryptoPriceService: CryptoPriceService,
     yahooPriceFetcher: any YahooFinancePriceFetcher,
-    coinGeckoApiKey: String?,
+    coinGeckoApiKeyProvider: @Sendable @escaping () -> String?,
     networking: NetworkingServices,
     sharedRegistryStore: SharedRegistryStore? = nil
   ) -> RegistryWiring {
@@ -182,13 +185,17 @@ extension ProfileSession {
       refreshTask = nil
       resolutionClient = overrides.resolutionClient
     } else {
-      let made = makeCoinGeckoCatalog(apiKey: coinGeckoApiKey, networking: networking)
+      let made = makeCoinGeckoCatalog(
+        coinGeckoApiKeyProvider: coinGeckoApiKeyProvider, networking: networking)
       catalog = made.catalog
       refreshTask = made.refreshTask
-      // Empty string when no key is configured so the resolver targets
-      // the free public CoinGecko endpoint. See `makeCryptoPriceService`.
+      // Resolves the key per request: an empty key targets the free public
+      // CoinGecko endpoint, a configured key the Pro host. Coalesce a missing
+      // keychain entry to `""` so the resolver always runs the free-tier path
+      // (it treats `nil` as opt-out). See `makeCryptoPriceService`.
       resolutionClient = CompositeTokenResolutionClient(
-        networking: networking, coinGeckoApiKey: coinGeckoApiKey ?? "")
+        networking: networking,
+        coinGeckoApiKeyProvider: { coinGeckoApiKeyProvider() ?? "" })
     }
     // Pass the shared registry store from the coordinator when
     // wired so cross-session mutations are observed transparently

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -7,6 +7,13 @@ import Foundation
 import GRDB
 import OSLog
 
+/// File-scoped logger for the market-data factory wiring. A top-level
+/// `let` (not a `static` on the extension) so the `@Sendable`
+/// `usdtRateLookup` closure can capture it without crossing `ProfileSession`
+/// isolation. `Logger` is `Sendable`.
+private let factoriesLogger = Logger(
+  subsystem: "com.moolah.app", category: "ProfileSessionFactories")
+
 extension ProfileSession {
   // MARK: - Market Data Services
 
@@ -14,7 +21,7 @@ extension ProfileSession {
   /// on: fiat exchange rates, stock prices, and crypto prices. Returned
   /// from `makeMarketDataServices` so `init` can assign each field in one
   /// step.
-  struct MarketDataServices {
+  struct MarketDataServices: Sendable {
     let exchangeRate: ExchangeRateService
     let stockPrice: StockPriceService
     let cryptoPrice: CryptoPriceService
@@ -85,6 +92,9 @@ extension ProfileSession {
         do {
           return try await cryptoCompareClient.dailyPrice(for: usdtMapping, on: date)
         } catch {
+          factoriesLogger.warning(
+            "CryptoCompare USDT rate lookup failed; falling back to USDT=1: \(error.localizedDescription, privacy: .public)"
+          )
           return Decimal(1)
         }
       })

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -73,7 +73,8 @@ extension ProfileSession {
     let resolverApiKey = coinGeckoApiKey ?? ""
     let cgHost = resolverApiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
     let cryptoCompareClient = CryptoCompareClient(
-      http: networking.client(forHost: "min-api.cryptocompare.com"))
+      http: networking.client(forHost: "min-api.cryptocompare.com"),
+      apiKeyProvider: { ProfileSession.resolveCryptoCompareApiKey() })
     let binanceClient = BinanceClient(
       http: networking.client(forHost: "api.binance.com"),
       usdtRateLookup: { date in

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -93,6 +93,8 @@ extension ProfileSession {
         http: networking.client(forHost: cgHost)),
       cryptoCompareClient,
       binanceClient,
+      // Last-resort $1 fallback for canonical USDC/USDT only (peg).
+      StablecoinPriceClient(),
     ]
 
     return CryptoPriceService(

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -185,7 +185,7 @@ final class ProfileSession: Identifiable {
       backend: backend,
       cryptoPriceService: services.cryptoPrice,
       yahooPriceFetcher: services.yahooPriceFetcher,
-      coinGeckoApiKey: services.coinGeckoApiKey,
+      coinGeckoApiKeyProvider: services.coinGeckoApiKeyProvider,
       networking: resolvedNetworking,
       sharedRegistryStore: syncCoordinator?.sharedRegistryStore
     )

--- a/Backends/Binance/BinanceClient.swift
+++ b/Backends/Binance/BinanceClient.swift
@@ -19,7 +19,7 @@ struct BinanceClient: CryptoPriceClient, Sendable {
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
     let prices = try await dailyPrices(for: mapping, in: date...date)
-    let dateString = Self.dateString(from: date)
+    let dateString = date.iso8601DateOnlyString
     guard let price = prices[dateString] else {
       throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: dateString)
     }
@@ -129,12 +129,6 @@ struct BinanceClient: CryptoPriceClient, Sendable {
 
   static func applyUsdtRate(_ prices: [String: Decimal], rate: Decimal) -> [String: Decimal] {
     prices.mapValues { $0 * rate }
-  }
-
-  private static func dateString(from date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    return formatter.string(from: date)
   }
 }
 

--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -13,12 +13,28 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
   /// CryptoCompare / Binance if a request 429s.
   private static let publicBaseURL =
     URL(string: "https://api.coingecko.com/api/v3") ?? URL(fileURLWithPath: "/")
-  private let http: RateLimitedHTTPClient
-  private let apiKey: String
+  /// Resolves the key per request (not once at construction) so a Pro key
+  /// entered in Settings flips both the request URL's host *and* the
+  /// rate-limit gate — looked up from `networking` for the same host — on
+  /// the next fetch. Reading the key once and binding `http` to one host at
+  /// init let the two diverge when the key changed mid-session.
+  private let apiKeyProvider: @Sendable () -> String?
+  private let networking: NetworkingServices
 
-  init(apiKey: String, http: RateLimitedHTTPClient) {
-    self.apiKey = apiKey
-    self.http = http
+  init(apiKeyProvider: @Sendable @escaping () -> String?, networking: NetworkingServices) {
+    self.apiKeyProvider = apiKeyProvider
+    self.networking = networking
+  }
+
+  /// The free public CoinGecko host. Used when no key is configured.
+  private static let publicHost = "api.coingecko.com"
+  /// The authenticated Pro host. Used whenever a key is configured.
+  private static let proHost = "pro-api.coingecko.com"
+
+  /// Picks the host that matches the key the URL builders target so the
+  /// rate-limit gate and the request URL never diverge.
+  private static func host(apiKey: String) -> String {
+    apiKey.isEmpty ? publicHost : proHost
   }
 
   /// Resolves the base URL by key presence: non-empty → Pro host,
@@ -49,8 +65,10 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     guard let coinId = mapping.coingeckoId else {
       throw CryptoPriceError.noProviderMapping(tokenId: mapping.instrumentId, provider: "CoinGecko")
     }
+    let apiKey = apiKeyProvider() ?? ""
     let url = Self.marketChartRangeURL(
       coinId: coinId, from: range.lowerBound, to: range.upperBound, apiKey: apiKey)
+    let http = networking.client(forHost: Self.host(apiKey: apiKey))
     let (data, _) = try await http.data(for: URLRequest(url: url))
     return try Self.parseMarketChartResponse(data)
   }
@@ -65,7 +83,9 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     )
     guard !idToMapping.isEmpty else { return [:] }
 
+    let apiKey = apiKeyProvider() ?? ""
     let url = Self.simplePriceURL(coinIds: Array(idToMapping.keys), apiKey: apiKey)
+    let http = networking.client(forHost: Self.host(apiKey: apiKey))
     let (data, _) = try await http.data(for: URLRequest(url: url))
     let coinPrices = try Self.parseSimplePriceResponse(data)
 
@@ -125,6 +145,22 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
     components.queryItems = authQueryItem(apiKey: apiKey).map { [$0] }
+    return components.url ?? pathURL
+  }
+
+  /// `/coins/list?include_platform=true` — the full coin catalog the
+  /// `SQLiteCoinGeckoCatalog` refresh downloads. Built here (rather than as
+  /// a hardcoded literal in the catalog) so host selection and the auth
+  /// query item stay in one tested place alongside the other endpoints.
+  static func coinsListURL(apiKey: String) -> URL {
+    let pathURL = baseURL(apiKey: apiKey).appendingPathComponent("coins/list")
+    var components =
+      URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+    var items: [URLQueryItem] = [
+      URLQueryItem(name: "include_platform", value: "true")
+    ]
+    if let auth = authQueryItem(apiKey: apiKey) { items.append(auth) }
+    components.queryItems = items
     return components.url ?? pathURL
   }
 

--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -32,8 +32,10 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
   private static let proHost = "pro-api.coingecko.com"
 
   /// Picks the host that matches the key the URL builders target so the
-  /// rate-limit gate and the request URL never diverge.
-  private static func host(apiKey: String) -> String {
+  /// rate-limit gate and the request URL never diverge. Internal (not
+  /// `private`) so the catalog refresh path can resolve the same host from
+  /// the one place these literals live (see `SQLiteCoinGeckoCatalog+Refresh`).
+  static func host(apiKey: String) -> String {
     apiKey.isEmpty ? publicHost : proHost
   }
 
@@ -52,7 +54,7 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
     let prices = try await dailyPrices(for: mapping, in: date...date)
-    let dateString = Self.dateString(from: date)
+    let dateString = date.iso8601DateOnlyString
     guard let price = prices[dateString] else {
       throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: dateString)
     }
@@ -240,12 +242,6 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     return ContractLookupResult(
       id: raw.id, symbol: raw.symbol, name: raw.name, decimals: decimals
     )
-  }
-
-  private static func dateString(from date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    return formatter.string(from: date)
   }
 }
 

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -33,8 +33,7 @@ extension SQLiteCoinGeckoCatalog {
       // and the rate-limit gate are derived from the same key, so they never
       // diverge.
       let apiKey = apiKeyProvider() ?? ""
-      let host = apiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
-      let http = networking.client(forHost: host)
+      let http = networking.client(forHost: CoinGeckoClient.host(apiKey: apiKey))
       let coinsListURL = CoinGeckoClient.coinsListURL(apiKey: apiKey)
       let assetPlatformsURL = CoinGeckoClient.assetPlatformsURL(apiKey: apiKey)
       async let coinsRequest = Self.fetchConditional(

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -28,10 +28,19 @@ extension SQLiteCoinGeckoCatalog {
       {
         return
       }
+      // Resolve the key per refresh so a Pro key entered in Settings flips
+      // the host (and the auth query item) on the next refresh. Both URLs
+      // and the rate-limit gate are derived from the same key, so they never
+      // diverge.
+      let apiKey = apiKeyProvider() ?? ""
+      let host = apiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
+      let http = networking.client(forHost: host)
+      let coinsListURL = CoinGeckoClient.coinsListURL(apiKey: apiKey)
+      let assetPlatformsURL = CoinGeckoClient.assetPlatformsURL(apiKey: apiKey)
       async let coinsRequest = Self.fetchConditional(
-        http: http, url: Self.coinsListURL, ifNoneMatch: meta.coinsEtag)
+        http: http, url: coinsListURL, ifNoneMatch: meta.coinsEtag)
       async let platformsRequest = Self.fetchConditional(
-        http: http, url: Self.assetPlatformsURL, ifNoneMatch: meta.platformsEtag)
+        http: http, url: assetPlatformsURL, ifNoneMatch: meta.platformsEtag)
       let coinsResult = try await coinsRequest
       let platformsResult = try await platformsRequest
 
@@ -72,18 +81,6 @@ extension SQLiteCoinGeckoCatalog {
 // MARK: - Constants and fetch primitives
 
 extension SQLiteCoinGeckoCatalog {
-  static let coinsListURL: URL = {
-    guard
-      let url = URL(string: "https://api.coingecko.com/api/v3/coins/list?include_platform=true")
-    else { preconditionFailure("malformed CoinGecko coins-list URL — fix the literal") }
-    return url
-  }()
-
-  static let assetPlatformsURL: URL = {
-    guard let url = URL(string: "https://api.coingecko.com/api/v3/asset_platforms")
-    else { preconditionFailure("malformed CoinGecko asset-platforms URL — fix the literal") }
-    return url
-  }()
   /// 24-hour stale-fetch guard. Refresh callers are no-ops within this
   /// window even if the previous fetch returned 304.
   static let maxAge: TimeInterval = 24 * 3600

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -13,7 +13,12 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   static let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
 
   private let directory: URL
-  let http: RateLimitedHTTPClient
+  /// Resolves the CoinGecko key per refresh (not once at construction) so a
+  /// Pro key entered in Settings flips the `/coins/list` + `/asset_platforms`
+  /// refresh from the free public host to the authenticated Pro host on the
+  /// next refresh.
+  let apiKeyProvider: @Sendable () -> String?
+  let networking: NetworkingServices
   private(set) var database: OpaquePointer?
 
   // MARK: - Cross-extension internals
@@ -28,7 +33,8 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   // `+SQLite.swift`.
   //
   // Used by +Search.swift only:    nothing in this file
-  // Used by +Refresh.swift only:   `http`, `replaceAll`, `insertCoins`,
+  // Used by +Refresh.swift only:   `apiKeyProvider`, `networking`,
+  //                                `replaceAll`, `insertCoins`,
   //                                `insertPlatforms`, `readMeta`
   // Used by both extensions:       `log` (static), `database` (read-only)
 
@@ -40,23 +46,29 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   /// in one named place.
   static func make(
     directory: URL,
-    http: RateLimitedHTTPClient
+    apiKeyProvider: @Sendable @escaping () -> String?,
+    networking: NetworkingServices
   ) throws -> SQLiteCoinGeckoCatalog {
     try FileManager.default.createDirectory(
       at: directory, withIntermediateDirectories: true
     )
     let database = try open(dbURL: directory.appendingPathComponent("catalog.sqlite"))
     return SQLiteCoinGeckoCatalog(
-      directory: directory, http: http, database: database)
+      directory: directory,
+      apiKeyProvider: apiKeyProvider,
+      networking: networking,
+      database: database)
   }
 
   private init(
     directory: URL,
-    http: RateLimitedHTTPClient,
+    apiKeyProvider: @Sendable @escaping () -> String?,
+    networking: NetworkingServices,
     database: OpaquePointer
   ) {
     self.directory = directory
-    self.http = http
+    self.apiKeyProvider = apiKeyProvider
+    self.networking = networking
     self.database = database
   }
 

--- a/Backends/CryptoCompare/CryptoCompareClient.swift
+++ b/Backends/CryptoCompare/CryptoCompareClient.swift
@@ -6,9 +6,11 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
   private static let baseURL =
     URL(string: "https://min-api.cryptocompare.com") ?? URL(fileURLWithPath: "/")
   private let http: RateLimitedHTTPClient
+  private let apiKeyProvider: @Sendable () -> String?
 
-  init(http: RateLimitedHTTPClient) {
+  init(http: RateLimitedHTTPClient, apiKeyProvider: @Sendable @escaping () -> String?) {
     self.http = http
+    self.apiKeyProvider = apiKeyProvider
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -27,7 +29,9 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
       throw CryptoPriceError.noProviderMapping(
         tokenId: mapping.instrumentId, provider: "CryptoCompare")
     }
-    let url = Self.histodayURL(symbol: symbol, from: range.lowerBound, to: range.upperBound)
+    let apiKey = apiKeyProvider() ?? ""
+    let url = Self.histodayURL(
+      symbol: symbol, from: range.lowerBound, to: range.upperBound, apiKey: apiKey)
     let (data, _) = try await http.data(for: URLRequest(url: url))
     return try Self.parseHistodayResponse(data)
   }
@@ -42,7 +46,8 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
     )
     guard !symbolToMapping.isEmpty else { return [:] }
 
-    let url = Self.priceMultiURL(symbols: Array(symbolToMapping.keys))
+    let apiKey = apiKeyProvider() ?? ""
+    let url = Self.priceMultiURL(symbols: Array(symbolToMapping.keys), apiKey: apiKey)
     let (data, _) = try await http.data(for: URLRequest(url: url))
     let symbolPrices = try Self.parsePriceMultiResponse(data)
 
@@ -57,19 +62,28 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
 
   // MARK: - URL builders (internal for testing)
 
-  static func histodayURL(symbol: String, from: Date, to: Date) -> URL {
+  /// `api_key` query item authenticating the request, or `nil` when no key
+  /// is configured. CryptoCompare's `min-api` host now rejects keyless
+  /// requests with HTTP 401, so a configured key is what restores access.
+  private static func authQueryItem(apiKey: String) -> URLQueryItem? {
+    apiKey.isEmpty ? nil : URLQueryItem(name: "api_key", value: apiKey)
+  }
+
+  static func histodayURL(symbol: String, from: Date, to: Date, apiKey: String) -> URL {
     let calendar = Calendar(identifier: .gregorian)
     let days = max(0, calendar.dateComponents([.day], from: from, to: to).day ?? 0)
     let toTimestamp = Int(to.timeIntervalSince1970)
     let pathURL = baseURL.appendingPathComponent("/data/v2/histoday")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
-    components.queryItems = [
+    var items: [URLQueryItem] = [
       URLQueryItem(name: "fsym", value: symbol),
       URLQueryItem(name: "tsym", value: "USD"),
       URLQueryItem(name: "limit", value: String(days)),
       URLQueryItem(name: "toTs", value: String(toTimestamp)),
     ]
+    if let auth = authQueryItem(apiKey: apiKey) { items.append(auth) }
+    components.queryItems = items
     return components.url ?? pathURL
   }
 
@@ -83,14 +97,16 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
     return components.url ?? pathURL
   }
 
-  static func priceMultiURL(symbols: [String]) -> URL {
+  static func priceMultiURL(symbols: [String], apiKey: String) -> URL {
     let pathURL = baseURL.appendingPathComponent("/data/pricemulti")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
-    components.queryItems = [
+    var items: [URLQueryItem] = [
       URLQueryItem(name: "fsyms", value: symbols.joined(separator: ",")),
       URLQueryItem(name: "tsyms", value: "USD"),
     ]
+    if let auth = authQueryItem(apiKey: apiKey) { items.append(auth) }
+    components.queryItems = items
     return components.url ?? pathURL
   }
 

--- a/Backends/CryptoCompare/CryptoCompareClient.swift
+++ b/Backends/CryptoCompare/CryptoCompareClient.swift
@@ -15,7 +15,7 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
     let prices = try await dailyPrices(for: mapping, in: date...date)
-    let dateString = Self.dateString(from: date)
+    let dateString = date.iso8601DateOnlyString
     guard let price = prices[dateString] else {
       throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: dateString)
     }
@@ -177,12 +177,6 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
       }
     }
     return result
-  }
-
-  private static func dateString(from date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    return formatter.string(from: date)
   }
 }
 

--- a/Backends/Stablecoin/StablecoinPriceClient.swift
+++ b/Backends/Stablecoin/StablecoinPriceClient.swift
@@ -21,7 +21,7 @@ struct StablecoinPriceClient: CryptoPriceClient, Sendable {
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
     let prices = try await dailyPrices(for: mapping, in: date...date)
-    let key = Self.dateString(from: date)
+    let key = date.iso8601DateOnlyString
     guard let price = prices[key] else {
       throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: key)
     }
@@ -38,7 +38,7 @@ struct StablecoinPriceClient: CryptoPriceClient, Sendable {
     var result: [String: Decimal] = [:]
     var current = range.lowerBound
     while current <= range.upperBound {
-      result[Self.dateString(from: current)] = Decimal(1)
+      result[current.iso8601DateOnlyString] = Decimal(1)
       guard let next = Calendar.utc.date(byAdding: .day, value: 1, to: current) else { break }
       current = next
     }
@@ -66,11 +66,5 @@ struct StablecoinPriceClient: CryptoPriceClient, Sendable {
         chainId: chainId, contractAddress: String(addressPart))
     else { return false }
     return peggedSymbols.contains(symbol)
-  }
-
-  private static func dateString(from date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    return formatter.string(from: date)
   }
 }

--- a/Backends/Stablecoin/StablecoinPriceClient.swift
+++ b/Backends/Stablecoin/StablecoinPriceClient.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Last-resort price source that reports a flat USD $1 for canonical USDC /
+/// USDT deployments. Stablecoins track their peg, so when every market-data
+/// provider declines a recognised stablecoin (e.g. an L2 USDC that
+/// CryptoCompare omits from its contract index and CoinGecko rate-limits), the
+/// peg is a safe fallback rather than leaving the token unpriced.
+///
+/// Membership is gated through `CanonicalTokenRegistry`, which only recognises
+/// the *legitimate* deployment addresses for each protected symbol — so a
+/// look-alike token reusing the "USDC" symbol at a different address yields no
+/// peg. The client declines everything it does not recognise by throwing
+/// `.noProviderMapping`, so the price service skips it silently and the next
+/// provider (none — this is last) is consulted exactly as for any other client
+/// without a symbol for the token.
+struct StablecoinPriceClient: CryptoPriceClient, Sendable {
+  /// The set of canonical symbols this client treats as $1-pegged.
+  private static let peggedSymbols: Set<String> = ["USDC", "USDT"]
+
+  var syncProvider: SyncProvider { .peggedStablecoin }
+
+  func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
+    let prices = try await dailyPrices(for: mapping, in: date...date)
+    let key = Self.dateString(from: date)
+    guard let price = prices[key] else {
+      throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: key)
+    }
+    return price
+  }
+
+  func dailyPrices(
+    for mapping: CryptoProviderMapping, in range: ClosedRange<Date>
+  ) async throws -> [String: Decimal] {
+    guard Self.isPegged(mapping.instrumentId) else {
+      throw CryptoPriceError.noProviderMapping(
+        tokenId: mapping.instrumentId, provider: "Stablecoin peg")
+    }
+    var result: [String: Decimal] = [:]
+    var current = range.lowerBound
+    while current <= range.upperBound {
+      result[Self.dateString(from: current)] = Decimal(1)
+      guard let next = Calendar.utc.date(byAdding: .day, value: 1, to: current) else { break }
+      current = next
+    }
+    return result
+  }
+
+  func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
+    var result: [String: Decimal] = [:]
+    for mapping in mappings where Self.isPegged(mapping.instrumentId) {
+      result[mapping.instrumentId] = Decimal(1)
+    }
+    return result
+  }
+
+  /// `true` when `instrumentId` ("<chainId>:<address>") names a canonical USDC
+  /// or USDT deployment. Native ids ("<chainId>:native") and non-canonical /
+  /// look-alike addresses return `false`.
+  private static func isPegged(_ instrumentId: String) -> Bool {
+    guard let separator = instrumentId.firstIndex(of: ":") else { return false }
+    let chainPart = instrumentId[..<separator]
+    let addressPart = instrumentId[instrumentId.index(after: separator)...]
+    guard let chainId = Int(chainPart), addressPart != "native" else { return false }
+    guard
+      let symbol = CanonicalTokenRegistry.symbol(
+        chainId: chainId, contractAddress: String(addressPart))
+    else { return false }
+    return peggedSymbols.contains(symbol)
+  }
+
+  private static func dateString(from date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return formatter.string(from: date)
+  }
+}

--- a/Domain/Models/SyncProvider.swift
+++ b/Domain/Models/SyncProvider.swift
@@ -13,6 +13,7 @@ enum SyncProvider: String {
   case coinGecko
   case cryptoCompare
   case binance
+  case peggedStablecoin
 
   /// Returns the user-facing brand name for each case, shown in the
   /// synced-account error caption. `.blockExplorer` resolves to the concrete
@@ -26,6 +27,7 @@ enum SyncProvider: String {
     case .coinGecko: return "CoinGecko"
     case .cryptoCompare: return "CryptoCompare"
     case .binance: return "Binance"
+    case .peggedStablecoin: return "Pegged stablecoin"
     }
   }
 }

--- a/Domain/Models/SyncProvider.swift
+++ b/Domain/Models/SyncProvider.swift
@@ -27,7 +27,7 @@ enum SyncProvider: String {
     case .coinGecko: return "CoinGecko"
     case .cryptoCompare: return "CryptoCompare"
     case .binance: return "Binance"
-    case .peggedStablecoin: return "Pegged stablecoin"
+    case .peggedStablecoin: return "Pegged Stablecoin"
     }
   }
 }

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -1,10 +1,11 @@
 // Features/Settings/CryptoSettingsView+TokenList.swift
 import SwiftUI
 
-/// "Registered Tokens" + "CoinGecko API Key" sections of the Crypto
-/// preferences tab. Every member here closes over the parent view's
-/// `store` / `showAddToken` / `coinGeckoApiKeyInput` bindings — no new
-/// state owned at this layer.
+/// "Registered Tokens" + "CoinGecko" / "CryptoCompare" API-key sections
+/// of the Crypto preferences tab. Every member here closes over the
+/// parent view's `store` / `showAddToken` / `coinGeckoApiKeyInput` /
+/// `cryptoCompareApiKeyInput` bindings — no new state owned at this
+/// layer.
 extension CryptoSettingsView {
 
   // MARK: - Registered Tokens
@@ -165,5 +166,70 @@ extension CryptoSettingsView {
         .disabled(coinGeckoApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
       }
     }
+  }
+
+  // MARK: - CryptoCompare API Key
+
+  var cryptoCompareApiKeySection: some View {
+    Section {
+      cryptoCompareApiKeyControl
+      Link(
+        "How to get a CryptoCompare API key",
+        destination: cryptoCompareSignupURL
+      )
+      .font(.caption)
+    } header: {
+      Text("CryptoCompare")
+    } footer: {
+      Text(
+        "Optional. Restores deep price history for tokens like DAI. "
+          + "Requires a free API key from CoinDesk Data, formerly CryptoCompare."
+      )
+    }
+  }
+
+  @ViewBuilder var cryptoCompareApiKeyControl: some View {
+    if store.hasCryptoCompareApiKey {
+      HStack {
+        Label("CryptoCompare API Key", systemImage: "key")
+        Spacer()
+        Text("Configured")
+          .foregroundStyle(.secondary)
+        Button("Remove", role: .destructive) {
+          store.clearCryptoCompareApiKey()
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.cryptoCompareApiKeyRemoveButton)
+      }
+    } else {
+      HStack {
+        SecureField("CryptoCompare API Key", text: $cryptoCompareApiKeyInput)
+          .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.cryptoCompareApiKeyField)
+        Button("Save") {
+          let trimmed = cryptoCompareApiKeyInput.trimmingCharacters(in: .whitespaces)
+          guard !trimmed.isEmpty else { return }
+          store.saveCryptoCompareApiKey(trimmed)
+          cryptoCompareApiKeyInput = ""
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(cryptoCompareApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.cryptoCompareApiKeySaveButton)
+      }
+    }
+  }
+
+  /// CoinDesk Data (formerly CryptoCompare) API landing page. Hard-coded
+  /// constant rather than environment / config because the URL is a
+  /// public resource and keeping it inline keeps the link a one-line
+  /// `Link(...)` call. `URL(string:)`'s force-unwrap is gated by a
+  /// known-good literal so a `nil` here is a programmer error, not a
+  /// runtime failure mode.
+  private var cryptoCompareSignupURL: URL {
+    guard let url = URL(string: "https://developers.coindesk.com") else {
+      preconditionFailure("CryptoSettingsView: malformed CryptoCompare signup URL literal")
+    }
+    return url
   }
 }

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -129,6 +129,11 @@ extension CryptoSettingsView {
   var coinGeckoApiKeySection: some View {
     Section {
       coinGeckoApiKeyControl
+      Link(
+        "How to get a CoinGecko API key",
+        destination: coinGeckoSignupURL
+      )
+      .font(.caption)
     } header: {
       Text("CoinGecko")
     } footer: {
@@ -140,30 +145,31 @@ extension CryptoSettingsView {
   }
 
   @ViewBuilder var coinGeckoApiKeyControl: some View {
-    if store.hasApiKey {
+    if store.hasCoinGeckoApiKey {
       HStack {
         Label("CoinGecko API Key", systemImage: "key")
         Spacer()
         Text("Configured")
           .foregroundStyle(.secondary)
         Button("Remove", role: .destructive) {
-          store.clearApiKey()
+          store.clearCoinGeckoApiKey()
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.coinGeckoApiKeyRemoveButton)
       }
     } else {
       HStack {
         SecureField("CoinGecko API Key", text: $coinGeckoApiKeyInput)
+          .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.coinGeckoApiKeyField)
         Button("Save") {
-          let trimmed = coinGeckoApiKeyInput.trimmingCharacters(in: .whitespaces)
-          guard !trimmed.isEmpty else { return }
-          store.saveApiKey(trimmed)
+          store.saveCoinGeckoApiKey(coinGeckoApiKeyInput)
           coinGeckoApiKeyInput = ""
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .disabled(coinGeckoApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
+        .disabled(coinGeckoApiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.coinGeckoApiKeySaveButton)
       }
     }
   }
@@ -207,14 +213,12 @@ extension CryptoSettingsView {
         SecureField("CryptoCompare API Key", text: $cryptoCompareApiKeyInput)
           .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.cryptoCompareApiKeyField)
         Button("Save") {
-          let trimmed = cryptoCompareApiKeyInput.trimmingCharacters(in: .whitespaces)
-          guard !trimmed.isEmpty else { return }
-          store.saveCryptoCompareApiKey(trimmed)
+          store.saveCryptoCompareApiKey(cryptoCompareApiKeyInput)
           cryptoCompareApiKeyInput = ""
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .disabled(cryptoCompareApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
+        .disabled(cryptoCompareApiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.cryptoCompareApiKeySaveButton)
       }
     }
@@ -229,6 +233,18 @@ extension CryptoSettingsView {
   private var cryptoCompareSignupURL: URL {
     guard let url = URL(string: "https://developers.coindesk.com") else {
       preconditionFailure("CryptoSettingsView: malformed CryptoCompare signup URL literal")
+    }
+    return url
+  }
+
+  /// CoinGecko API landing page. Hard-coded constant rather than
+  /// environment / config because the URL is a public resource and keeping
+  /// it inline keeps the link a one-line `Link(...)` call. `URL(string:)`'s
+  /// force-unwrap is gated by a known-good literal so a `nil` here is a
+  /// programmer error, not a runtime failure mode.
+  private var coinGeckoSignupURL: URL {
+    guard let url = URL(string: "https://www.coingecko.com/en/api") else {
+      preconditionFailure("CryptoSettingsView: malformed CoinGecko signup URL literal")
     }
     return url
   }

--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -24,6 +24,7 @@ struct CryptoSettingsView: View {
   // `CryptoSettingsView+TokenList.swift` can read / mutate the same
   // local UI state. Not part of the public surface.
   @State var coinGeckoApiKeyInput = ""
+  @State var cryptoCompareApiKeyInput = ""
   @State var alchemyApiKeyInput = ""
   @State var showAddToken = false
 
@@ -43,6 +44,7 @@ struct CryptoSettingsView: View {
       tokenInboxNavigationSection
       tokenListSection
       coinGeckoApiKeySection
+      cryptoCompareApiKeySection
     }
     .formStyle(.grouped)
     .navigationTitle("Crypto Tokens")

--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -124,14 +124,12 @@ struct CryptoSettingsView: View {
       SecureField("Alchemy API Key", text: $alchemyApiKeyInput)
         .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.alchemyApiKeyField)
       Button("Save") {
-        let trimmed = alchemyApiKeyInput.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        store.saveAlchemyApiKey(trimmed)
+        store.saveAlchemyApiKey(alchemyApiKeyInput)
         alchemyApiKeyInput = ""
       }
       .buttonStyle(.bordered)
       .controlSize(.small)
-      .disabled(alchemyApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
+      .disabled(alchemyApiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
       .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.alchemyApiKeySaveButton)
     }
   }
@@ -221,4 +219,26 @@ struct CryptoSettingsView: View {
 
   // The "Registered Tokens" + "CoinGecko API Key" sections live in
   // `CryptoSettingsView+TokenList.swift`.
+}
+
+#Preview("No keys") {
+  // Preview-only wiring: an in-memory registry + a no-network price
+  // service exercises the empty "no keys configured" state. The store's
+  // keychain reads return `nil` on the preview host, so every provider
+  // renders its entry-field row. `PreviewBackend.create(sharedRegistry:)`
+  // supplies a conversion service wired over the same in-memory
+  // profile-index DB the registry owns.
+  // In-memory open cannot fail (no filesystem path); preview-only path.
+  // swiftlint:disable:next force_try
+  let database = try! ProfileIndexDatabase.openInMemory()
+  let registry = GRDBInstrumentRegistryRepository(database: database)
+  let backend = PreviewBackend.create(sharedRegistry: registry)
+  let priceService = CryptoPriceService(clients: [], database: registry.database)
+  let store = CryptoTokenStore(
+    registry: registry,
+    cryptoPriceService: priceService,
+    conversionService: backend.conversionService)
+  return NavigationStack {
+    CryptoSettingsView(store: store)
+  }
 }

--- a/Features/Settings/CryptoTokenStore+APIKeys.swift
+++ b/Features/Settings/CryptoTokenStore+APIKeys.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Provider API-key surface for `CryptoTokenStore` — the CoinGecko,
+/// Alchemy, and CryptoCompare keychain reads / writes that back the
+/// Crypto preferences tab. Split into its own file so the core store
+/// stays under the file-length limit. Every member proxies the
+/// store's `let` keychain handles; none owns new state.
+///
+/// Each provider follows the same shape: a `has…ApiKey` read that
+/// drives a status badge, a `save…ApiKey(_:)` that persists to the
+/// synced Keychain, and a `clear…ApiKey()` that removes the entry. The
+/// key value itself is never logged; failure paths log only the
+/// wrapping `error.localizedDescription` (which carries the underlying
+/// `OSStatus` via `KeychainError`).
+extension CryptoTokenStore {
+
+  // MARK: - CoinGecko API Key
+
+  var hasApiKey: Bool {
+    do {
+      return try apiKeyStore.restoreString() != nil
+    } catch {
+      logger.error("keychain read failed: \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  func saveApiKey(_ key: String) {
+    do {
+      try apiKeyStore.saveString(key)
+      setError(nil)
+    } catch {
+      logger.error(
+        "CoinGecko API key save failed: \(error.localizedDescription, privacy: .public)")
+      setError("Failed to save API key: \(error.localizedDescription)")
+    }
+  }
+
+  func clearApiKey() {
+    apiKeyStore.clear()
+  }
+
+  // MARK: - Alchemy API Key
+  //
+  // The Alchemy key drives the wallet auto-import.
+  // `ProfileSession.resolveAlchemyApiKey()` reads from the same
+  // `(service, account)` keychain entry, so a write here is picked up
+  // by the next sync cycle without further plumbing.
+
+  /// `true` when an Alchemy API key is configured in the synced
+  /// Keychain. Read on every UI render to drive the status badge —
+  /// the keychain read is cheap (~µs) and consulting a cached `Bool`
+  /// would require an explicit invalidation hook on save / clear.
+  var hasAlchemyApiKey: Bool {
+    do {
+      return try alchemyKeyStore.restoreString() != nil
+    } catch {
+      logger.error("keychain read failed: \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  /// Persists the Alchemy API key to the synced Keychain. Sets
+  /// `error` (without logging the key) on failure.
+  func saveAlchemyApiKey(_ key: String) {
+    do {
+      try alchemyKeyStore.saveString(key)
+      setError(nil)
+    } catch {
+      logger.error(
+        "Alchemy API key save failed: \(error.localizedDescription, privacy: .public)")
+      setError("Failed to save Alchemy API key: \(error.localizedDescription)")
+    }
+  }
+
+  /// Removes the Alchemy API key from the synced Keychain. Subsequent
+  /// sync cycles will produce `WalletSyncError.missingApiKey` until a
+  /// new key is saved.
+  func clearAlchemyApiKey() {
+    alchemyKeyStore.clear()
+  }
+
+  // MARK: - CryptoCompare API Key
+  //
+  // The CryptoCompare key unlocks deep historical price coverage for
+  // tokens like DAI. The price client reads from the same
+  // `(service, account)` keychain entry, so a write here is picked up
+  // by the next price request without further plumbing.
+
+  /// `true` when a CryptoCompare API key is configured in the synced
+  /// Keychain. Read on every UI render to drive the status badge — the
+  /// keychain read is cheap (~µs) and consulting a cached `Bool` would
+  /// require an explicit invalidation hook on save / clear.
+  var hasCryptoCompareApiKey: Bool {
+    do {
+      return try cryptocompareKeyStore.restoreString() != nil
+    } catch {
+      logger.error("keychain read failed: \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  /// Persists the CryptoCompare API key to the synced Keychain. Sets
+  /// `error` (without logging the key) on failure.
+  func saveCryptoCompareApiKey(_ key: String) {
+    do {
+      try cryptocompareKeyStore.saveString(key)
+      setError(nil)
+    } catch {
+      logger.error(
+        "CryptoCompare API key save failed: \(error.localizedDescription, privacy: .public)")
+      setError("Failed to save CryptoCompare API key: \(error.localizedDescription)")
+    }
+  }
+
+  /// Removes the CryptoCompare API key from the synced Keychain.
+  /// Subsequent price requests fall back to the unauthenticated
+  /// CryptoCompare tier until a new key is saved.
+  func clearCryptoCompareApiKey() {
+    cryptocompareKeyStore.clear()
+  }
+}

--- a/Features/Settings/CryptoTokenStore+APIKeys.swift
+++ b/Features/Settings/CryptoTokenStore+APIKeys.swift
@@ -7,8 +7,10 @@ import Foundation
 /// store's `let` keychain handles; none owns new state.
 ///
 /// Each provider follows the same shape: a `has…ApiKey` read that
-/// drives a status badge, a `save…ApiKey(_:)` that persists to the
-/// synced Keychain, and a `clear…ApiKey()` that removes the entry. The
+/// drives a status badge, a `save…ApiKey(_:)` that trims surrounding
+/// whitespace and persists to the synced Keychain (an all-whitespace
+/// input is a no-op, never persisted empty), and a `clear…ApiKey()`
+/// that removes the entry. The
 /// key value itself is never logged; failure paths log only the
 /// wrapping `error.localizedDescription` (which carries the underlying
 /// `OSStatus` via `KeychainError`).
@@ -16,7 +18,7 @@ extension CryptoTokenStore {
 
   // MARK: - CoinGecko API Key
 
-  var hasApiKey: Bool {
+  var hasCoinGeckoApiKey: Bool {
     do {
       return try apiKeyStore.restoreString() != nil
     } catch {
@@ -25,9 +27,11 @@ extension CryptoTokenStore {
     }
   }
 
-  func saveApiKey(_ key: String) {
+  func saveCoinGeckoApiKey(_ key: String) {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
     do {
-      try apiKeyStore.saveString(key)
+      try apiKeyStore.saveString(trimmed)
       setError(nil)
     } catch {
       logger.error(
@@ -36,7 +40,7 @@ extension CryptoTokenStore {
     }
   }
 
-  func clearApiKey() {
+  func clearCoinGeckoApiKey() {
     apiKeyStore.clear()
   }
 
@@ -63,8 +67,10 @@ extension CryptoTokenStore {
   /// Persists the Alchemy API key to the synced Keychain. Sets
   /// `error` (without logging the key) on failure.
   func saveAlchemyApiKey(_ key: String) {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
     do {
-      try alchemyKeyStore.saveString(key)
+      try alchemyKeyStore.saveString(trimmed)
       setError(nil)
     } catch {
       logger.error(
@@ -103,8 +109,10 @@ extension CryptoTokenStore {
   /// Persists the CryptoCompare API key to the synced Keychain. Sets
   /// `error` (without logging the key) on failure.
   func saveCryptoCompareApiKey(_ key: String) {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
     do {
-      try cryptocompareKeyStore.saveString(key)
+      try cryptocompareKeyStore.saveString(trimmed)
       setError(nil)
     } catch {
       logger.error(

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -69,10 +69,18 @@ final class CryptoTokenStore {
   private let registry: any InstrumentRegistryRepository
   private let cryptoPriceService: CryptoPriceService
   private let conversionService: any InstrumentConversionService
-  private let logger = Logger(
+
+  /// Internal (not `private`) so the `CryptoTokenStore+APIKeys`
+  /// extension in its own file can log keychain failures through the
+  /// same category.
+  let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoTokenStore")
 
-  private let apiKeyStore: KeychainStore
+  // The three API-key keychain stores are internal (not `private`) so
+  // the `CryptoTokenStore+APIKeys` extension — which lives in a sibling
+  // file to keep this type under the file-length limit — can read and
+  // write them. The save / has / clear surface lives in that extension.
+  let apiKeyStore: KeychainStore
 
   /// Keychain entry for the Alchemy API key, used by the crypto-wallet
   /// auto-import. Service / account strings are pinned to the values
@@ -82,7 +90,17 @@ final class CryptoTokenStore {
   /// inject a
   /// non-synced `KeychainStore` since the test runner cannot write to
   /// the synced keychain in CI.
-  private let alchemyKeyStore: KeychainStore
+  let alchemyKeyStore: KeychainStore
+
+  /// Keychain entry for the CryptoCompare API key, used by the price
+  /// client to unlock deep historical price coverage for tokens like
+  /// DAI. Service / account strings are pinned to the values
+  /// `ProfileSession+CryptoSync` reads on the fetch side so reads pick
+  /// up whatever the settings UI writes here. Production wires this to
+  /// the iCloud-synced keychain (`synchronizable: true`); tests inject a
+  /// non-synced `KeychainStore` since the test runner cannot write to
+  /// the synced keychain in CI.
+  let cryptocompareKeyStore: KeychainStore
 
   /// Subscription to the registry's change stream so per-session side
   /// effects fire when ANY session (including this one) mutates the
@@ -105,6 +123,7 @@ final class CryptoTokenStore {
     conversionService: any InstrumentConversionService,
     apiKeyStore: KeychainStore,
     alchemyKeyStore: KeychainStore,
+    cryptocompareKeyStore: KeychainStore,
     sharedStore: SharedRegistryStore? = nil
   ) {
     self.registry = registry
@@ -112,6 +131,7 @@ final class CryptoTokenStore {
     self.conversionService = conversionService
     self.apiKeyStore = apiKeyStore
     self.alchemyKeyStore = alchemyKeyStore
+    self.cryptocompareKeyStore = cryptocompareKeyStore
     self.sharedStore = sharedStore
 
     let stream = registry.observeChanges()
@@ -156,6 +176,8 @@ final class CryptoTokenStore {
         service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true),
       alchemyKeyStore: KeychainStore(
         service: KeychainServices.apiKeys, account: "alchemy", synchronizable: true),
+      cryptocompareKeyStore: KeychainStore(
+        service: KeychainServices.apiKeys, account: "cryptocompare", synchronizable: true),
       sharedStore: sharedStore)
   }
 
@@ -307,72 +329,12 @@ final class CryptoTokenStore {
     onRegistrationsChanged?()
   }
 
-  // MARK: - CoinGecko API Key
-
-  var hasApiKey: Bool {
-    do {
-      return try apiKeyStore.restoreString() != nil
-    } catch {
-      logger.error("keychain read failed: \(error.localizedDescription)")
-      return false
-    }
-  }
-
-  func saveApiKey(_ key: String) {
-    do {
-      try apiKeyStore.saveString(key)
-      self.error = nil
-    } catch {
-      logger.error(
-        "CoinGecko API key save failed: \(error.localizedDescription, privacy: .public)")
-      self.error = "Failed to save API key: \(error.localizedDescription)"
-    }
-  }
-
-  func clearApiKey() {
-    apiKeyStore.clear()
-  }
-
-  // MARK: - Alchemy API Key
-  //
-  // The Alchemy key drives the wallet auto-import.
-  // `ProfileSession.resolveAlchemyApiKey()` reads from the same
-  // `(service, account)` keychain entry, so a write here is picked up
-  // by the next sync cycle without further plumbing. The key value
-  // itself is never logged; failure paths log only the wrapping
-  // `error.localizedDescription` (which carries the underlying
-  // `OSStatus` via `KeychainError`).
-
-  /// `true` when an Alchemy API key is configured in the synced
-  /// Keychain. Read on every UI render to drive the status badge —
-  /// the keychain read is cheap (~µs) and consulting a cached `Bool`
-  /// would require an explicit invalidation hook on save / clear.
-  var hasAlchemyApiKey: Bool {
-    do {
-      return try alchemyKeyStore.restoreString() != nil
-    } catch {
-      logger.error("keychain read failed: \(error.localizedDescription)")
-      return false
-    }
-  }
-
-  /// Persists the Alchemy API key to the synced Keychain. Sets
-  /// `error` (without logging the key) on failure.
-  func saveAlchemyApiKey(_ key: String) {
-    do {
-      try alchemyKeyStore.saveString(key)
-      self.error = nil
-    } catch {
-      logger.error(
-        "Alchemy API key save failed: \(error.localizedDescription, privacy: .public)")
-      self.error = "Failed to save Alchemy API key: \(error.localizedDescription)"
-    }
-  }
-
-  /// Removes the Alchemy API key from the synced Keychain. Subsequent
-  /// sync cycles will produce `WalletSyncError.missingApiKey` until a
-  /// new key is saved.
-  func clearAlchemyApiKey() {
-    alchemyKeyStore.clear()
+  /// Internal write seam for the `error` published state, used by the
+  /// `CryptoTokenStore+APIKeys` extension (a sibling file) which cannot
+  /// reach the `private(set)` setter directly. Keeps the public read
+  /// surface `private(set)` while allowing the split-out key methods to
+  /// clear / set the error string.
+  func setError(_ message: String?) {
+    self.error = message
   }
 }

--- a/MoolahTests/Backends/CoinGeckoCatalogContractLookupTests.swift
+++ b/MoolahTests/Backends/CoinGeckoCatalogContractLookupTests.swift
@@ -18,7 +18,8 @@ final class CoinGeckoCatalogContractLookupTests {
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
   }
 
   deinit {

--- a/MoolahTests/Backends/CoinGeckoClientPerRequestKeyTests.swift
+++ b/MoolahTests/Backends/CoinGeckoClientPerRequestKeyTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// `CoinGeckoClient` resolves its key (and therefore its host) per request via
+/// the injected provider, so a Pro key entered mid-session flips both the
+/// request URL's host and the rate-limit gate on the next fetch without
+/// reconstructing the client. Class-based + `.serialized` so the shared
+/// `StubURLProtocol.handlers` map is reset in `deinit`.
+@Suite("CoinGeckoClient per-request key", .serialized)
+final class CoinGeckoClientPerRequestKeyTests {
+  deinit {
+    StubURLProtocol.handlers = [:]
+  }
+
+  private func makeNetworking() -> NetworkingServices {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return NetworkingServices(session: URLSession(configuration: config))
+  }
+
+  private let ethMapping = CryptoProviderMapping(
+    instrumentId: "1:native", coingeckoId: "ethereum",
+    cryptocompareSymbol: nil, binanceSymbol: nil)
+
+  /// One mutable `apiKey` box drives the provider so a single client can be
+  /// driven across the empty → Pro transition without reconstructing it.
+  @Test
+  func currentPricesFlipsHostAndKeyWhenProviderFlips() async throws {
+    let priceJSON = #"{"ethereum":{"usd":1623.45}}"#
+    let publicURL = LockedBox<URL?>(nil)
+    let proURL = LockedBox<URL?>(nil)
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/simple/price"] = { request in
+      publicURL.set(request.url)
+      return (HTTPURLResponse.ok(etag: ""), Data(priceJSON.utf8))
+    }
+    StubURLProtocol.handlers["pro-api.coingecko.com:/api/v3/simple/price"] = { request in
+      proURL.set(request.url)
+      return (HTTPURLResponse.ok(etag: ""), Data(priceJSON.utf8))
+    }
+
+    let key = LockedBox<String?>("")
+    let client = CoinGeckoClient(
+      apiKeyProvider: { key.get() }, networking: makeNetworking())
+
+    // Empty key → free public host, no auth query item.
+    _ = try await client.currentPrices(for: [ethMapping])
+    let firstURL = try #require(publicURL.get())
+    let firstComponents = try #require(URLComponents(url: firstURL, resolvingAgainstBaseURL: false))
+    #expect(firstComponents.host == "api.coingecko.com")
+    let firstNames = Set((firstComponents.queryItems ?? []).map(\.name))
+    #expect(!firstNames.contains("x_cg_pro_api_key"))
+
+    // Flip the key in place — no reconstruction — and the next request must
+    // target the Pro host with the auth query item.
+    key.set("prokey")
+    _ = try await client.currentPrices(for: [ethMapping])
+    let secondURL = try #require(proURL.get())
+    let secondComponents = try #require(
+      URLComponents(url: secondURL, resolvingAgainstBaseURL: false))
+    #expect(secondComponents.host == "pro-api.coingecko.com")
+    let secondItems = try #require(secondComponents.queryItems)
+    let secondQuery = Dictionary(secondItems.map { ($0.name, $0.value ?? "") }) { first, _ in first
+    }
+    #expect(secondQuery["x_cg_pro_api_key"] == "prokey")
+  }
+}

--- a/MoolahTests/Backends/CoinGeckoClientTests.swift
+++ b/MoolahTests/Backends/CoinGeckoClientTests.swift
@@ -117,6 +117,32 @@ struct CoinGeckoClientTests {
     #expect((components.queryItems ?? []).isEmpty)
   }
 
+  @Test
+  func coinsListURLUsesPublicHostAndIncludesPlatformWhenApiKeyIsEmpty() throws {
+    let url = CoinGeckoClient.coinsListURL(apiKey: "")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    #expect(components.host == "api.coingecko.com")
+    #expect(components.path == "/api/v3/coins/list")
+    let items = try #require(components.queryItems)
+    let queryItems = try Dictionary(
+      uniqueKeysWithValues: items.map { try ($0.name, #require($0.value)) })
+    #expect(queryItems["include_platform"] == "true")
+    #expect(queryItems["x_cg_pro_api_key"] == nil)
+  }
+
+  @Test
+  func coinsListURLUsesProHostWithKeyWhenApiKeyIsSet() throws {
+    let url = CoinGeckoClient.coinsListURL(apiKey: "prokey")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    #expect(components.host == "pro-api.coingecko.com")
+    #expect(components.path == "/api/v3/coins/list")
+    let items = try #require(components.queryItems)
+    let queryItems = try Dictionary(
+      uniqueKeysWithValues: items.map { try ($0.name, #require($0.value)) })
+    #expect(queryItems["include_platform"] == "true")
+    #expect(queryItems["x_cg_pro_api_key"] == "prokey")
+  }
+
   // MARK: - Response parsing
 
   @Test
@@ -206,7 +232,7 @@ struct CoinGeckoClientTests {
     let services = NetworkingServices(
       session: URLSession(configuration: .ephemeral))
     let client = CoinGeckoClient(
-      apiKey: "key", http: services.client(forHost: "pro-api.coingecko.com"))
+      apiKeyProvider: { "key" }, networking: services)
     await #expect(throws: CryptoPriceError.self) {
       try await client.dailyPrice(for: mapping, on: Date())
     }

--- a/MoolahTests/Backends/CryptoCompareClientAuthTests.swift
+++ b/MoolahTests/Backends/CryptoCompareClientAuthTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Auth-query-item behaviour for `CryptoCompareClient`'s URL builders, split
+/// from `CryptoCompareClientTests` to keep each suite under the type-body
+/// length limit. CryptoCompare's `min-api` host now 401s keyless requests, so
+/// the `api_key` query item is what restores access.
+@Suite("CryptoCompareClient auth")
+struct CryptoCompareClientAuthTests {
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test
+  func dailyPricesURLIncludesApiKeyWhenConfigured() throws {
+    let from = try date("2026-04-01")
+    let to = try date("2026-04-10")
+    let url = CryptoCompareClient.histodayURL(symbol: "USDT", from: from, to: to, apiKey: "k123")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = try #require(components.queryItems)
+    let queryItems = try Dictionary(
+      uniqueKeysWithValues: items.map { try ($0.name, #require($0.value)) })
+    #expect(queryItems["api_key"] == "k123")
+  }
+
+  @Test
+  func dailyPricesURLOmitsApiKeyWhenEmpty() throws {
+    let from = try date("2026-04-01")
+    let to = try date("2026-04-10")
+    let url = CryptoCompareClient.histodayURL(symbol: "USDT", from: from, to: to, apiKey: "")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = try #require(components.queryItems)
+    #expect(!items.contains { $0.name == "api_key" })
+  }
+
+  @Test
+  func currentPricesURLIncludesApiKeyWhenConfigured() throws {
+    let url = CryptoCompareClient.priceMultiURL(symbols: ["ETH", "BTC"], apiKey: "k123")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = try #require(components.queryItems)
+    let queryItems = try Dictionary(
+      uniqueKeysWithValues: items.map { try ($0.name, #require($0.value)) })
+    #expect(queryItems["api_key"] == "k123")
+  }
+
+  @Test
+  func currentPricesURLOmitsApiKeyWhenEmpty() throws {
+    let url = CryptoCompareClient.priceMultiURL(symbols: ["ETH", "BTC"], apiKey: "")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = try #require(components.queryItems)
+    #expect(!items.contains { $0.name == "api_key" })
+  }
+}

--- a/MoolahTests/Backends/CryptoCompareClientTests.swift
+++ b/MoolahTests/Backends/CryptoCompareClientTests.swift
@@ -21,7 +21,7 @@ struct CryptoCompareClientTests {
   func dailyPricesURLIncludesSymbolAndDateRange() throws {
     let from = try date("2026-04-01")
     let to = try date("2026-04-10")
-    let url = CryptoCompareClient.histodayURL(symbol: "ETH", from: from, to: to)
+    let url = CryptoCompareClient.histodayURL(symbol: "ETH", from: from, to: to, apiKey: "")
     let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
     #expect(components.host == "min-api.cryptocompare.com")
     #expect(components.path == "/data/v2/histoday")
@@ -36,7 +36,7 @@ struct CryptoCompareClientTests {
 
   @Test
   func currentPricesURLIncludesMultipleSymbols() throws {
-    let url = CryptoCompareClient.priceMultiURL(symbols: ["ETH", "BTC"])
+    let url = CryptoCompareClient.priceMultiURL(symbols: ["ETH", "BTC"], apiKey: "")
     let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
     let items = try #require(components.queryItems)
     let queryItems = try Dictionary(
@@ -261,7 +261,9 @@ struct CryptoCompareClientTests {
     )
     let services = NetworkingServices(
       session: URLSession(configuration: .ephemeral))
-    let client = CryptoCompareClient(http: services.client(forHost: "min-api.cryptocompare.com"))
+    let client = CryptoCompareClient(
+      http: services.client(forHost: "min-api.cryptocompare.com"),
+      apiKeyProvider: { nil })
     await #expect(throws: CryptoPriceError.self) {
       try await client.dailyPrice(for: mapping, on: Date())
     }

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
@@ -21,11 +21,11 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     try? FileManager.default.removeItem(at: tempDir)
   }
 
-  private func makeClient() -> RateLimitedHTTPClient {
+  private func makeNetworking() -> NetworkingServices {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [StubURLProtocol.self]
     let session = URLSession(configuration: config)
-    return NetworkingServices(session: session).client(forHost: "api.coingecko.com")
+    return NetworkingServices(session: session)
   }
 
   private func loadFixture(_ name: String) throws -> Data {
@@ -45,7 +45,8 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
 
-    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: makeClient())
+    let catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { "" }, networking: makeNetworking())
     await catalog.refreshIfStale()
 
     let count = try await catalog.coinCountForTesting()
@@ -68,7 +69,8 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
-    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: makeClient())
+    let catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { "" }, networking: makeNetworking())
     await catalog.refreshIfStale()
 
     // Fast-forward `last_fetched` so the next call is "stale".
@@ -106,7 +108,8 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
-    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: makeClient())
+    let catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { "" }, networking: makeNetworking())
     await catalog.refreshIfStale()
     await catalog.refreshIfStale()
 
@@ -123,7 +126,8 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
-    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: makeClient())
+    let catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { "" }, networking: makeNetworking())
     await catalog.refreshIfStale()
     try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
 
@@ -150,7 +154,8 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platforms)
     }
-    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: makeClient())
+    let catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { "" }, networking: makeNetworking())
     await catalog.refreshIfStale()
     try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
 
@@ -165,5 +170,47 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     #expect(pepe.first?.coingeckoId == "pepe")
     let meta = try await catalog.readMetaForTesting()
     #expect(meta.coinsEtag == "W/\"a2\"")
+  }
+
+  /// A provider returning a Pro key must route the refresh to the Pro host
+  /// with the `x_cg_pro_api_key` query item — and still carry
+  /// `include_platform=true` on the coins-list request. Guards the key-aware
+  /// host/auth selection now that the catalog reads its key per refresh.
+  @Test
+  func refreshWithProKeyTargetsProHostWithKey() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    let coinsURL = LockedBox<URL?>(nil)
+    let platformsURL = LockedBox<URL?>(nil)
+    StubURLProtocol.handlers["pro-api.coingecko.com:/api/v3/coins/list"] = { request in
+      coinsURL.set(request.url)
+      return (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["pro-api.coingecko.com:/api/v3/asset_platforms"] = { request in
+      platformsURL.set(request.url)
+      return (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { "prokey" }, networking: makeNetworking())
+    await catalog.refreshIfStale()
+
+    let coins = try #require(coinsURL.get())
+    let coinsComponents = try #require(URLComponents(url: coins, resolvingAgainstBaseURL: false))
+    #expect(coinsComponents.host == "pro-api.coingecko.com")
+    #expect(queryValue(coinsComponents, "x_cg_pro_api_key") == "prokey")
+    #expect(queryValue(coinsComponents, "include_platform") == "true")
+
+    let platforms = try #require(platformsURL.get())
+    let platformsComponents = try #require(
+      URLComponents(url: platforms, resolvingAgainstBaseURL: false))
+    #expect(platformsComponents.host == "pro-api.coingecko.com")
+    #expect(queryValue(platformsComponents, "x_cg_pro_api_key") == "prokey")
+
+    let coinCount = try await catalog.coinCountForTesting()
+    #expect(coinCount == 3)
+  }
+
+  private func queryValue(_ components: URLComponents, _ name: String) -> String? {
+    components.queryItems?.first { $0.name == name }?.value
   }
 }

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
@@ -17,7 +17,8 @@ final class SQLiteCoinGeckoCatalogSearchTests {
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
   }
 
   deinit {

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
@@ -24,7 +24,8 @@ final class SQLiteCoinGeckoCatalogStorageTests {
   func openCreatesFreshSchema() async throws {
     let catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
     let dbURL = tempDir.appendingPathComponent("catalog.sqlite")
     #expect(FileManager.default.fileExists(atPath: dbURL.path))
     let meta = try await catalog.readMetaForTesting()
@@ -38,7 +39,8 @@ final class SQLiteCoinGeckoCatalogStorageTests {
   func replaceAllCoinsAndPlatformsCommitsAtomically() async throws {
     let catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
     let coins: [SQLiteCoinGeckoCatalog.RawCoin] = [
       .init(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:]),
       .init(
@@ -63,7 +65,8 @@ final class SQLiteCoinGeckoCatalogStorageTests {
   func replaceAllReplacesPriorContent() async throws {
     let catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
     let first: [SQLiteCoinGeckoCatalog.RawCoin] = [
       .init(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:])
     ]
@@ -82,7 +85,8 @@ final class SQLiteCoinGeckoCatalogStorageTests {
   func constraintFailureIncludesSqliteErrorMessage() async throws {
     let catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
     let withDuplicate: [SQLiteCoinGeckoCatalog.RawCoin] = [
       .init(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
       .init(id: "tether", symbol: "USDT", name: "Tether (dup)", platforms: [:]),
@@ -107,7 +111,8 @@ final class SQLiteCoinGeckoCatalogStorageTests {
   func replaceAllRollsBackOnConstraintFailure() async throws {
     let catalog = try SQLiteCoinGeckoCatalog.make(
       directory: tempDir,
-      http: NetworkingServices().client(forHost: "api.coingecko.com"))
+      apiKeyProvider: { nil },
+      networking: NetworkingServices())
 
     // Seed a successful first batch so we have prior state to preserve.
     let first: [SQLiteCoinGeckoCatalog.RawCoin] = [
@@ -137,16 +142,19 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func schemaVersionMismatchRecreatesFile() async throws {
-    let dummyHttp = NetworkingServices().client(forHost: "api.coingecko.com")
-    _ = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: dummyHttp)
+    let networking = NetworkingServices()
+    _ = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { nil }, networking: networking)
     let dbURL = tempDir.appendingPathComponent("catalog.sqlite")
     let creationOriginal =
       try FileManager.default.attributesOfItem(atPath: dbURL.path)[.creationDate] as? Date
 
-    let stale = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: dummyHttp)
+    let stale = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { nil }, networking: networking)
     try await stale.writeMetaSchemaVersionForTesting(999)
 
-    let reopened = try SQLiteCoinGeckoCatalog.make(directory: tempDir, http: dummyHttp)
+    let reopened = try SQLiteCoinGeckoCatalog.make(
+      directory: tempDir, apiKeyProvider: { nil }, networking: networking)
     let metaAfter = try await reopened.readMetaForTesting()
     #expect(metaAfter.schemaVersion == CoinGeckoCatalogSchema.version)
 

--- a/MoolahTests/Backends/StablecoinPriceClientTests.swift
+++ b/MoolahTests/Backends/StablecoinPriceClientTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins `StablecoinPriceClient`: a last-resort price source that returns a flat
+/// $1 for canonical USDC / USDT deployments (per `CanonicalTokenRegistry`) and
+/// declines everything else by throwing `.noProviderMapping`.
+@Suite("StablecoinPriceClient")
+struct StablecoinPriceClientTests {
+  private let client = StablecoinPriceClient()
+
+  private let mainnetUSDC = "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+  private let mainnetUSDT = "1:0xdac17f958d2ee523a2206206994597c13d831ec7"
+  private let optimismUSDC = "10:0x0b2c639c533813f4aa9d7837caf62653d097ff85"
+  private let mainnetUNI = "1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+
+  private func mapping(_ instrumentId: String) -> CryptoProviderMapping {
+    CryptoProviderMapping(
+      instrumentId: instrumentId, coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil)
+  }
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test("Reports the pegged-stablecoin sync provider")
+  func reportsSyncProvider() {
+    #expect(client.syncProvider == .peggedStablecoin)
+  }
+
+  @Test("Mainnet USDC daily-price range yields $1 for every day")
+  func mainnetUSDCRangeIsAllOne() async throws {
+    let start = try date("2024-01-01")
+    let end = try date("2024-01-03")
+    let prices = try await client.dailyPrices(for: mapping(mainnetUSDC), in: start...end)
+
+    #expect(prices.count == 3)
+    #expect(prices.keys.sorted() == ["2024-01-01", "2024-01-02", "2024-01-03"])
+    #expect(prices.values.allSatisfy { $0 == Decimal(1) })
+  }
+
+  @Test("Mainnet USDT single-day price is $1")
+  func mainnetUSDTSingleDayIsOne() async throws {
+    let price = try await client.dailyPrice(for: mapping(mainnetUSDT), on: try date("2024-06-01"))
+    #expect(price == Decimal(1))
+  }
+
+  @Test("Optimism USDC is recognised as pegged")
+  func optimismUSDCIsOne() async throws {
+    let price = try await client.dailyPrice(for: mapping(optimismUSDC), on: try date("2024-06-01"))
+    #expect(price == Decimal(1))
+  }
+
+  @Test("Non-stablecoin token has no provider mapping")
+  func nonStablecoinThrows() async throws {
+    await #expect(
+      throws: CryptoPriceError.noProviderMapping(
+        tokenId: mainnetUNI, provider: "Stablecoin peg")
+    ) {
+      _ = try await client.dailyPrice(for: mapping(mainnetUNI), on: try date("2024-06-01"))
+    }
+  }
+
+  @Test("Native asset id has no provider mapping")
+  func nativeThrows() async throws {
+    let native = "1:native"
+    await #expect(
+      throws: CryptoPriceError.noProviderMapping(
+        tokenId: native, provider: "Stablecoin peg")
+    ) {
+      _ = try await client.dailyPrice(for: mapping(native), on: try date("2024-06-01"))
+    }
+  }
+
+  @Test("Impersonator at a non-canonical address has no provider mapping")
+  func impersonatorThrows() async throws {
+    let impersonator = "1:0x000000000000000000000000000000000000dead"
+    await #expect(
+      throws: CryptoPriceError.noProviderMapping(
+        tokenId: impersonator, provider: "Stablecoin peg")
+    ) {
+      _ = try await client.dailyPrice(for: mapping(impersonator), on: try date("2024-06-01"))
+    }
+  }
+
+  @Test("Current prices report $1 for stablecoins and omit others")
+  func currentPricesPegStablecoinsOnly() async throws {
+    let prices = try await client.currentPrices(for: [
+      mapping(mainnetUSDC), mapping(mainnetUSDT), mapping(mainnetUNI),
+    ])
+
+    #expect(prices[mainnetUSDC] == Decimal(1))
+    #expect(prices[mainnetUSDT] == Decimal(1))
+    #expect(prices[mainnetUNI] == nil)
+    #expect(prices.count == 2)
+  }
+}

--- a/MoolahTests/Domain/Models/SyncProviderTests.swift
+++ b/MoolahTests/Domain/Models/SyncProviderTests.swift
@@ -26,6 +26,16 @@ struct SyncProviderTests {
     #expect(SyncProvider.binance.displayName == "Binance")
   }
 
+  @Test("Pegged stablecoin provider has a user-facing display name")
+  func peggedStablecoinDisplayName() {
+    #expect(SyncProvider.peggedStablecoin.displayName == "Pegged stablecoin")
+  }
+
+  @Test("Pegged stablecoin is enumerated in allCases")
+  func peggedStablecoinIsACase() {
+    #expect(SyncProvider.allCases.contains(.peggedStablecoin))
+  }
+
   @Test("Round-trips through JSON as its raw token")
   func jsonRoundTrip() throws {
     let data = try JSONEncoder().encode(SyncProvider.blockExplorer)

--- a/MoolahTests/Domain/Models/SyncProviderTests.swift
+++ b/MoolahTests/Domain/Models/SyncProviderTests.swift
@@ -28,7 +28,7 @@ struct SyncProviderTests {
 
   @Test("Pegged stablecoin provider has a user-facing display name")
   func peggedStablecoinDisplayName() {
-    #expect(SyncProvider.peggedStablecoin.displayName == "Pegged stablecoin")
+    #expect(SyncProvider.peggedStablecoin.displayName == "Pegged Stablecoin")
   }
 
   @Test("Pegged stablecoin is enumerated in allCases")

--- a/MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
@@ -93,6 +93,30 @@ struct CryptoSettingsAPIKeyTests {
     #expect(fixture.store.hasAlchemyApiKey == false)
   }
 
+  // MARK: - Trimming
+
+  @Test("saveAlchemyApiKey trims surrounding whitespace before persisting")
+  func saveAlchemyApiKeyTrimsWhitespace() throws {
+    let fixture = try makeFixture()
+    defer { fixture.alchemyKeychain.clear() }
+
+    fixture.store.saveAlchemyApiKey("  k  ")
+
+    #expect(fixture.store.hasAlchemyApiKey == true)
+    #expect(try fixture.alchemyKeychain.restoreString() == "k")
+  }
+
+  @Test("saveAlchemyApiKey ignores an all-whitespace key")
+  func saveAlchemyApiKeyIgnoresBlank() throws {
+    let fixture = try makeFixture()
+    defer { fixture.alchemyKeychain.clear() }
+
+    fixture.store.saveAlchemyApiKey("   ")
+
+    #expect(fixture.store.hasAlchemyApiKey == false)
+    #expect(try fixture.alchemyKeychain.restoreString() == nil)
+  }
+
   // MARK: - Service / account isolation
 
   @Test("saveAlchemyApiKey writes to the alchemy keychain, not coingecko")

--- a/MoolahTests/Features/Settings/CryptoSettingsCoinGeckoKeyTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsCoinGeckoKeyTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for the CoinGecko API key UI surface on `CryptoTokenStore`.
+/// The store wraps a `KeychainStore` keyed on
+/// (`com.moolah.api-keys`, `coingecko`) — the same entry
+/// `ProfileSession.resolveCoinGeckoApiKey()` reads on the price /
+/// resolution side, so a write here must round-trip through the
+/// keychain to be picked up by the next fetch.
+///
+/// Production uses the iCloud-synced keychain
+/// (`synchronizable: true`), but the macOS test runner cannot write to
+/// it (the runner isn't part of an iCloud-signed-in user session). We
+/// inject a per-test, non-synchronisable `KeychainStore` instance via
+/// the store's test seam initialiser. Each test uses a unique service
+/// id (`UUID()` in the prefix) so concurrent test runs cannot collide
+/// on the same keychain row, mirroring `KeychainStoreTests`.
+@Suite("CryptoTokenStore — CoinGecko API key")
+@MainActor
+struct CryptoSettingsCoinGeckoKeyTests {
+  private struct Fixture {
+    let store: CryptoTokenStore
+    let coingeckoKeychain: KeychainStore
+  }
+
+  /// Builds a store whose CoinGecko keychain entry is non-synchronisable
+  /// and namespaced under a per-test unique service id. Returns the
+  /// keychain handle too so tests can read the raw entry to confirm
+  /// round-trips.
+  private func makeFixture() throws -> Fixture {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let priceService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient()], database: database)
+    let alchemyService = "com.moolah.test.alchemy.\(UUID().uuidString)"
+    let coingeckoService = "com.moolah.test.coingecko.\(UUID().uuidString)"
+    let cryptocompareService = "com.moolah.test.cryptocompare.\(UUID().uuidString)"
+    let alchemyKeychain = KeychainStore(
+      service: alchemyService, account: "alchemy", synchronizable: false)
+    let coingeckoKeychain = KeychainStore(
+      service: coingeckoService, account: "coingecko", synchronizable: false)
+    let cryptocompareKeychain = KeychainStore(
+      service: cryptocompareService, account: "cryptocompare", synchronizable: false)
+    let store = CryptoTokenStore(
+      registry: registry,
+      cryptoPriceService: priceService,
+      conversionService: RecordingConversionService(),
+      apiKeyStore: coingeckoKeychain,
+      alchemyKeyStore: alchemyKeychain,
+      cryptocompareKeyStore: cryptocompareKeychain)
+    return Fixture(store: store, coingeckoKeychain: coingeckoKeychain)
+  }
+
+  // MARK: - Save / read round-trip
+
+  @Test("saveCoinGeckoApiKey persists through KeychainStore")
+  func saveCoinGeckoApiKeyPersists() throws {
+    let fixture = try makeFixture()
+    defer { fixture.coingeckoKeychain.clear() }
+
+    fixture.store.saveCoinGeckoApiKey("cg_test_round_trip_abc")
+
+    #expect(fixture.store.hasCoinGeckoApiKey == true)
+    let restored = try fixture.coingeckoKeychain.restoreString()
+    #expect(restored == "cg_test_round_trip_abc")
+  }
+
+  @Test("hasCoinGeckoApiKey is false on a fresh keychain entry")
+  func hasCoinGeckoApiKeyIsFalseWhenEmpty() throws {
+    let fixture = try makeFixture()
+    #expect(fixture.store.hasCoinGeckoApiKey == false)
+  }
+
+  @Test("clearCoinGeckoApiKey removes the keychain entry")
+  func clearCoinGeckoApiKeyRemovesEntry() throws {
+    let fixture = try makeFixture()
+    fixture.store.saveCoinGeckoApiKey("cg_test_clear_me")
+    fixture.store.clearCoinGeckoApiKey()
+    #expect(fixture.store.hasCoinGeckoApiKey == false)
+  }
+
+  // MARK: - Trimming
+
+  @Test("saveCoinGeckoApiKey trims surrounding whitespace before persisting")
+  func saveCoinGeckoApiKeyTrimsWhitespace() throws {
+    let fixture = try makeFixture()
+    defer { fixture.coingeckoKeychain.clear() }
+
+    fixture.store.saveCoinGeckoApiKey("  k  ")
+
+    #expect(fixture.store.hasCoinGeckoApiKey == true)
+    #expect(try fixture.coingeckoKeychain.restoreString() == "k")
+  }
+
+  @Test("saveCoinGeckoApiKey ignores an all-whitespace key")
+  func saveCoinGeckoApiKeyIgnoresBlank() throws {
+    let fixture = try makeFixture()
+    defer { fixture.coingeckoKeychain.clear() }
+
+    fixture.store.saveCoinGeckoApiKey("   ")
+
+    #expect(fixture.store.hasCoinGeckoApiKey == false)
+    #expect(try fixture.coingeckoKeychain.restoreString() == nil)
+  }
+}

--- a/MoolahTests/Features/Settings/CryptoSettingsCryptoCompareKeyTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsCryptoCompareKeyTests.swift
@@ -85,6 +85,30 @@ struct CryptoSettingsCryptoCompareKeyTests {
     #expect(fixture.store.hasCryptoCompareApiKey == false)
   }
 
+  // MARK: - Trimming
+
+  @Test("saveCryptoCompareApiKey trims surrounding whitespace before persisting")
+  func saveCryptoCompareApiKeyTrimsWhitespace() throws {
+    let fixture = try makeFixture()
+    defer { fixture.cryptocompareKeychain.clear() }
+
+    fixture.store.saveCryptoCompareApiKey("  k  ")
+
+    #expect(fixture.store.hasCryptoCompareApiKey == true)
+    #expect(try fixture.cryptocompareKeychain.restoreString() == "k")
+  }
+
+  @Test("saveCryptoCompareApiKey ignores an all-whitespace key")
+  func saveCryptoCompareApiKeyIgnoresBlank() throws {
+    let fixture = try makeFixture()
+    defer { fixture.cryptocompareKeychain.clear() }
+
+    fixture.store.saveCryptoCompareApiKey("   ")
+
+    #expect(fixture.store.hasCryptoCompareApiKey == false)
+    #expect(try fixture.cryptocompareKeychain.restoreString() == nil)
+  }
+
   // MARK: - Service / account isolation
 
   @Test("saveCryptoCompareApiKey writes to the cryptocompare keychain, not coingecko")

--- a/MoolahTests/Features/Settings/CryptoSettingsCryptoCompareKeyTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsCryptoCompareKeyTests.swift
@@ -1,16 +1,14 @@
-// MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
 import Foundation
 import GRDB
 import Testing
 
 @testable import Moolah
 
-/// Tests for the Alchemy API key UI surface on `CryptoTokenStore`.
+/// Tests for the CryptoCompare API key UI surface on `CryptoTokenStore`.
 /// The store wraps a `KeychainStore` keyed on
-/// (`com.moolah.api-keys`, `alchemy`) — the same entry
-/// `ProfileSession.resolveAlchemyApiKey()` reads on the sync side, so
-/// a write here must round-trip through the keychain to be picked up
-/// by the next sync cycle.
+/// (`com.moolah.api-keys`, `cryptocompare`) — the same entry the price
+/// client reads on the fetch side, so a write here must round-trip
+/// through the keychain to be picked up by the next price request.
 ///
 /// Production uses the iCloud-synced keychain
 /// (`synchronizable: true`), but the macOS test runner cannot write to
@@ -19,26 +17,20 @@ import Testing
 /// the store's test seam initialiser. Each test uses a unique service
 /// id (`UUID()` in the prefix) so concurrent test runs cannot collide
 /// on the same keychain row, mirroring `KeychainStoreTests`.
-///
-/// We still cover the "production wires the iCloud-synced keychain at
-/// the canonical service / account" claim via a separate test that
-/// inspects the production initialiser's plumbing without depending on
-/// a successful save.
-@Suite("CryptoTokenStore — Alchemy API key")
+@Suite("CryptoTokenStore — CryptoCompare API key")
 @MainActor
-struct CryptoSettingsAPIKeyTests {
+struct CryptoSettingsCryptoCompareKeyTests {
   private struct Fixture {
     let store: CryptoTokenStore
-    let alchemyKeychain: KeychainStore
+    let cryptocompareKeychain: KeychainStore
     let coingeckoKeychain: KeychainStore
   }
 
-  /// Builds a store whose Alchemy + CoinGecko keychain entries are
+  /// Builds a store whose CryptoCompare + CoinGecko keychain entries are
   /// non-synchronisable and namespaced under per-test unique service
   /// ids. Returns the keychain handles too so tests can read the raw
   /// entry to confirm round-trips.
   private func makeFixture() throws -> Fixture {
-    // Registry + price cache live on the profile-index DB.
     let database = try ProfileIndexDatabase.openInMemory()
     let registry = GRDBInstrumentRegistryRepository(database: database)
     let priceService = CryptoPriceService(
@@ -61,51 +53,51 @@ struct CryptoSettingsAPIKeyTests {
       cryptocompareKeyStore: cryptocompareKeychain)
     return Fixture(
       store: store,
-      alchemyKeychain: alchemyKeychain,
+      cryptocompareKeychain: cryptocompareKeychain,
       coingeckoKeychain: coingeckoKeychain)
   }
 
   // MARK: - Save / read round-trip
 
-  @Test("saveAlchemyApiKey persists through KeychainStore")
-  func saveAlchemyApiKeyPersists() throws {
+  @Test("saveCryptoCompareApiKey persists through KeychainStore")
+  func saveCryptoCompareApiKeyPersists() throws {
     let fixture = try makeFixture()
-    defer { fixture.alchemyKeychain.clear() }
+    defer { fixture.cryptocompareKeychain.clear() }
 
-    fixture.store.saveAlchemyApiKey("alch_test_round_trip_abc")
+    fixture.store.saveCryptoCompareApiKey("cc_test_round_trip_abc")
 
-    #expect(fixture.store.hasAlchemyApiKey == true)
-    let restored = try fixture.alchemyKeychain.restoreString()
-    #expect(restored == "alch_test_round_trip_abc")
+    #expect(fixture.store.hasCryptoCompareApiKey == true)
+    let restored = try fixture.cryptocompareKeychain.restoreString()
+    #expect(restored == "cc_test_round_trip_abc")
   }
 
-  @Test("hasAlchemyApiKey is false on a fresh keychain entry")
-  func hasAlchemyApiKeyIsFalseWhenEmpty() throws {
+  @Test("hasCryptoCompareApiKey is false on a fresh keychain entry")
+  func hasCryptoCompareApiKeyIsFalseWhenEmpty() throws {
     let fixture = try makeFixture()
-    #expect(fixture.store.hasAlchemyApiKey == false)
+    #expect(fixture.store.hasCryptoCompareApiKey == false)
   }
 
-  @Test("clearAlchemyApiKey removes the keychain entry")
-  func clearAlchemyApiKeyRemovesEntry() throws {
+  @Test("clearCryptoCompareApiKey removes the keychain entry")
+  func clearCryptoCompareApiKeyRemovesEntry() throws {
     let fixture = try makeFixture()
-    fixture.store.saveAlchemyApiKey("alch_test_clear_me")
-    fixture.store.clearAlchemyApiKey()
-    #expect(fixture.store.hasAlchemyApiKey == false)
+    fixture.store.saveCryptoCompareApiKey("cc_test_clear_me")
+    fixture.store.clearCryptoCompareApiKey()
+    #expect(fixture.store.hasCryptoCompareApiKey == false)
   }
 
   // MARK: - Service / account isolation
 
-  @Test("saveAlchemyApiKey writes to the alchemy keychain, not coingecko")
-  func saveAlchemyApiKeyTargetsAlchemyAccount() throws {
+  @Test("saveCryptoCompareApiKey writes to the cryptocompare keychain, not coingecko")
+  func saveCryptoCompareApiKeyTargetsCryptoCompareAccount() throws {
     let fixture = try makeFixture()
     defer {
-      fixture.alchemyKeychain.clear()
+      fixture.cryptocompareKeychain.clear()
       fixture.coingeckoKeychain.clear()
     }
 
-    fixture.store.saveAlchemyApiKey("alch_isolation_test_xyz")
+    fixture.store.saveCryptoCompareApiKey("cc_isolation_test_xyz")
 
-    #expect(try fixture.alchemyKeychain.restoreString() == "alch_isolation_test_xyz")
+    #expect(try fixture.cryptocompareKeychain.restoreString() == "cc_isolation_test_xyz")
     // The write must not spill into the CoinGecko slot. With per-test
     // unique service ids this is guaranteed by construction; the
     // assertion documents the contract for future readers.
@@ -114,17 +106,14 @@ struct CryptoSettingsAPIKeyTests {
 
   // MARK: - Privacy
 
-  @Test("saveAlchemyApiKey does not surface the key in store.error on success")
-  func saveAlchemyApiKeyNeverLogsKeyOnSuccess() throws {
+  @Test("saveCryptoCompareApiKey does not surface the key in store.error on success")
+  func saveCryptoCompareApiKeyNeverLogsKeyOnSuccess() throws {
     let fixture = try makeFixture()
-    defer { fixture.alchemyKeychain.clear() }
+    defer { fixture.cryptocompareKeychain.clear() }
 
-    let secret = "alch_privacy_canary_should_not_appear"
-    fixture.store.saveAlchemyApiKey(secret)
+    let secret = "cc_privacy_canary_should_not_appear"
+    fixture.store.saveCryptoCompareApiKey(secret)
 
-    // The store's `error` should not contain the secret value on
-    // either path. (On success it's nil; we still check just in case
-    // a future refactor sets an info string with the key inside.)
     #expect(fixture.store.error?.contains(secret) != true)
   }
 }

--- a/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
@@ -33,7 +33,7 @@ struct CompositeTokenResolutionClientTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: nil
+      coinGeckoApiKeyProvider: { nil }
     )
 
     let result = try await client.resolve(
@@ -70,7 +70,7 @@ struct CompositeTokenResolutionClientTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: nil
+      coinGeckoApiKeyProvider: { nil }
     )
 
     let result = try await client.resolve(
@@ -95,7 +95,7 @@ struct CompositeTokenResolutionClientTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: nil
+      coinGeckoApiKeyProvider: { nil }
     )
 
     let result = try await client.resolve(
@@ -130,7 +130,7 @@ struct CompositeTokenResolutionClientTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: nil
+      coinGeckoApiKeyProvider: { nil }
     )
 
     let result = try await client.resolve(
@@ -179,7 +179,7 @@ struct CompositeTokenResolutionClientTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: nil
+      coinGeckoApiKeyProvider: { nil }
     )
 
     // The spam contract from the issue's repro wallet, sharing ticker
@@ -228,7 +228,7 @@ struct CompositeTokenResolutionClientTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: nil
+      coinGeckoApiKeyProvider: { nil }
     )
 
     let eth = try await client.resolve(
@@ -296,7 +296,7 @@ final class PostConfirmBySymbolTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: "",
+      coinGeckoApiKeyProvider: { "" },
       networking: makeNetworking()
     )
     let result = try await client.resolve(
@@ -340,7 +340,7 @@ final class PostConfirmBySymbolTests {
     let client = CompositeTokenResolutionClient(
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
-      coinGeckoApiKey: "",
+      coinGeckoApiKeyProvider: { "" },
       networking: makeNetworking()
     )
     let result = try await client.resolve(

--- a/MoolahTests/Shared/CompositeTokenResolutionLocalFirstTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionLocalFirstTests.swift
@@ -38,7 +38,7 @@ final class CompositeTokenResolutionLocalFirstTests {
     let client = CompositeTokenResolutionClient(
       coinListData: Data(#"{"Data":{}}"#.utf8),
       exchangeInfoData: Data(#"{"symbols":[]}"#.utf8),
-      coinGeckoApiKey: nil,
+      coinGeckoApiKeyProvider: { nil },
       localResolver: local
     )
 
@@ -62,7 +62,7 @@ final class CompositeTokenResolutionLocalFirstTests {
       match: LocalContractMatch(coingeckoId: "usd-coin", symbol: "USDC", name: "USDC"))
     let client = CompositeTokenResolutionClient(
       networking: noHandlerNetworking(),
-      coinGeckoApiKey: "",
+      coinGeckoApiKeyProvider: { "" },
       localResolver: local
     )
 
@@ -83,7 +83,7 @@ final class CompositeTokenResolutionLocalFirstTests {
     let client = CompositeTokenResolutionClient(
       coinListData: Data(#"{"Data":{}}"#.utf8),
       exchangeInfoData: Data(#"{"symbols":[]}"#.utf8),
-      coinGeckoApiKey: nil,
+      coinGeckoApiKeyProvider: { nil },
       localResolver: local
     )
 

--- a/MoolahTests/Shared/CompositeTokenResolutionProKeyTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionProKeyTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// The resolver reads its CoinGecko key per request through the injected
+/// provider, so a Pro key entered mid-session routes the asset-platforms and
+/// contract-lookup round-trips to the Pro host on the next resolution — no
+/// reconstruction. Class-based + `.serialized` so the shared
+/// `StubURLProtocol.handlers` map is reset in `deinit`.
+@Suite("CompositeTokenResolutionClient pro key", .serialized)
+final class CompositeTokenResolutionProKeyTests {
+  deinit {
+    StubURLProtocol.handlers = [:]
+  }
+
+  private func makeNetworking() -> NetworkingServices {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return NetworkingServices(session: URLSession(configuration: config))
+  }
+
+  @Test
+  func resolveWithProKeyTargetsProHostWithKey() async throws {
+    let capturedURLs = LockedBox<[URL]>([])
+    StubURLProtocol.handlers["pro-api.coingecko.com:/api/v3/asset_platforms"] = { request in
+      if let url = request.url { capturedURLs.set(capturedURLs.get() + [url]) }
+      return (
+        HTTPURLResponse.ok(etag: ""),
+        Data(#"[{"id":"ethereum","chain_identifier":1,"name":"Ethereum"}]"#.utf8)
+      )
+    }
+    let contractKey =
+      "pro-api.coingecko.com:/api/v3/coins/ethereum/contract/"
+      + "0xdac17f958d2ee523a2206206994597c13d831ec7"
+    StubURLProtocol.handlers[contractKey] = { request in
+      if let url = request.url { capturedURLs.set(capturedURLs.get() + [url]) }
+      return (
+        HTTPURLResponse.ok(etag: ""),
+        Data(#"{"id":"tether","symbol":"usdt","name":"Tether","detail_platforms":{}}"#.utf8)
+      )
+    }
+
+    let client = CompositeTokenResolutionClient(
+      coinListData: Data(#"{ "Data": {} }"#.utf8),
+      exchangeInfoData: Data(#"{ "symbols": [] }"#.utf8),
+      coinGeckoApiKeyProvider: { "prokey" },
+      networking: makeNetworking()
+    )
+    let result = try await client.resolve(
+      chainId: 1,
+      contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      symbol: "USDT",
+      isNative: false
+    )
+
+    #expect(result.coingeckoId == "tether")
+    let hosts = Set(capturedURLs.get().compactMap(\.host))
+    #expect(hosts == ["pro-api.coingecko.com"])
+    let allKeyed = capturedURLs.get().allSatisfy { url in
+      URLComponents(url: url, resolvingAgainstBaseURL: false)?
+        .queryItems?.contains { $0.name == "x_cg_pro_api_key" && $0.value == "prokey" } ?? false
+    }
+    #expect(allKeyed)
+  }
+}

--- a/MoolahTests/Shared/CryptoPriceServiceStablecoinTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceStablecoinTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins `StablecoinPriceClient`'s role as the *last-resort* member of the
+/// price-service provider chain: it fills a recognised stablecoin with $1 only
+/// when every earlier provider declines, and is never consulted once an earlier
+/// provider returns real data.
+@Suite("CryptoPriceService — stablecoin peg fallback")
+struct CryptoPriceServiceStablecoinTests {
+  private let usdtInstrument = Instrument.crypto(
+    chainId: 1, contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+    symbol: "USDT", name: "Tether", decimals: 6
+  )
+  private let usdtMapping = CryptoProviderMapping(
+    instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
+    coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
+  )
+
+  private func makeService(
+    clients: [CryptoPriceClient],
+    database: DatabaseQueue,
+    now: @Sendable @escaping () -> Date
+  ) throws -> CryptoPriceService {
+    let utc = try #require(TimeZone(identifier: "UTC"))
+    return CryptoPriceService(
+      clients: clients, database: database, resolutionClient: nil, now: now, timeZone: utc)
+  }
+
+  private func midnight(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test("Peg fills a deep range when every earlier provider fails")
+  func pegFillsRangeWhenProvidersFail() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let frozen = try midnight("2024-03-01")
+    let failingStub = FixedCryptoPriceClient(
+      shouldFail: true, failureError: URLError(.notConnectedToInternet),
+      syncProvider: .cryptoCompare)
+    let service = try makeService(
+      clients: [failingStub, StablecoinPriceClient()], database: database, now: { frozen })
+
+    let start = try midnight("2024-01-01")
+    let end = try midnight("2024-01-05")
+    let series = try await service.prices(
+      for: usdtInstrument, mapping: usdtMapping, in: start...end)
+
+    #expect(series.count == 5)
+    #expect(series.allSatisfy { $0.price == Decimal(1) })
+  }
+
+  @Test("Peg is not consulted once an earlier provider returns real data")
+  func pegNotConsultedWhenProviderReturnsData() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let frozen = try midnight("2024-03-01")
+    let realStub = FixedCryptoPriceClient(
+      prices: [
+        "1:0xdac17f958d2ee523a2206206994597c13d831ec7": [
+          "2024-01-01": dec("0.88"),
+          "2024-01-02": dec("0.88"),
+          "2024-01-03": dec("0.88"),
+        ]
+      ],
+      syncProvider: .cryptoCompare)
+    let service = try makeService(
+      clients: [realStub, StablecoinPriceClient()], database: database, now: { frozen })
+
+    let start = try midnight("2024-01-01")
+    let end = try midnight("2024-01-03")
+    let series = try await service.prices(
+      for: usdtInstrument, mapping: usdtMapping, in: start...end)
+
+    #expect(series.count == 3)
+    #expect(series.allSatisfy { $0.price == dec("0.88") })
+    #expect(series.allSatisfy { $0.price != Decimal(1) })
+  }
+}

--- a/Shared/CompositeTokenResolutionClient.swift
+++ b/Shared/CompositeTokenResolutionClient.swift
@@ -4,7 +4,13 @@ import Foundation
 /// to populate provider-specific identifiers for a token.
 struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
   private let networking: NetworkingServices
-  private let coinGeckoApiKey: String?
+  /// Resolves the CoinGecko key per request (not once at construction) so a
+  /// Pro key entered in Settings flips contract-lookup and asset-platforms
+  /// calls from the free public host to the Pro host on the next resolution
+  /// without rebuilding the client. An empty key (the default) still queries
+  /// the free public host — the CoinGecko step is best-effort, never gated
+  /// off by an empty key.
+  private let coinGeckoApiKeyProvider: @Sendable () -> String?
   /// Offline `(chainId, contract) → CoinGecko id` source, consulted before any
   /// network provider so a token already known to the bundled / cached catalog
   /// is priced immediately. `nil` disables the local-first path (e.g. tests).
@@ -16,11 +22,11 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
 
   init(
     networking: NetworkingServices,
-    coinGeckoApiKey: String? = nil,
+    coinGeckoApiKeyProvider: @Sendable @escaping () -> String? = { nil },
     localResolver: LocalContractResolver? = nil
   ) {
     self.networking = networking
-    self.coinGeckoApiKey = coinGeckoApiKey
+    self.coinGeckoApiKeyProvider = coinGeckoApiKeyProvider
     self.localResolver = localResolver
     self.preloadedCoinList = nil
     self.preloadedExchangeInfo = nil
@@ -32,12 +38,12 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
   init(
     coinListData: Data,
     exchangeInfoData: Data,
-    coinGeckoApiKey: String?,
+    coinGeckoApiKeyProvider: @Sendable @escaping () -> String?,
     networking: NetworkingServices = NetworkingServices(),
     localResolver: LocalContractResolver? = nil
   ) {
     self.networking = networking
-    self.coinGeckoApiKey = coinGeckoApiKey
+    self.coinGeckoApiKeyProvider = coinGeckoApiKeyProvider
     self.localResolver = localResolver
     self.preloadedCoinList = coinListData
     self.preloadedExchangeInfo = exchangeInfoData
@@ -117,14 +123,17 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
 
   /// Step 2: CoinGecko contract-based lookup (ERC-20s only). Runs before
   /// Binance so a CG-confirmed symbol can authorise the Binance pair
-  /// attribution (#790). An empty `apiKey` falls through to the free
-  /// public CoinGecko endpoint so users without a Pro key still get
-  /// tokens like USDC priced. Tests that pass `nil` for the key opt out
-  /// of CoinGecko entirely so they don't hit the network.
+  /// attribution (#790). An empty key (`""`) falls through to the free
+  /// public CoinGecko endpoint so users without a Pro key still get tokens
+  /// like USDC priced; a configured key targets the Pro host. A provider
+  /// returning `nil` opts out of CoinGecko entirely so tests that don't stub
+  /// the network don't reach for it. The live factories pass a provider that
+  /// coalesces a missing keychain entry to `""`, so production always runs
+  /// the free-tier path. Resolution is best-effort — any error is swallowed.
   private func resolveFromCoinGecko(
     chainId: Int, contractAddress: String, result: inout TokenResolutionResult
   ) async {
-    guard let apiKey = coinGeckoApiKey else { return }
+    guard let apiKey = coinGeckoApiKeyProvider() else { return }
     do {
       let platformMapping = try await fetchAssetPlatforms(apiKey: apiKey)
       guard let platformSlug = platformMapping[chainId] else { return }

--- a/UITestSupport/UITestIdentifiers+CryptoSettings.swift
+++ b/UITestSupport/UITestIdentifiers+CryptoSettings.swift
@@ -21,6 +21,16 @@ extension UITestIdentifiers {
       "crypto.settings.registration.\(id)"
     }
 
+    /// Secure field for the CoinGecko API key. Pinned so a UI test can
+    /// drive the settings flow end-to-end.
+    public static let coinGeckoApiKeyField = "crypto.settings.coingecko.field"
+
+    /// "Save" button next to the CoinGecko API key entry field.
+    public static let coinGeckoApiKeySaveButton = "crypto.settings.coingecko.save"
+
+    /// "Remove" button shown when a CoinGecko key is already configured.
+    public static let coinGeckoApiKeyRemoveButton = "crypto.settings.coingecko.remove"
+
     /// Secure field for the Alchemy API key. Pinned so a UI test can
     /// drive the settings flow end-to-end.
     public static let alchemyApiKeyField = "crypto.settings.alchemy.field"

--- a/UITestSupport/UITestIdentifiers+CryptoSettings.swift
+++ b/UITestSupport/UITestIdentifiers+CryptoSettings.swift
@@ -31,6 +31,17 @@ extension UITestIdentifiers {
     /// "Remove" button shown when an Alchemy key is already configured.
     public static let alchemyApiKeyRemoveButton = "crypto.settings.alchemy.remove"
 
+    /// Secure field for the CryptoCompare API key. Pinned so a UI test
+    /// can drive the settings flow end-to-end.
+    public static let cryptoCompareApiKeyField = "crypto.settings.cryptocompare.field"
+
+    /// "Save" button next to the CryptoCompare API key entry field.
+    public static let cryptoCompareApiKeySaveButton = "crypto.settings.cryptocompare.save"
+
+    /// "Remove" button shown when a CryptoCompare key is already
+    /// configured.
+    public static let cryptoCompareApiKeyRemoveButton = "crypto.settings.cryptocompare.remove"
+
     /// Navigation row that opens the Discovered Tokens inbox.
     public static let discoveredTokensRow = "crypto.settings.discoveredTokens"
 

--- a/plans/2026-06-16-stablecoin-peg-and-cryptocompare-key-design.md
+++ b/plans/2026-06-16-stablecoin-peg-and-cryptocompare-key-design.md
@@ -1,0 +1,233 @@
+# Stablecoin $1 fallback + per-request CryptoCompare / CoinGecko keys
+
+**Date:** 2026-06-16
+**Status:** Design — approved, pending spec review
+
+## Problem
+
+The production net-worth graph and income/expense reports have gaps for
+crypto tokens whose only deep-history price source is CryptoCompare.
+CryptoCompare's `min-api.cryptocompare.com` now hard-requires an API key
+(HTTP 401 "API key required" for keyless requests). `CryptoCompareClient`
+sends no key and `RateLimitedHTTPClient` injects none, so every CryptoCompare
+fetch fails — `parseHistodayResponse` throws on the `{"Data":{},"Err":{…}}`
+error body and nothing is written. The fix (#1136) that routed CoinGecko-only
+tokens to CryptoCompare for deep history was written when CryptoCompare was
+keyless; CryptoCompare changed the rules underneath it.
+
+Concretely, in the production "Real Profile":
+
+- Tokens with a **Binance** symbol (ETH, BTC, ENS, UNI, OP, TIA, STRK, LDO)
+  have full history — Binance klines are keyless and date-anchored.
+- Tokens with **no Binance pair** (USDC, USDT, DAI, HEX, SAITABIT) are stuck:
+  CoinGecko serves only the last ~365 days and CryptoCompare 401s, so their
+  deep tails never fill. A held *priced* token that can't be valued on a day
+  drops that day from the graph (per-day Rule 11), blanking the chart.
+
+## Goals
+
+1. **USDC / USDT:** never leave a gap — fall back to a constant **$1.00 USD**
+   for any date no real provider can price. USDC and USDT are
+   fiat-collateralised, redeemable 1:1, so $1 is accurate to within rounding.
+2. **DAI excluded:** DAI is crypto-collateralised (a softer peg that can drift,
+   e.g. it fell with USDC during the March 2023 depeg). It keeps **real
+   prices**, restored by goal 3 — never a hard $1 peg.
+3. **CryptoCompare API key:** let the user enter a CryptoCompare (CoinDesk
+   Data) key in Settings so deep history works again for every CryptoCompare
+   token (DAI, HEX, and the rest). Takes effect immediately — no restart.
+4. **CoinGecko key (add-on):** make the existing CoinGecko key take effect
+   immediately too, instead of only at the next session construction.
+
+## Non-goals
+
+- Pegging DAI or any other stablecoin. Only USDC and USDT.
+- Making the token-discovery catalog / resolver pick up a new CoinGecko key
+  without a restart (see Scope boundary below). This change covers the
+  **price-fetch** path, which is what governs backfill.
+- Any schema, CloudKit, or migration change. All changes are read-time.
+
+## Background: how the price pipeline fills gaps
+
+`CryptoPriceService` holds an ordered `clients: [CryptoPriceClient]` chain
+(currently CoinGecko → CryptoCompare → Binance). Two layers matter:
+
+- **Provider loop** (`fetchRange` / `fetchAndExtendCache` in
+  `Shared/CryptoPriceService+FetchRange.swift`): iterates `clients` in order;
+  the **first client that returns a non-empty result** for the requested
+  (sub-)range persists it and stops. A client that throws
+  `CryptoPriceError.noProviderMapping` is skipped silently (a routing
+  decision, e.g. USDT has no Binance pair); other throws are recorded as the
+  attributed error and the loop continues. The loop is **first-non-empty-wins
+  per range**, not per-missing-date.
+- **Coverage layer** (`uncoveredSubRanges` / `prices(for:mapping:in:)`): gap
+  filling is driven here. The cache tracks each token as a contiguous
+  `[earliestDate, latestDate]` window; a requested range outside that window
+  produces a backward sub-range (older than `earliest`) and/or a forward
+  sub-range (newer than `latest`), and **each uncovered sub-range** is run
+  through the provider loop independently.
+
+**Consequence that shapes the design:** a token's deep tail is fetched as its
+own backward sub-range. So a provider placed **last** in the chain is consulted
+for a sub-range only when every real provider returned empty or threw for that
+sub-range. That is exactly "real price if available, else fallback" — without
+any change to the loop or coverage logic.
+
+A USDT→$1 fallback precedent already exists at
+`ProfileSession+Factories.swift:84-88` (Binance's `usdtRateLookup` returns
+`Decimal(1)` when CryptoCompare can't price USDT for quote conversion).
+
+## Design
+
+### 1. `StablecoinPriceClient` — a last-resort $1 provider
+
+A new `CryptoPriceClient` appended **last** in the `priceClients` array, after
+CoinGecko, CryptoCompare, and Binance.
+
+```
+struct StablecoinPriceClient: CryptoPriceClient, Sendable {
+  var syncProvider: SyncProvider { .peggedStablecoin }
+
+  func dailyPrices(for mapping: CryptoProviderMapping,
+                   in range: ClosedRange<Date>) async throws -> [String: Decimal]
+  func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal
+  func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal]
+}
+```
+
+Behaviour:
+
+- Parse `mapping.instrumentId` (`"<chainId>:<address>"`) into `chainId` +
+  `contractAddress`. A `"<chainId>:native"` id has no address → not a
+  stablecoin.
+- If `CanonicalTokenRegistry.symbol(chainId:contractAddress:)` is `"USDC"` or
+  `"USDT"`, return `1.0` for **every** UTC day in `range` (enumerated with
+  `Calendar.utc`, matching the date-key format the cache uses). Otherwise
+  `throw CryptoPriceError.noProviderMapping(tokenId:provider:)` so the
+  provider loop skips it.
+- `currentPrices` returns `1.0` for each canonical USDC/USDT mapping, omits the
+  rest.
+
+Because it's last and only answers for USDC/USDT, real providers win whenever
+they have data (a genuine USDC depeg day is captured); $1 only fills dates no
+real provider could. Filled $1 rows persist through the normal
+`mergeReturningDelta` / `persistDelta` path — it behaves like any other
+provider, so the graph and reports read it with no special-casing.
+
+**Address source:** reuse `CanonicalTokenRegistry` (already holds exactly the
+USDC/USDT canonical addresses per chain plus the reverse `symbol(...)` lookup,
+keyed on `(chainId, lowercased address)`). Gated to `{"USDC","USDT"}`. This
+keeps the pegged address set current as the vendored token lists regenerate,
+and inherits the registry's exact-address trust model — an impersonator at a
+different address resolves to `nil` and is **not** pegged.
+
+**`SyncProvider.peggedStablecoin`:** a new case purely for provider attribution
+symmetry. The client never throws a real error, so it never becomes an
+attributed outage.
+
+### 2. CryptoCompare API key — per-request injection
+
+- **Keychain:** account `"cryptocompare"`, service `KeychainServices.apiKeys`,
+  `synchronizable: true` — mirrors `"alchemy"` / `"coingecko"`.
+- **Client:** `CryptoCompareClient` gains a `apiKeyProvider: @Sendable () ->
+  String?` closure (replacing the keyless `init(http:)`). The URL builders
+  `histodayURL` / `priceMultiURL` append `URLQueryItem(name: "api_key",
+  value:)` when the resolved key is non-empty, and omit it otherwise (keyless
+  requests still 401, but that's no worse than today). Reading per request
+  means a freshly entered key works without a restart.
+- **Wiring:** in `ProfileSession+CryptoSync.swift`, add a `nonisolated static
+  func resolveCryptoCompareApiKey() -> String?` (mirrors
+  `resolveAlchemyApiKey`), passed as the provider closure where
+  `CryptoCompareClient` is constructed in
+  `ProfileSession.makeCryptoPriceService`.
+
+### 3. CoinGecko key — also per-request
+
+Currently the key and the host (`api.coingecko.com` free vs
+`pro-api.coingecko.com` pro) are baked at construction, so a newly entered key
+needs a restart.
+
+- `CoinGeckoClient` gains the same `apiKeyProvider: @Sendable () -> String?`
+  closure and holds **both** host-bound HTTP clients (free + pro). Per request:
+  resolve the key; if non-empty, target the pro host with `x_cg_pro_api_key`;
+  else the free host (current keyless behaviour).
+- Wiring reads the key per request via a `resolveCoinGeckoApiKey()` closure
+  from the `"coingecko"` keychain entry.
+
+**Scope boundary (confirmed):** this immediacy applies to the **price-fetch**
+clients only. The discovery catalog (`makeCoinGeckoCatalog`,
+`makeLookupCatalog`) and `CompositeTokenResolutionClient` continue to read the
+CoinGecko key once at session construction; a restart picks up a new key for
+those. Bounding the change here keeps it focused on backfill, which is the
+reported problem.
+
+### 4. Settings UI
+
+Add a **CryptoCompare** API-key section to `CryptoSettingsView` (likely
+`CryptoSettingsView+TokenList.swift`, alongside Alchemy and CoinGecko),
+mirroring the existing pattern exactly: a `SecureField` bound to local
+`@State`, a Save button that trims and persists then clears the field, a
+"Configured ✓ / Remove" state when a key exists, and a footer link to the
+CoinDesk Data signup page.
+
+New `CryptoTokenStore` members (mirroring the Alchemy ones):
+`cryptocompareKeyStore` field, `saveCryptoCompareApiKey(_:)`,
+`hasCryptoCompareApiKey` (computed), `clearCryptoCompareApiKey()`. Errors log
+`localizedDescription` only — never the key value.
+
+### 5. Help docs
+
+- **New task article:** `site/help/_src/topics/get-a-cryptocompare-api-key.html`
+  + a `toc.json` entry under parent `investments-and-crypto`. Task-type,
+  200–600 words, imperative steps, a Result section, HELP_GUIDE / BRAND_GUIDE
+  voice (second person, plain-spoken, Australian spelling, no banned marketing
+  words). Bold exact UI labels (`**Settings > Crypto Tokens**`), "select" for
+  cross-platform.
+- **Accuracy:** CryptoCompare is now **CoinDesk Data** (`developers.coindesk.com`
+  — the host in the 401 message). The signup / key-creation steps and the free
+  tier's limits **must be verified against the live developer portal** when the
+  article is written, not transcribed from memory.
+- **Light updates:** add the CryptoCompare key to `manage-crypto-tokens.html`
+  (which already documents Alchemy + CoinGecko key entry), and note the
+  key requirement next to CryptoCompare in
+  `supported-crypto-chains-and-providers.html`.
+
+## Testing (TDD — write tests first)
+
+- **`StablecoinPriceClient`** (new unit suite): returns $1 for canonical
+  USDC/USDT on mainnet and at least one L2 (Optimism), for a single date and a
+  multi-day range (every day present, all `1.0`); throws `noProviderMapping`
+  for a non-stablecoin token, for a `:native` id, and for an impersonator
+  address that is not the canonical USDC/USDT.
+- **Integration via `CryptoPriceService`** (TestBackend, in-memory GRDB): with
+  `StablecoinPriceClient` last, a USDT deep range where all real providers
+  return empty/throw fills $1 across the range; a range where a real provider
+  returns a non-$1 value keeps the real value (peg does **not** override).
+- **`CryptoCompareClient`** URL-builder tests: `api_key` appended when the
+  provider returns a non-empty key, omitted when nil/empty.
+- **`CoinGeckoClient`**: pro host + `x_cg_pro_api_key` when key present, free
+  host and no pro param when absent; key resolved per request (a provider that
+  flips from empty to non-empty changes the targeted host without
+  reconstruction).
+- **`CryptoTokenStore`**: save / has / clear the CryptoCompare key (mirror the
+  Alchemy store tests), against an injected in-memory `KeychainStore`.
+- **`help-review`** agent over the new + edited help articles before merge.
+
+## Risks / notes
+
+- **Interior cache holes:** coverage is tracked as a contiguous
+  `[earliest, latest]` window, so an interior hole inside a covered window is
+  not re-fetched. The $1 fallback fills contiguous backward/forward sub-ranges
+  (no interior holes introduced). This is a pre-existing property, unchanged.
+- **Keyless CryptoCompare still 401s.** Users without a key see no regression;
+  USDC/USDT are covered by the peg, and other CryptoCompare-only tokens (DAI,
+  HEX) stay gapped until a key is entered — exactly today's behaviour for them.
+- **Per-request keychain reads** add one keychain lookup per price fetch.
+  Fetches are already rate-limited and infrequent; negligible. Matches the
+  existing Alchemy per-request pattern.
+
+## Out-of-scope follow-ups
+
+- Making the CoinGecko discovery catalog / resolver pick up a key change
+  without a restart.
+- Pegging additional fiat-backed stablecoins (PYUSD, GUSD, TUSD, USDS) — easy
+  to add to the `{"USDC","USDT"}` gate later if wanted, but not in this change.

--- a/plans/2026-06-16-stablecoin-peg-and-cryptocompare-key-design.md
+++ b/plans/2026-06-16-stablecoin-peg-and-cryptocompare-key-design.md
@@ -36,14 +36,13 @@ Concretely, in the production "Real Profile":
    Data) key in Settings so deep history works again for every CryptoCompare
    token (DAI, HEX, and the rest). Takes effect immediately — no restart.
 4. **CoinGecko key (add-on):** make the existing CoinGecko key take effect
-   immediately too, instead of only at the next session construction.
+   immediately across **all** of its uses — price fetching, token resolution,
+   and the discovery catalog — instead of only at the next session
+   construction.
 
 ## Non-goals
 
 - Pegging DAI or any other stablecoin. Only USDC and USDT.
-- Making the token-discovery catalog / resolver pick up a new CoinGecko key
-  without a restart (see Scope boundary below). This change covers the
-  **price-fetch** path, which is what governs backfill.
 - Any schema, CloudKit, or migration change. All changes are read-time.
 
 ## Background: how the price pipeline fills gaps
@@ -140,25 +139,52 @@ attributed outage.
   `CryptoCompareClient` is constructed in
   `ProfileSession.makeCryptoPriceService`.
 
-### 3. CoinGecko key — also per-request
+### 3. CoinGecko key — per-request across all consumers
 
-Currently the key and the host (`api.coingecko.com` free vs
-`pro-api.coingecko.com` pro) are baked at construction, so a newly entered key
-needs a restart.
+Today the key is read **once** in `makeMarketDataServices`
+(`ProfileSession+Factories.swift:35-38`) into a `String?` and threaded into
+four consumers, each of which bakes the key (and its free-vs-pro host choice)
+at construction. A newly entered key therefore needs a restart everywhere.
 
-- `CoinGeckoClient` gains the same `apiKeyProvider: @Sendable () -> String?`
-  closure and holds **both** host-bound HTTP clients (free + pro). Per request:
-  resolve the key; if non-empty, target the pro host with `x_cg_pro_api_key`;
-  else the free host (current keyless behaviour).
-- Wiring reads the key per request via a `resolveCoinGeckoApiKey()` closure
-  from the `"coingecko"` keychain entry.
+The fix: stop threading a `String?`. Instead thread a single
+`@Sendable () -> String?` **key-provider closure** —
+`resolveCoinGeckoApiKey()`, a `nonisolated static func` that reads the
+`"coingecko"` keychain entry on each call (mirrors `resolveAlchemyApiKey`).
+Every consumer resolves the key (and selects host: empty → `api.coingecko.com`,
+non-empty → `pro-api.coingecko.com` + `x_cg_pro_api_key`) **per
+request/refresh**. `NetworkingServices.client(forHost:)` vends a fresh wrapper
+over a per-host cached rate gate, so switching host per call is cheap and safe.
 
-**Scope boundary (confirmed):** this immediacy applies to the **price-fetch**
-clients only. The discovery catalog (`makeCoinGeckoCatalog`,
-`makeLookupCatalog`) and `CompositeTokenResolutionClient` continue to read the
-CoinGecko key once at session construction; a restart picks up a new key for
-those. Bounding the change here keeps it focused on backfill, which is the
-reported problem.
+Consumer-by-consumer:
+
+- **`CoinGeckoClient`** (price): replace the stored `apiKey: String` + single
+  pre-bound `http` with the provider closure + a `NetworkingServices` handle
+  (or both host-bound clients). Per request: resolve key → pick host → build
+  URL with the `x_cg_pro_api_key` param when present. Its URL builders already
+  pick the base URL from the key (`baseURL(apiKey:)`); only the bound `http`
+  host must move from construction-time to per-request so it can't diverge from
+  the URL host.
+- **`CompositeTokenResolutionClient`** (resolver): smallest change — it already
+  selects host per request (`resolveFromCoinGecko` / `fetchAssetPlatforms`) and
+  holds `networking`. Replace the stored `coinGeckoApiKey: String?` with the
+  provider closure and call it at each use. Empty key keeps today's free-host
+  behaviour.
+- **`SQLiteCoinGeckoCatalog`** (discovery catalog, via `makeCoinGeckoCatalog`
+  and `makeLookupCatalog`): today its refresh uses **hardcoded free-tier URLs
+  and never sends the key** (`SQLiteCoinGeckoCatalog+Refresh.swift:75-86`), and
+  the host is baked at `make(...)`. Give the catalog the provider closure +
+  `NetworkingServices` so each `refreshIfStale()` resolves the key, selects the
+  host, and builds the `coins/list` / `asset_platforms` URLs with the pro key
+  param when present. This both honours a runtime key change and fixes the
+  latent gap where a configured Pro key was ignored by catalog refresh.
+
+  **Timing nuance:** catalog refresh is a once-per-session background task
+  gated by a 24 h max-age + ETag, not a per-user-action request. So
+  "immediately" here means **its next refresh** uses the current key — the
+  catalog is not re-fetched the instant a key is saved. Price fetching and
+  token resolution, which *are* request-driven, do pick up the new key on the
+  very next call. This matches the user intent (no stale baked-in key, no
+  restart needed) while being honest about the catalog's refresh cadence.
 
 ### 4. Settings UI
 
@@ -206,8 +232,16 @@ New `CryptoTokenStore` members (mirroring the Alchemy ones):
   provider returns a non-empty key, omitted when nil/empty.
 - **`CoinGeckoClient`**: pro host + `x_cg_pro_api_key` when key present, free
   host and no pro param when absent; key resolved per request (a provider that
-  flips from empty to non-empty changes the targeted host without
+  flips from empty to non-empty changes the targeted host + param without
   reconstruction).
+- **`CompositeTokenResolutionClient`**: the contract-lookup and
+  `asset_platforms` calls resolve the key per request — a provider flipping
+  empty → non-empty switches host + param on the next resolution, no
+  reconstruction.
+- **`SQLiteCoinGeckoCatalog`** refresh: builds `coins/list` / `asset_platforms`
+  URLs with the pro key param + pro host when the provider returns a key, and
+  the free host with no param when empty (a regression guard for the latent
+  "refresh ignored the key" gap). Use an injected provider + stub HTTP.
 - **`CryptoTokenStore`**: save / has / clear the CryptoCompare key (mirror the
   Alchemy store tests), against an injected in-memory `KeychainStore`.
 - **`help-review`** agent over the new + edited help articles before merge.
@@ -221,13 +255,13 @@ New `CryptoTokenStore` members (mirroring the Alchemy ones):
 - **Keyless CryptoCompare still 401s.** Users without a key see no regression;
   USDC/USDT are covered by the peg, and other CryptoCompare-only tokens (DAI,
   HEX) stay gapped until a key is entered — exactly today's behaviour for them.
-- **Per-request keychain reads** add one keychain lookup per price fetch.
-  Fetches are already rate-limited and infrequent; negligible. Matches the
-  existing Alchemy per-request pattern.
+- **Per-request keychain reads** add one keychain lookup per outbound CoinGecko
+  / CryptoCompare call (price fetch, token resolution, catalog refresh). These
+  are rate-limited and infrequent; negligible. Matches the existing Alchemy
+  per-request pattern. If it ever shows up, the provider closure can memoise
+  with invalidation on save — not needed now.
 
 ## Out-of-scope follow-ups
 
-- Making the CoinGecko discovery catalog / resolver pick up a key change
-  without a restart.
 - Pegging additional fiat-backed stablecoins (PYUSD, GUSD, TUSD, USDS) — easy
   to add to the `{"USDC","USDT"}` gate later if wanted, but not in this change.

--- a/plans/2026-06-16-stablecoin-peg-and-cryptocompare-key-plan.md
+++ b/plans/2026-06-16-stablecoin-peg-and-cryptocompare-key-plan.md
@@ -1,0 +1,246 @@
+# Stablecoin $1 Fallback + CryptoCompare Key + Per-request CoinGecko Key — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore deep-history price backfill for crypto tokens by (a) pegging held USDC/USDT to $1.00 as a last-resort provider, (b) letting the user enter a CryptoCompare API key, and (c) making the CoinGecko key take effect immediately across all consumers.
+
+**Architecture:** Add a `StablecoinPriceClient` last in the existing `CryptoPriceService` provider chain so real prices always win and $1 only fills otherwise-empty dates. Replace baked `String?` API keys with `@Sendable () -> String?` key-provider closures (mirroring the existing `LiveAlchemyClient(apiKeyProvider:)` pattern) for both CryptoCompare and CoinGecko, read from the keychain per request. Add a Settings field + keychain entry for the CryptoCompare key and a help article.
+
+**Tech stack:** Swift 6, Swift Testing (`@Suite`/`@Test`/`#expect`/`#require`), GRDB, SwiftUI, `just` build/test/format. Project conventions: one extension per protocol conformance; tests are Swift Testing not XCTest; never edit `project.pbxproj` (run `just generate` if a new file must join a target).
+
+**Conventions for every task:**
+- New `.swift` files under an existing source dir are picked up by `xcodegen` globs, but run `just generate` after adding files, before building.
+- Capture test output: `mkdir -p .agent-tmp && just test-mac <Filter> 2>&1 | tee .agent-tmp/out.txt`.
+- After each task: `just format` then `just format-check`, then `just build-mac`, then the task's tests. Commit only when green.
+- Worktree: `/Users/aj/Documents/code/moolah-project/moolah-native.stablecoin-peg-cc-key`, branch `stablecoin-peg-cc-key`. Use `git -C <worktree>` for git.
+
+---
+
+## File Structure
+
+**Create:**
+- `Backends/Stablecoin/StablecoinPriceClient.swift` — the $1 fallback `CryptoPriceClient`.
+- `MoolahTests/Backends/StablecoinPriceClientTests.swift` — unit tests.
+- `MoolahTests/Shared/CryptoPriceServiceStablecoinTests.swift` — integration (peg is last-resort).
+- `site/help/_src/topics/get-a-cryptocompare-api-key.html` — help article.
+
+**Modify:**
+- `Domain/Models/SyncProvider.swift` — add `.peggedStablecoin` case + display name.
+- `Backends/CryptoCompare/CryptoCompareClient.swift` — `apiKeyProvider` closure + `api_key` query item.
+- `Backends/CoinGecko/CoinGeckoClient.swift` — `apiKeyProvider` closure + per-request host/key.
+- `Shared/CompositeTokenResolutionClient.swift` — `apiKeyProvider` closure.
+- `Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift` + `SQLiteCoinGeckoCatalog+Refresh.swift` — key-aware refresh.
+- `App/ProfileSession+Factories.swift` — wire `StablecoinPriceClient` + key-provider closures.
+- `App/ProfileSession+CatalogFactory.swift` — pass key-provider closures to catalog/lookup.
+- `App/ProfileSession+CryptoSync.swift` — add `resolveCryptoCompareApiKey()` + `resolveCoinGeckoApiKey()`.
+- `Features/Settings/CryptoTokenStore.swift` — CryptoCompare key store methods.
+- `Features/Settings/CryptoSettingsView*.swift` — CryptoCompare key UI section.
+- `MoolahTests/.../CryptoTokenStoreTests*.swift`, `CryptoCompareClientTests.swift`, `CoinGeckoClientTests.swift`, `CompositeTokenResolutionClientTests.swift`, catalog refresh tests — extend.
+- `site/help/_src/toc.json`, `manage-crypto-tokens.html`, `supported-crypto-chains-and-providers.html` — register + cross-link.
+
+---
+
+## Task 1: Add `SyncProvider.peggedStablecoin`
+
+**Files:** Modify `Domain/Models/SyncProvider.swift`; Test `MoolahTests/Domain/SyncProviderTests.swift` (create if absent, else extend).
+
+- [ ] **Step 1 — failing test:** add a `@Test` asserting `SyncProvider.peggedStablecoin.displayName == "Pegged stablecoin"` and that `.peggedStablecoin` is in `SyncProvider.allCases`.
+- [ ] **Step 2 — run, expect fail** (`just test-mac SyncProviderTests`): compile error / missing case.
+- [ ] **Step 3 — implement:** add `case peggedStablecoin` to the enum and `case .peggedStablecoin: return "Pegged stablecoin"` to `displayName`. (String raw value defaults to `"peggedStablecoin"`.)
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — format + commit:** `feat(crypto): add SyncProvider.peggedStablecoin`.
+
+---
+
+## Task 2: `StablecoinPriceClient` + unit tests
+
+**Files:** Create `Backends/Stablecoin/StablecoinPriceClient.swift`, `MoolahTests/Backends/StablecoinPriceClientTests.swift`.
+
+Canonical addresses come from `CanonicalTokenRegistry.symbol(chainId:contractAddress:) -> String?` (returns `"USDC"`/`"USDT"` for the canonical mainnet/L2 addresses, `nil` otherwise). `CryptoProviderMapping.instrumentId` is `"<chainId>:<address>"` (or `"<chainId>:native"`). Enumerate days with `Calendar.utc` and key with the same `ISO8601DateFormatter` (`.withFullDate`) shape the other clients use.
+
+- [ ] **Step 1 — failing tests** (`StablecoinPriceClientTests`), Swift Testing `@Suite`:
+  - mainnet USDC `dailyPrices(in:)` over a 3-day range returns 3 entries all `Decimal(1)`, keyed `yyyy-MM-dd`.
+  - mainnet USDT `dailyPrice(on:)` returns `Decimal(1)`.
+  - an Optimism USDC address (look it up via `CanonicalTokenRegistry.bundled[10]["USDC"]`) returns `1`.
+  - a non-stablecoin token (e.g. UNI `1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984`) throws `CryptoPriceError.noProviderMapping`.
+  - a `:native` id (`1:native`) throws `noProviderMapping`.
+  - an impersonator (USDC symbol mapping but a random non-canonical address) throws `noProviderMapping`.
+  - `currentPrices(for:)` returns `1` for canonical USDC/USDT instrumentIds and omits others.
+  - `syncProvider == .peggedStablecoin`.
+- [ ] **Step 2 — run, expect fail** (type not found).
+- [ ] **Step 3 — implement** `struct StablecoinPriceClient: CryptoPriceClient, Sendable`:
+  - `var syncProvider: SyncProvider { .peggedStablecoin }`.
+  - private `func isPegged(_ instrumentId: String) -> Bool`: split on first `":"`, parse `chainId` `Int`, require an address segment (not `"native"`); return `CanonicalTokenRegistry.symbol(chainId:contractAddress:)` is `"USDC"` or `"USDT"`.
+  - `dailyPrices(for:in:)`: `guard isPegged(mapping.instrumentId) else { throw .noProviderMapping(tokenId: mapping.instrumentId, provider: "Stablecoin peg") }`; enumerate each UTC day from `range.lowerBound` to `range.upperBound` inclusive, key with the formatter, value `Decimal(1)`.
+  - `dailyPrice(for:on:)`: reuse `dailyPrices(for: mapping, in: date...date)`, return the single value (or throw `.noPriceAvailable` if absent — won't happen for pegged).
+  - `currentPrices(for:)`: map each `isPegged` mapping's `instrumentId → Decimal(1)`, skip others; return `[:]` when none.
+- [ ] **Step 4 — `just generate` then run, expect pass.**
+- [ ] **Step 5 — format + commit:** `feat(crypto): add StablecoinPriceClient $1 fallback provider`.
+
+---
+
+## Task 3: Wire `StablecoinPriceClient` last + integration test
+
+**Files:** Modify `App/ProfileSession+Factories.swift` (`makeCryptoPriceService`, the `priceClients` array ~lines 90-96). Test `MoolahTests/Shared/CryptoPriceServiceStablecoinTests.swift`.
+
+The integration test constructs `CryptoPriceService` directly with a fake `[CryptoPriceClient]` chain + an in-memory `DatabaseWriter` (copy the construction pattern from the nearest existing `CryptoPriceService` test — likely `CryptoPriceServiceCoalescingTests` / `CryptoPriceServiceTests`; reuse its `DatabaseQueue` + `GatedCryptoPriceClient`/stub helpers).
+
+- [ ] **Step 1 — failing integration tests:**
+  - Chain `[failingClient, StablecoinPriceClient()]` where `failingClient` throws for USDT over a deep range → `prices(for: usdtMapping, in: deepRange)` yields `Decimal(1)` for every day (peg filled the gap).
+  - Chain `[stubReturningRealValue, StablecoinPriceClient()]` where the stub returns e.g. `0.88` for the range → result is `0.88`, **not** `1` (real provider wins; peg never consulted because it's last and the loop stops on first non-empty).
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:** append `StablecoinPriceClient()` as the final element of the `priceClients` array in `makeCryptoPriceService` (after `binanceClient`). Add a one-line comment: last-resort $1 for canonical USDC/USDT only.
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — format + commit:** `feat(crypto): peg held USDC/USDT to $1 as last-resort price`.
+
+---
+
+## Task 4: CryptoCompare API key — client injection + URL-builder tests
+
+**Files:** Modify `Backends/CryptoCompare/CryptoCompareClient.swift`. Test: extend `MoolahTests/.../CryptoCompareClientTests.swift` (find it; if URL-builder tests live there, add there).
+
+Mirror `CoinGeckoClient.authQueryItem`. CryptoCompare authenticates via `api_key` query item.
+
+- [ ] **Step 1 — failing tests:**
+  - `CryptoCompareClient.histodayURL(symbol:from:to:)` is currently keyless and static; refactor so the key reaches the URL. Test that when the client's provider returns `"k123"`, the built request URL contains `api_key=k123`; when it returns `nil`/`""`, no `api_key` item is present. (If the URL builders must stay static for testability, make them take an `apiKey: String` param like CoinGecko's, and test the static builder directly: `histodayURL(symbol:from:to:apiKey:)` contains/omits `api_key`.)
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:**
+  - Add stored `private let apiKeyProvider: @Sendable () -> String?`. Change `init(http:)` → `init(http:apiKeyProvider:)`. Update all construction sites (Task 5 covers the live one; update any test/preview constructors to pass `{ nil }`).
+  - Add `private static func authQueryItem(apiKey: String) -> URLQueryItem?` returning `api_key` when non-empty.
+  - Thread the resolved key into `histodayURL` and `priceMultiURL` (add an `apiKey: String` parameter to each, append the auth item when present), and resolve `let apiKey = apiKeyProvider() ?? ""` at each call inside `dailyPrices`/`currentPrices`.
+- [ ] **Step 4 — run, expect pass; `just build-mac` to catch construction-site breaks.**
+- [ ] **Step 5 — format + commit:** `feat(crypto): send CryptoCompare api_key when configured`.
+
+---
+
+## Task 5: Wire CryptoCompare key resolver
+
+**Files:** Modify `App/ProfileSession+CryptoSync.swift` (add resolver), `App/ProfileSession+Factories.swift` (`makeCryptoPriceService`: pass provider to `CryptoCompareClient`; note the `usdtRateLookup` closure also builds with `cryptoCompareClient`, so it inherits the key automatically).
+
+- [ ] **Step 1 — implement resolver** (no separate unit test — it's a thin keychain read mirroring `resolveAlchemyApiKey`; covered indirectly):
+```swift
+nonisolated static func resolveCryptoCompareApiKey() -> String? {
+  let store = KeychainStore(
+    service: KeychainServices.apiKeys, account: "cryptocompare", synchronizable: true)
+  return try? store.restoreString()
+}
+```
+- [ ] **Step 2 — wire:** in `makeCryptoPriceService`, construct `CryptoCompareClient(http: ..., apiKeyProvider: { ProfileSession.resolveCryptoCompareApiKey() })`.
+- [ ] **Step 3 — `just build-mac`, run crypto price/test suites green.**
+- [ ] **Step 4 — format + commit:** `feat(crypto): resolve CryptoCompare key from keychain per request`.
+
+---
+
+## Task 6: CoinGecko client — per-request key + host
+
+**Files:** Modify `Backends/CoinGecko/CoinGeckoClient.swift`. Test: extend `MoolahTests/.../CoinGeckoClientTests.swift`.
+
+The static URL builders already take `apiKey: String` and pick host via `baseURL(apiKey:)` — keep them. The change is: the **instance** must resolve the key per request AND route the HTTP call to the matching host (today `http` is bound to one host at construction, so a runtime key flip would desync URL-host vs gate-host).
+
+- [ ] **Step 1 — failing test:** construct a `CoinGeckoClient` whose `apiKeyProvider` returns `""` then `"prokey"`; assert (via an injected fake networking/HTTP that records the requested host + URL) that an empty key targets `api.coingecko.com` with no `x_cg_pro_api_key`, and a non-empty key targets `pro-api.coingecko.com` with `x_cg_pro_api_key=prokey` — without reconstructing the client. (Follow the existing CoinGeckoClient test's HTTP-stub pattern; if it currently injects a single `RateLimitedHTTPClient`, extend the client to accept a host-resolving closure or a `NetworkingServices` so the stub can observe both hosts.)
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:** replace `apiKey: String` + single `http` with `apiKeyProvider: @Sendable () -> String?` and a way to obtain a host-bound client per request. Preferred: inject `networking: NetworkingServices` and call `networking.client(forHost: host)` per request, where `host = apiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"`. Resolve `let apiKey = apiKeyProvider() ?? ""` at the top of `dailyPrices`/`currentPrices`, pass it to the existing static URL builders, and dispatch through the per-request host client. Keep the URL builders unchanged.
+- [ ] **Step 4 — `just generate` (no new file, skip) → run, expect pass; `just build-mac`.**
+- [ ] **Step 5 — format + commit:** `refactor(crypto): resolve CoinGecko key + host per request`.
+
+---
+
+## Task 7: `CompositeTokenResolutionClient` — per-request key
+
+**Files:** Modify `Shared/CompositeTokenResolutionClient.swift`. Test: extend `MoolahTests/Shared/CompositeTokenResolutionClientTests.swift`.
+
+It already selects host per request (`resolveFromCoinGecko`, `fetchAssetPlatforms`) and holds `networking`. Replace stored `coinGeckoApiKey: String?` with `apiKeyProvider: @Sendable () -> String?`.
+
+- [ ] **Step 1 — failing test:** a resolution call with a provider returning `"prokey"` hits the pro host with `x_cg_pro_api_key`; with `""` hits the free host. (Reuse the suite's existing networking stub; the existing tests pass `coinGeckoApiKey:` — they'll need updating to pass a closure, which is expected churn.)
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:** change both `init`s to take `apiKeyProvider: @Sendable () -> String?` (production default `{ nil }`); store it; at each use `let apiKey = apiKeyProvider() ?? ""`. Today `resolveFromCoinGecko` early-returns when key is `nil`; preserve "empty ⇒ still query free host" semantics (don't early-return on empty — only treat the resolver as available; today it's passed `?? ""` so it always queries). Match current behaviour: free host queried even with empty key.
+- [ ] **Step 4 — update all construction sites** (`ProfileSession+Factories.swift` ×2) — Task 9 finalises wiring; for now pass `{ nil }` or the real resolver to keep the build green. Update test constructors.
+- [ ] **Step 5 — run, expect pass; format + commit:** `refactor(crypto): resolve CoinGecko key per request in token resolver`.
+
+---
+
+## Task 8: `SQLiteCoinGeckoCatalog` refresh — key-aware
+
+**Files:** Modify `Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift`, `SQLiteCoinGeckoCatalog+Refresh.swift`. Test: extend / create `MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift`.
+
+Today refresh uses hardcoded free-tier URL literals (`coinsListURL`, `assetPlatformsURL`) and a pre-bound `http`, ignoring the key entirely. Make the catalog hold a key provider + `NetworkingServices` and build refresh URLs/host per refresh.
+
+- [ ] **Step 1 — failing test:** drive a refresh with a key provider returning `"prokey"` against a recording HTTP stub; assert it requested `pro-api.coingecko.com/.../coins/list...` with `x_cg_pro_api_key=prokey` and `asset_platforms` likewise; with `""` it requested `api.coingecko.com` and no key param. (Build URLs via the existing `CoinGeckoClient` static helpers where possible — `assetPlatformsURL(apiKey:)` exists; add a `coinsListURL(apiKey:)` static builder to `CoinGeckoClient` with `include_platform=true` so both URL shapes live in one place and are unit-testable.)
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:**
+  - Add `static func coinsListURL(apiKey: String) -> URL` to `CoinGeckoClient` (path `coins/list`, query `include_platform=true` + auth item).
+  - Change `SQLiteCoinGeckoCatalog.make(...)`/init to take `apiKeyProvider: @Sendable () -> String?` + `networking: NetworkingServices` instead of a pre-bound `http`. In `+Refresh.swift`, resolve `let apiKey = apiKeyProvider() ?? ""`, build the two URLs via the new static builders, and obtain `networking.client(forHost:)` for the matching host. Remove the hardcoded URL literals.
+- [ ] **Step 4 — `just generate` (if new test file) → run, expect pass; `just build-mac`.**
+- [ ] **Step 5 — format + commit:** `fix(crypto): catalog refresh honours CoinGecko key + host`.
+
+---
+
+## Task 9: Thread CoinGecko key-provider through factories
+
+**Files:** Modify `App/ProfileSession+Factories.swift` (`makeMarketDataServices`, `makeCryptoPriceService`, `makeRegistryWiring`), `App/ProfileSession+CatalogFactory.swift` (`makeCoinGeckoCatalog`, `makeLookupCatalog`), `App/ProfileSession+CryptoSync.swift` (add `resolveCoinGeckoApiKey`).
+
+- [ ] **Step 1 — add resolver** in `ProfileSession+CryptoSync.swift`:
+```swift
+nonisolated static func resolveCoinGeckoApiKey() -> String? {
+  let store = KeychainStore(
+    service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true)
+  return try? store.restoreString()
+}
+```
+- [ ] **Step 2 — replace baked reads:** remove the one-shot `coinGeckoApiKey = try? apiKeyStore.restoreString()` reads; define `let cgKeyProvider: @Sendable () -> String? = { ProfileSession.resolveCoinGeckoApiKey() }` and pass it to: `CoinGeckoClient`, `CompositeTokenResolutionClient` (both sites), `makeCoinGeckoCatalog`, `makeLookupCatalog`, `makeCryptoPriceService`. Update those factory signatures from `coinGeckoApiKey: String?` to `coinGeckoApiKeyProvider: @Sendable () -> String?`. The `MarketDataServices.coinGeckoApiKey` field (consumed by `makeRegistryWiring`) becomes `coinGeckoApiKeyProvider`.
+- [ ] **Step 3 — `just build-mac`** — fix every call site the signature change touches until it compiles.
+- [ ] **Step 4 — run full crypto + resolver + catalog suites green.**
+- [ ] **Step 5 — format + commit:** `feat(crypto): CoinGecko key takes effect immediately everywhere`.
+
+---
+
+## Task 10: `CryptoTokenStore` — CryptoCompare key methods
+
+**Files:** Modify `Features/Settings/CryptoTokenStore.swift`. Test: extend the store's test file (mirror the Alchemy key tests — find `saveAlchemyApiKey`/`hasAlchemyApiKey` tests).
+
+- [ ] **Step 1 — failing tests** (inject an in-memory/temp `KeychainStore` as the existing Alchemy tests do): `saveCryptoCompareApiKey("k")` ⇒ `hasCryptoCompareApiKey == true`; `clearCryptoCompareApiKey()` ⇒ `false`; saving trims whitespace (match Alchemy behaviour).
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:** add `private let cryptocompareKeyStore: KeychainStore` (account `"cryptocompare"`, service `KeychainServices.apiKeys`, `synchronizable: true`) to both the designated and convenience initialisers (mirror `alchemyKeyStore`). Add `saveCryptoCompareApiKey(_:)`, `var hasCryptoCompareApiKey: Bool`, `clearCryptoCompareApiKey()` — copy the Alchemy method bodies, logging `localizedDescription` only.
+- [ ] **Step 4 — run, expect pass; `just build-mac`.**
+- [ ] **Step 5 — format + commit:** `feat(settings): store CryptoCompare API key in keychain`.
+
+---
+
+## Task 11: Settings UI — CryptoCompare key section
+
+**Files:** Modify the CoinGecko/Alchemy key section view (`Features/Settings/CryptoSettingsView+TokenList.swift` or wherever the CoinGecko key `SecureField` lives — grep `hasAlchemyApiKey`/`saveApiKey`).
+
+- [ ] **Step 1 — implement** a CryptoCompare section mirroring the CoinGecko one exactly: `@State private var cryptocompareApiKeyInput = ""`; a `SecureField`; a Save button → `store.saveCryptoCompareApiKey(trimmed)` then clear input; a "Configured ✓ / Remove" row gated on `store.hasCryptoCompareApiKey` → `store.clearCryptoCompareApiKey()`; a footer `Link` to `https://developers.coindesk.com` with copy explaining the key restores deep price history. Use exact section/label wording consistent with neighbours; apply `.accessibilityIdentifier` consistent with the Alchemy/CoinGecko fields if they have them.
+- [ ] **Step 2 — `just build-mac`; check no warnings** (`mcp__xcode__XcodeListNavigatorIssues` severity warning, or xcodebuild).
+- [ ] **Step 3 — `@agent-ui-review`** on the changed view; apply findings.
+- [ ] **Step 4 — format + commit:** `feat(settings): add CryptoCompare API key field`.
+
+---
+
+## Task 12: Help docs
+
+**Files:** Create `site/help/_src/topics/get-a-cryptocompare-api-key.html`; modify `site/help/_src/toc.json`, `manage-crypto-tokens.html`, `supported-crypto-chains-and-providers.html`.
+
+- [ ] **Step 1 — verify live signup flow:** WebFetch `https://developers.coindesk.com` (and its API-keys / free-tier pages) to confirm the current account-creation + key-generation steps and free-tier limits. CryptoCompare rebranded to CoinDesk Data — the article MUST reflect the live portal, not memory.
+- [ ] **Step 2 — write the article** as an `<article>` fragment following `add-an-exchange-account.html` structure (h1 verb-led title, one-sentence intro, **Before you start**, **Steps** (ol, imperative, verified URLs/labels), **Result**, **Related**). HELP_GUIDE/BRAND_GUIDE voice: second person, Australian spelling, no banned marketing words, bold exact UI labels (`**Settings**`), "select" not "click".
+- [ ] **Step 3 — register** in `toc.json` under `parent: "investments-and-crypto"`; add a CryptoCompare-key paragraph to `manage-crypto-tokens.html` and a key-required note beside CryptoCompare in `supported-crypto-chains-and-providers.html`; cross-link via Related.
+- [ ] **Step 4 — `just build-help` (or `just generate`)** to confirm it builds; `@agent-help-review` over the new + edited articles; apply findings.
+- [ ] **Step 5 — commit:** `docs(help): how to create and enter a CryptoCompare API key`.
+
+---
+
+## Task 13: Whole-suite verification + reviews
+
+- [ ] **Step 1 — `just format-check`** — zero diffs / zero SwiftLint violations (fix in place; never baseline).
+- [ ] **Step 2 — `just build-mac`** — zero warnings in user code.
+- [ ] **Step 3 — `just test`** (iOS + macOS) → `.agent-tmp/full.txt`; grep `failed|error:`; all green.
+- [ ] **Step 4 — review agents:** `@agent-code-review` (all changed Swift), `@agent-concurrency-review` (clients/closures/Sendable), `@agent-instrument-conversion-review` (peg path). Apply every Critical/Important/Minor finding (separate follow-up only if truly out of scope, and ask first).
+- [ ] **Step 5 — push branch, open PR** with a body summarising the three changes + the production diagnosis that motivated them; then land via the `landing-prs` skill (merge queue / automerge). Monitor to merged.
+
+---
+
+## Self-review notes (author)
+- Spec coverage: peg (T1-3), CryptoCompare key client+wire+UI+store (T4,5,10,11), CoinGecko all-consumers per-request (T6-9), help (T12), verification/reviews (T13). All spec sections mapped.
+- DAI deliberately not pegged — `isPegged` gate is `{"USDC","USDT"}` only (T2).
+- Type consistency: `apiKeyProvider: @Sendable () -> String?` used uniformly across CryptoCompare/CoinGecko clients, resolver, catalog; factory params renamed to `…Provider`. Resolver names: `resolveCryptoCompareApiKey`, `resolveCoinGeckoApiKey` (mirror `resolveAlchemyApiKey`).
+- Risk: T6-9 is the broad refactor; keep build green after each by updating all call sites + test constructors in the same task.

--- a/site/help/_src/toc.json
+++ b/site/help/_src/toc.json
@@ -47,6 +47,7 @@
     { "slug": "add-a-crypto-wallet", "title": "Add a crypto wallet account", "parent": "investments-and-crypto" },
     { "slug": "add-an-exchange-account", "title": "Add an exchange account", "parent": "investments-and-crypto" },
     { "slug": "manage-crypto-tokens", "title": "Manage crypto tokens, discovered tokens, and spam", "parent": "investments-and-crypto" },
+    { "slug": "get-a-cryptocompare-api-key", "title": "Get a CryptoCompare API key", "parent": "investments-and-crypto" },
 
     { "slug": "importing-data", "title": "Importing data", "parent": null },
     { "slug": "import-a-csv-file", "title": "Import a CSV file", "parent": "importing-data" },

--- a/site/help/_src/topics/get-a-cryptocompare-api-key.html
+++ b/site/help/_src/topics/get-a-cryptocompare-api-key.html
@@ -1,29 +1,20 @@
 <article>
   <h1>Get a CryptoCompare API key</h1>
-  <p>Create a free CryptoCompare API key and enter it in Moolah to restore deep price history for tokens that only CryptoCompare can price, such as DAI.</p>
+  <p>Create a free CryptoCompare API key and enter it in Moolah to restore deep price history for tokens that only CryptoCompare can price, such as DAI. The key is yours. Moolah stores it in your iCloud Keychain and queries CryptoCompare directly from your device — never through a Moolah server.</p>
 
   <h2>Why you might need one</h2>
   <p>CryptoCompare — now called CoinDesk Data — is one of the price sources Moolah falls back to for crypto tokens. It used to work without a key. It now needs a free API key for the deep historical data behind it. For most tokens this doesn't matter, because CoinGecko prices them. But a few tokens, like DAI, rely on CryptoCompare for their full price history. Without a key, their older prices can't backfill.</p>
-  <p>The key is optional. Crypto sync, current prices, and most history all work without it. Add a key only if you hold a token whose older prices aren't filling in.</p>
-
-  <h2>Before you start</h2>
-  <ul>
-    <li>You'll create a free account on the CoinDesk Data developer portal. No payment details are needed for the free tier.</li>
-    <li>The key is yours. Moolah stores it privately in your iCloud Keychain and queries CryptoCompare directly from your device — never through a Moolah server.</li>
-  </ul>
+  <p>The key is optional. Crypto sync, current prices, and most history all work without it. If a token's older prices aren't filling in, add a key.</p>
 
   <h2>Steps</h2>
-  <p>First, create the key on the developer portal:</p>
+  <p>First, create the key on the CoinDesk Data developer portal. No payment details are needed for the free tier. Then enter it in Moolah.</p>
   <ol>
-    <li>Go to the CoinDesk Data developer portal at <strong>developers.coindesk.com</strong>.</li>
+    <li>Go to the CoinDesk Data developer portal at <a href="https://developers.coindesk.com">developers.coindesk.com</a>.</li>
     <li>Select <strong>Log In / Sign Up</strong> and create a free account.</li>
     <li>Open your API keys page from your account profile.</li>
     <li>Create a new API key and give it a name you'll recognise, such as "Moolah".</li>
     <li>Copy the key.</li>
-  </ol>
-  <p>Then enter it in Moolah:</p>
-  <ol>
-    <li>Open <strong>Settings &gt; Crypto Tokens</strong>.</li>
+    <li>In Moolah, open <strong>Settings &gt; Crypto Tokens</strong>.</li>
     <li>In the <strong>CryptoCompare</strong> section, paste the key into the <strong>CryptoCompare API Key</strong> field.</li>
     <li>Select <strong>Save</strong>.</li>
   </ol>

--- a/site/help/_src/topics/get-a-cryptocompare-api-key.html
+++ b/site/help/_src/topics/get-a-cryptocompare-api-key.html
@@ -1,0 +1,40 @@
+<article>
+  <h1>Get a CryptoCompare API key</h1>
+  <p>Create a free CryptoCompare API key and enter it in Moolah to restore deep price history for tokens that only CryptoCompare can price, such as DAI.</p>
+
+  <h2>Why you might need one</h2>
+  <p>CryptoCompare — now called CoinDesk Data — is one of the price sources Moolah falls back to for crypto tokens. It used to work without a key. It now needs a free API key for the deep historical data behind it. For most tokens this doesn't matter, because CoinGecko prices them. But a few tokens, like DAI, rely on CryptoCompare for their full price history. Without a key, their older prices can't backfill.</p>
+  <p>The key is optional. Crypto sync, current prices, and most history all work without it. Add a key only if you hold a token whose older prices aren't filling in.</p>
+
+  <h2>Before you start</h2>
+  <ul>
+    <li>You'll create a free account on the CoinDesk Data developer portal. No payment details are needed for the free tier.</li>
+    <li>The key is yours. Moolah stores it privately in your iCloud Keychain and queries CryptoCompare directly from your device — never through a Moolah server.</li>
+  </ul>
+
+  <h2>Steps</h2>
+  <p>First, create the key on the developer portal:</p>
+  <ol>
+    <li>Go to the CoinDesk Data developer portal at <strong>developers.coindesk.com</strong>.</li>
+    <li>Select <strong>Log In / Sign Up</strong> and create a free account.</li>
+    <li>Open your API keys page from your account profile.</li>
+    <li>Create a new API key and give it a name you'll recognise, such as "Moolah".</li>
+    <li>Copy the key.</li>
+  </ol>
+  <p>Then enter it in Moolah:</p>
+  <ol>
+    <li>Open <strong>Settings &gt; Crypto Tokens</strong>.</li>
+    <li>In the <strong>CryptoCompare</strong> section, paste the key into the <strong>CryptoCompare API Key</strong> field.</li>
+    <li>Select <strong>Save</strong>.</li>
+  </ol>
+  <p>To swap in a new key later, select <strong>Remove</strong>, then paste and save the new one.</p>
+
+  <h2>Result</h2>
+  <p>The CryptoCompare section shows <strong>Configured</strong>. On the next sync, Moolah backfills the deep price history for affected tokens, so their older balances value correctly.</p>
+
+  <h2>Related</h2>
+  <ul>
+    <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+    <li><a href="supported-crypto-chains-and-providers.html">Supported crypto chains and data providers</a></li>
+  </ul>
+</article>

--- a/site/help/_src/topics/manage-crypto-tokens.html
+++ b/site/help/_src/topics/manage-crypto-tokens.html
@@ -20,6 +20,14 @@
     <li>Select <strong>Save</strong>.</li>
   </ol>
 
+  <h2>Optional: add a CryptoCompare key for deep history</h2>
+  <p>CryptoCompare — now CoinDesk Data — is one of Moolah's fallback price sources. It now needs a free API key for its deep historical data. Most tokens don't rely on it, but a few, such as DAI, need it to backfill their older prices. Add a key only if a token's older balances aren't valuing correctly.</p>
+  <ol>
+    <li>In the <strong>CryptoCompare</strong> section, paste your key into the <strong>CryptoCompare API Key</strong> field.</li>
+    <li>Select <strong>Save</strong>.</li>
+  </ol>
+  <p>For where to create the key, see <a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a>.</p>
+
   <h2>What gets priced: registered tokens</h2>
   <p>The <strong>Registered Tokens</strong> list is the set of tokens Moolah prices. Native chain tokens (ETH on Ethereum, OP Mainnet, and Base) are priced automatically. You add other tokens as you want them tracked.</p>
   <ol>

--- a/site/help/_src/topics/manage-crypto-tokens.html
+++ b/site/help/_src/topics/manage-crypto-tokens.html
@@ -26,7 +26,7 @@
     <li>In the <strong>CryptoCompare</strong> section, paste your key into the <strong>CryptoCompare API Key</strong> field.</li>
     <li>Select <strong>Save</strong>.</li>
   </ol>
-  <p>For where to create the key, see <a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a>.</p>
+  <p>To create a key, see <a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a>.</p>
 
   <h2>What gets priced: registered tokens</h2>
   <p>The <strong>Registered Tokens</strong> list is the set of tokens Moolah prices. Native chain tokens (ETH on Ethereum, OP Mainnet, and Base) are priced automatically. You add other tokens as you want them tracked.</p>

--- a/site/help/_src/topics/supported-crypto-chains-and-providers.html
+++ b/site/help/_src/topics/supported-crypto-chains-and-providers.html
@@ -27,7 +27,7 @@
       <tr><td>Blockscout</td><td>Native and internal ETH activity for crypto wallets</td><td>Required. Runs on every sync; it's the authoritative source, so a failure stops the sync. No key needed.</td></tr>
       <tr><td>Coinstash</td><td>Exchange account sync</td><td>Uses your own read-only API token, configured per account.</td></tr>
       <tr><td>CoinGecko</td><td>Token prices, highest priority</td><td>Optional. Add a free Demo API key in <strong>Settings &gt; Crypto Tokens</strong> to use it.</td></tr>
-      <tr><td>CryptoCompare</td><td>Token prices, fallback</td><td>No key needed.</td></tr>
+      <tr><td>CryptoCompare</td><td>Token prices, fallback</td><td>Requires a free API key for deep price history, configured in <strong>Settings &gt; Crypto Tokens</strong>.</td></tr>
       <tr><td>Binance</td><td>Token prices, fallback</td><td>No key needed.</td></tr>
       <tr><td>Frankfurter</td><td>Fiat exchange rates</td><td>No key needed.</td></tr>
       <tr><td>Yahoo Finance</td><td>Stock prices and ticker search</td><td>No key needed.</td></tr>
@@ -39,6 +39,7 @@
     <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
     <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
     <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+    <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
     <li><a href="sync-and-privacy.html">Sync and privacy</a></li>
   </ul>
 </article>

--- a/site/help/_src/topics/supported-crypto-chains-and-providers.html
+++ b/site/help/_src/topics/supported-crypto-chains-and-providers.html
@@ -26,7 +26,7 @@
       <tr><td>Alchemy</td><td>ERC-20 token transfers for crypto wallets</td><td>Required. Runs on every sync. Uses your own API key, configured in <strong>Settings &gt; Crypto Tokens</strong>.</td></tr>
       <tr><td>Blockscout</td><td>Native and internal ETH activity for crypto wallets</td><td>Required. Runs on every sync; it's the authoritative source, so a failure stops the sync. No key needed.</td></tr>
       <tr><td>Coinstash</td><td>Exchange account sync</td><td>Uses your own read-only API token, configured per account.</td></tr>
-      <tr><td>CoinGecko</td><td>Token prices, highest priority</td><td>Optional. Add a free Demo API key in <strong>Settings &gt; Crypto Tokens</strong> to use it.</td></tr>
+      <tr><td>CoinGecko</td><td>Token prices, highest priority</td><td>No key needed. Optionally, add a free Demo API key in <strong>Settings &gt; Crypto Tokens</strong> for more request headroom.</td></tr>
       <tr><td>CryptoCompare</td><td>Token prices, fallback</td><td>Requires a free API key for deep price history, configured in <strong>Settings &gt; Crypto Tokens</strong>.</td></tr>
       <tr><td>Binance</td><td>Token prices, fallback</td><td>No key needed.</td></tr>
       <tr><td>Frankfurter</td><td>Fiat exchange rates</td><td>No key needed.</td></tr>

--- a/site/help/_src/topics/sync-and-privacy.html
+++ b/site/help/_src/topics/sync-and-privacy.html
@@ -12,7 +12,7 @@
 
   <p>Exchange API tokens are a special case. They're stored in iCloud Keychain, which is Apple's encrypted store for secrets. iCloud Keychain is separate from CloudKit. It syncs the token across your devices so you don't have to paste it on every one. The token stays out of the regular profile data.</p>
 
-  <p>Your price-provider keys — the Alchemy key and the optional CoinGecko key — work the same way. They're kept in iCloud Keychain too, so you enter them once and they follow you to your other devices, separate from your profile data.</p>
+  <p>Your price-provider keys — the Alchemy key, the optional CoinGecko key, and the optional CryptoCompare key — work the same way. They're kept in iCloud Keychain too, so you enter them once and they follow you to your other devices, separate from your profile data.</p>
 
   <h2>Third-party providers</h2>
   <p>If you add a crypto wallet or an exchange account, your device talks directly to the relevant providers. That's Alchemy, Blockscout, CoinGecko, and Coinstash, depending on what you've set up. Frankfurter is used for fiat exchange rates. These calls go from your device to those providers; they don't go through Moolah. The API keys and tokens you supply are yours, used by your device.</p>

--- a/site/help/_src/topics/what-syncs-and-what-stays-on-device.html
+++ b/site/help/_src/topics/what-syncs-and-what-stays-on-device.html
@@ -26,7 +26,7 @@
 
   <h2>Stored in iCloud Keychain</h2>
   <p>Exchange API tokens are kept in iCloud Keychain, Apple's encrypted store for secrets. This is separate from CloudKit. iCloud Keychain syncs the token across your devices so you don't have to paste it on each one. The token still lives separately from your profile data.</p>
-  <p>Your price-provider API keys — your Alchemy key and optional CoinGecko key — are kept in iCloud Keychain the same way, so you only enter them once and they follow you to your other devices.</p>
+  <p>Your price-provider API keys — your Alchemy key, your optional CoinGecko key, and the optional CryptoCompare key — are kept in iCloud Keychain the same way, so you only enter them once and they follow you to your other devices.</p>
 
   <h2>Stays on each device</h2>
   <p>Some things are specific to a device and don't follow you around. Each device keeps its own copy.</p>

--- a/site/help/accounts.html
+++ b/site/help/accounts.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/add-a-crypto-wallet.html
+++ b/site/help/add-a-crypto-wallet.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html" aria-current="page">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/add-an-account.html
+++ b/site/help/add-an-account.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/add-an-exchange-account.html
+++ b/site/help/add-an-exchange-account.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html" aria-current="page">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/add-an-investment-account.html
+++ b/site/help/add-an-investment-account.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/add-or-edit-a-transaction.html
+++ b/site/help/add-or-edit-a-transaction.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/analyse-net-worth-and-forecast.html
+++ b/site/help/analyse-net-worth-and-forecast.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/assign-a-transaction-to-an-earmark.html
+++ b/site/help/assign-a-transaction-to-an-earmark.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/balance-looks-wrong.html
+++ b/site/help/balance-looks-wrong.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/categories.html
+++ b/site/help/categories.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/create-an-earmark.html
+++ b/site/help/create-an-earmark.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/create-and-manage-import-rules.html
+++ b/site/help/create-and-manage-import-rules.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/create-and-organise-categories.html
+++ b/site/help/create-and-organise-categories.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/create-your-first-profile.html
+++ b/site/help/create-your-first-profile.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/csv-import-needs-setup.html
+++ b/site/help/csv-import-needs-setup.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/delete-a-transaction.html
+++ b/site/help/delete-a-transaction.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/earmarks-and-budgets.html
+++ b/site/help/earmarks-and-budgets.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/edit-hide-reorder-or-delete-an-account.html
+++ b/site/help/edit-hide-reorder-or-delete-an-account.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/export-or-import-a-profile.html
+++ b/site/help/export-or-import-a-profile.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/filter-and-search-transactions.html
+++ b/site/help/filter-and-search-transactions.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/get-a-cryptocompare-api-key.html
+++ b/site/help/get-a-cryptocompare-api-key.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Record an investment value snapshot — moolah.rocks help</title>
+  <title>Get a CryptoCompare API key — moolah.rocks help</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -72,12 +72,12 @@
     <li><a href="investments-and-crypto.html">Investments and crypto</a>
       <ul>
         <li><a href="add-an-investment-account.html">Add an investment account</a></li>
-        <li><a href="record-an-investment-snapshot.html" aria-current="page">Record an investment value snapshot</a></li>
+        <li><a href="record-an-investment-snapshot.html">Record an investment value snapshot</a></li>
         <li><a href="record-a-trade.html">Record a trade</a></li>
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
-        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html" aria-current="page">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>
@@ -118,35 +118,43 @@
     </aside>
     <main class="help-content">
       <article>
-  <h1>Record an investment value snapshot</h1>
-  <p>Record the current value of a Recorded-value investment account whenever you check the balance.</p>
+  <h1>Get a CryptoCompare API key</h1>
+  <p>Create a free CryptoCompare API key and enter it in Moolah to restore deep price history for tokens that only CryptoCompare can price, such as DAI.</p>
+
+  <h2>Why you might need one</h2>
+  <p>CryptoCompare — now called CoinDesk Data — is one of the price sources Moolah falls back to for crypto tokens. It used to work without a key. It now needs a free API key for the deep historical data behind it. For most tokens this doesn't matter, because CoinGecko prices them. But a few tokens, like DAI, rely on CryptoCompare for their full price history. Without a key, their older prices can't backfill.</p>
+  <p>The key is optional. Crypto sync, current prices, and most history all work without it. Add a key only if you hold a token whose older prices aren't filling in.</p>
 
   <h2>Before you start</h2>
-  <p>This article applies to investment accounts set to <strong>Recorded value</strong>. If your account is set to Calculated from trades, record your activity as trades instead — see <a href="record-a-trade.html">Record a trade</a>.</p>
-  <p>You don't need a snapshot every day or even every week — whenever you check the account is enough.</p>
+  <ul>
+    <li>You'll create a free account on the CoinDesk Data developer portal. No payment details are needed for the free tier.</li>
+    <li>The key is yours. Moolah stores it privately in your iCloud Keychain and queries CryptoCompare directly from your device — never through a Moolah server.</li>
+  </ul>
 
   <h2>Steps</h2>
+  <p>First, create the key on the developer portal:</p>
   <ol>
-    <li>Open the investment account from the sidebar.</li>
-    <li>Select <strong>Record Value</strong> (or <strong>+</strong> in the toolbar).</li>
-    <li>Enter the <strong>Date</strong> the value applies to. The default is today, but you can back-date a snapshot to the statement date.</li>
-    <li>Enter the <strong>Value</strong> in the account's currency.</li>
+    <li>Go to the CoinDesk Data developer portal at <strong>developers.coindesk.com</strong>.</li>
+    <li>Select <strong>Log In / Sign Up</strong> and create a free account.</li>
+    <li>Open your API keys page from your account profile.</li>
+    <li>Create a new API key and give it a name you'll recognise, such as "Moolah".</li>
+    <li>Copy the key.</li>
+  </ol>
+  <p>Then enter it in Moolah:</p>
+  <ol>
+    <li>Open <strong>Settings &gt; Crypto Tokens</strong>.</li>
+    <li>In the <strong>CryptoCompare</strong> section, paste the key into the <strong>CryptoCompare API Key</strong> field.</li>
     <li>Select <strong>Save</strong>.</li>
   </ol>
-
-  <h2>How snapshots show up</h2>
-  <p>Each snapshot appears in the account's values list, newest at the top. The net worth graph holds the value steady between snapshots and steps to the new value on the date you recorded it. Recording occasional snapshots is enough to keep the graph honest.</p>
-
-  <h2>Editing or removing a snapshot</h2>
-  <p>To remove a snapshot, swipe its row in the values list (iOS) or right-click and select <strong>Delete</strong> (Mac). To change a value or its date, delete the snapshot and record a fresh one.</p>
+  <p>To swap in a new key later, select <strong>Remove</strong>, then paste and save the new one.</p>
 
   <h2>Result</h2>
-  <p>The new snapshot appears in the account's values list and shapes the net worth graph between recordings. The account's contribution to the <strong>Investment Total</strong> updates to the latest value.</p>
+  <p>The CryptoCompare section shows <strong>Configured</strong>. On the next sync, Moolah backfills the deep price history for affected tokens, so their older balances value correctly.</p>
 
   <h2>Related</h2>
   <ul>
-    <li><a href="add-an-investment-account.html">Add an investment account</a></li>
-    <li><a href="analyse-net-worth-and-forecast.html">Analyse net worth and forecast upcoming months</a></li>
+    <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+    <li><a href="supported-crypto-chains-and-providers.html">Supported crypto chains and data providers</a></li>
   </ul>
 </article>
 

--- a/site/help/get-a-cryptocompare-api-key.html
+++ b/site/help/get-a-cryptocompare-api-key.html
@@ -119,30 +119,21 @@
     <main class="help-content">
       <article>
   <h1>Get a CryptoCompare API key</h1>
-  <p>Create a free CryptoCompare API key and enter it in Moolah to restore deep price history for tokens that only CryptoCompare can price, such as DAI.</p>
+  <p>Create a free CryptoCompare API key and enter it in Moolah to restore deep price history for tokens that only CryptoCompare can price, such as DAI. The key is yours. Moolah stores it in your iCloud Keychain and queries CryptoCompare directly from your device — never through a Moolah server.</p>
 
   <h2>Why you might need one</h2>
   <p>CryptoCompare — now called CoinDesk Data — is one of the price sources Moolah falls back to for crypto tokens. It used to work without a key. It now needs a free API key for the deep historical data behind it. For most tokens this doesn't matter, because CoinGecko prices them. But a few tokens, like DAI, rely on CryptoCompare for their full price history. Without a key, their older prices can't backfill.</p>
-  <p>The key is optional. Crypto sync, current prices, and most history all work without it. Add a key only if you hold a token whose older prices aren't filling in.</p>
-
-  <h2>Before you start</h2>
-  <ul>
-    <li>You'll create a free account on the CoinDesk Data developer portal. No payment details are needed for the free tier.</li>
-    <li>The key is yours. Moolah stores it privately in your iCloud Keychain and queries CryptoCompare directly from your device — never through a Moolah server.</li>
-  </ul>
+  <p>The key is optional. Crypto sync, current prices, and most history all work without it. If a token's older prices aren't filling in, add a key.</p>
 
   <h2>Steps</h2>
-  <p>First, create the key on the developer portal:</p>
+  <p>First, create the key on the CoinDesk Data developer portal. No payment details are needed for the free tier. Then enter it in Moolah.</p>
   <ol>
-    <li>Go to the CoinDesk Data developer portal at <strong>developers.coindesk.com</strong>.</li>
+    <li>Go to the CoinDesk Data developer portal at <a href="https://developers.coindesk.com">developers.coindesk.com</a>.</li>
     <li>Select <strong>Log In / Sign Up</strong> and create a free account.</li>
     <li>Open your API keys page from your account profile.</li>
     <li>Create a new API key and give it a name you'll recognise, such as "Moolah".</li>
     <li>Copy the key.</li>
-  </ol>
-  <p>Then enter it in Moolah:</p>
-  <ol>
-    <li>Open <strong>Settings &gt; Crypto Tokens</strong>.</li>
+    <li>In Moolah, open <strong>Settings &gt; Crypto Tokens</strong>.</li>
     <li>In the <strong>CryptoCompare</strong> section, paste the key into the <strong>CryptoCompare API Key</strong> field.</li>
     <li>Select <strong>Save</strong>.</li>
   </ol>

--- a/site/help/getting-started.html
+++ b/site/help/getting-started.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/how-import-detects-your-file.html
+++ b/site/help/how-import-detects-your-file.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/i-deleted-a-transaction-by-accident.html
+++ b/site/help/i-deleted-a-transaction-by-accident.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/icloud-says-its-off.html
+++ b/site/help/icloud-says-its-off.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/icloud-storage-is-full.html
+++ b/site/help/icloud-storage-is-full.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/import-a-csv-file.html
+++ b/site/help/import-a-csv-file.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/importing-data.html
+++ b/site/help/importing-data.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html" aria-current="page">Importing data</a>

--- a/site/help/index.html
+++ b/site/help/index.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/investments-and-crypto.html
+++ b/site/help/investments-and-crypto.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/keyboard-shortcuts.html
+++ b/site/help/keyboard-shortcuts.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/manage-crypto-tokens.html
+++ b/site/help/manage-crypto-tokens.html
@@ -145,7 +145,7 @@
     <li>In the <strong>CryptoCompare</strong> section, paste your key into the <strong>CryptoCompare API Key</strong> field.</li>
     <li>Select <strong>Save</strong>.</li>
   </ol>
-  <p>For where to create the key, see <a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a>.</p>
+  <p>To create a key, see <a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a>.</p>
 
   <h2>What gets priced: registered tokens</h2>
   <p>The <strong>Registered Tokens</strong> list is the set of tokens Moolah prices. Native chain tokens (ETH on Ethereum, OP Mainnet, and Base) are priced automatically. You add other tokens as you want them tracked.</p>

--- a/site/help/manage-crypto-tokens.html
+++ b/site/help/manage-crypto-tokens.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html" aria-current="page">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>
@@ -137,6 +138,14 @@
     <li>In the <strong>CoinGecko</strong> section, paste your key into the <strong>API Key</strong> field.</li>
     <li>Select <strong>Save</strong>.</li>
   </ol>
+
+  <h2>Optional: add a CryptoCompare key for deep history</h2>
+  <p>CryptoCompare — now CoinDesk Data — is one of Moolah's fallback price sources. It now needs a free API key for its deep historical data. Most tokens don't rely on it, but a few, such as DAI, need it to backfill their older prices. Add a key only if a token's older balances aren't valuing correctly.</p>
+  <ol>
+    <li>In the <strong>CryptoCompare</strong> section, paste your key into the <strong>CryptoCompare API Key</strong> field.</li>
+    <li>Select <strong>Save</strong>.</li>
+  </ol>
+  <p>For where to create the key, see <a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a>.</p>
 
   <h2>What gets priced: registered tokens</h2>
   <p>The <strong>Registered Tokens</strong> list is the set of tokens Moolah prices. Native chain tokens (ETH on Ethereum, OP Mainnet, and Base) are priced automatically. You add other tokens as you want them tracked.</p>

--- a/site/help/manage-your-profiles.html
+++ b/site/help/manage-your-profiles.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/pay-a-scheduled-transaction.html
+++ b/site/help/pay-a-scheduled-transaction.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/pick-up-a-profile-on-another-device.html
+++ b/site/help/pick-up-a-profile-on-another-device.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/profiles.html
+++ b/site/help/profiles.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/record-a-trade.html
+++ b/site/help/record-a-trade.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/record-a-transfer.html
+++ b/site/help/record-a-transfer.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/reference.html
+++ b/site/help/reference.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/reports-and-analysis.html
+++ b/site/help/reports-and-analysis.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/review-recently-imported-transactions.html
+++ b/site/help/review-recently-imported-transactions.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/scheduled-transaction-didnt-post.html
+++ b/site/help/scheduled-transaction-didnt-post.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/scheduled-transactions.html
+++ b/site/help/scheduled-transactions.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/set-a-budget-for-an-earmark.html
+++ b/site/help/set-a-budget-for-an-earmark.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/set-up-a-recurring-transaction.html
+++ b/site/help/set-up-a-recurring-transaction.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/set-up-a-watched-folder.html
+++ b/site/help/set-up-a-watched-folder.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/sidebar-totals.html
+++ b/site/help/sidebar-totals.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/split-a-transaction.html
+++ b/site/help/split-a-transaction.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/supported-crypto-chains-and-providers.html
+++ b/site/help/supported-crypto-chains-and-providers.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>
@@ -145,7 +146,7 @@
       <tr><td>Blockscout</td><td>Native and internal ETH activity for crypto wallets</td><td>Required. Runs on every sync; it's the authoritative source, so a failure stops the sync. No key needed.</td></tr>
       <tr><td>Coinstash</td><td>Exchange account sync</td><td>Uses your own read-only API token, configured per account.</td></tr>
       <tr><td>CoinGecko</td><td>Token prices, highest priority</td><td>Optional. Add a free Demo API key in <strong>Settings &gt; Crypto Tokens</strong> to use it.</td></tr>
-      <tr><td>CryptoCompare</td><td>Token prices, fallback</td><td>No key needed.</td></tr>
+      <tr><td>CryptoCompare</td><td>Token prices, fallback</td><td>Requires a free API key for deep price history, configured in <strong>Settings &gt; Crypto Tokens</strong>.</td></tr>
       <tr><td>Binance</td><td>Token prices, fallback</td><td>No key needed.</td></tr>
       <tr><td>Frankfurter</td><td>Fiat exchange rates</td><td>No key needed.</td></tr>
       <tr><td>Yahoo Finance</td><td>Stock prices and ticker search</td><td>No key needed.</td></tr>
@@ -157,6 +158,7 @@
     <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
     <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
     <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+    <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
     <li><a href="sync-and-privacy.html">Sync and privacy</a></li>
   </ul>
 </article>

--- a/site/help/supported-crypto-chains-and-providers.html
+++ b/site/help/supported-crypto-chains-and-providers.html
@@ -145,7 +145,7 @@
       <tr><td>Alchemy</td><td>ERC-20 token transfers for crypto wallets</td><td>Required. Runs on every sync. Uses your own API key, configured in <strong>Settings &gt; Crypto Tokens</strong>.</td></tr>
       <tr><td>Blockscout</td><td>Native and internal ETH activity for crypto wallets</td><td>Required. Runs on every sync; it's the authoritative source, so a failure stops the sync. No key needed.</td></tr>
       <tr><td>Coinstash</td><td>Exchange account sync</td><td>Uses your own read-only API token, configured per account.</td></tr>
-      <tr><td>CoinGecko</td><td>Token prices, highest priority</td><td>Optional. Add a free Demo API key in <strong>Settings &gt; Crypto Tokens</strong> to use it.</td></tr>
+      <tr><td>CoinGecko</td><td>Token prices, highest priority</td><td>No key needed. Optionally, add a free Demo API key in <strong>Settings &gt; Crypto Tokens</strong> for more request headroom.</td></tr>
       <tr><td>CryptoCompare</td><td>Token prices, fallback</td><td>Requires a free API key for deep price history, configured in <strong>Settings &gt; Crypto Tokens</strong>.</td></tr>
       <tr><td>Binance</td><td>Token prices, fallback</td><td>No key needed.</td></tr>
       <tr><td>Frankfurter</td><td>Fiat exchange rates</td><td>No key needed.</td></tr>

--- a/site/help/sync-and-privacy.html
+++ b/site/help/sync-and-privacy.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/sync-and-privacy.html
+++ b/site/help/sync-and-privacy.html
@@ -131,7 +131,7 @@
 
   <p>Exchange API tokens are a special case. They're stored in iCloud Keychain, which is Apple's encrypted store for secrets. iCloud Keychain is separate from CloudKit. It syncs the token across your devices so you don't have to paste it on every one. The token stays out of the regular profile data.</p>
 
-  <p>Your price-provider keys — the Alchemy key and the optional CoinGecko key — work the same way. They're kept in iCloud Keychain too, so you enter them once and they follow you to your other devices, separate from your profile data.</p>
+  <p>Your price-provider keys — the Alchemy key, the optional CoinGecko key, and the optional CryptoCompare key — work the same way. They're kept in iCloud Keychain too, so you enter them once and they follow you to your other devices, separate from your profile data.</p>
 
   <h2>Third-party providers</h2>
   <p>If you add a crypto wallet or an exchange account, your device talks directly to the relevant providers. That's Alchemy, Blockscout, CoinGecko, and Coinstash, depending on what you've set up. Frankfurter is used for fiat exchange rates. These calls go from your device to those providers; they don't go through Moolah. The API keys and tokens you supply are yours, used by your device.</p>

--- a/site/help/transactions.html
+++ b/site/help/transactions.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/troubleshooting.html
+++ b/site/help/troubleshooting.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/try-moolah-without-committing-real-data.html
+++ b/site/help/try-moolah-without-committing-real-data.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/turn-on-icloud-sync.html
+++ b/site/help/turn-on-icloud-sync.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/view-income-and-expense-by-category.html
+++ b/site/help/view-income-and-expense-by-category.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/wallet-or-exchange-isnt-syncing.html
+++ b/site/help/wallet-or-exchange-isnt-syncing.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/what-syncs-and-what-stays-on-device.html
+++ b/site/help/what-syncs-and-what-stays-on-device.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>

--- a/site/help/what-syncs-and-what-stays-on-device.html
+++ b/site/help/what-syncs-and-what-stays-on-device.html
@@ -145,7 +145,7 @@
 
   <h2>Stored in iCloud Keychain</h2>
   <p>Exchange API tokens are kept in iCloud Keychain, Apple's encrypted store for secrets. This is separate from CloudKit. iCloud Keychain syncs the token across your devices so you don't have to paste it on each one. The token still lives separately from your profile data.</p>
-  <p>Your price-provider API keys — your Alchemy key and optional CoinGecko key — are kept in iCloud Keychain the same way, so you only enter them once and they follow you to your other devices.</p>
+  <p>Your price-provider API keys — your Alchemy key, your optional CoinGecko key, and the optional CryptoCompare key — are kept in iCloud Keychain the same way, so you only enter them once and they follow you to your other devices.</p>
 
   <h2>Stays on each device</h2>
   <p>Some things are specific to a device and don't follow you around. Each device keeps its own copy.</p>

--- a/site/help/wont-open-this-profile.html
+++ b/site/help/wont-open-this-profile.html
@@ -77,6 +77,7 @@
         <li><a href="add-a-crypto-wallet.html">Add a crypto wallet account</a></li>
         <li><a href="add-an-exchange-account.html">Add an exchange account</a></li>
         <li><a href="manage-crypto-tokens.html">Manage crypto tokens, discovered tokens, and spam</a></li>
+        <li><a href="get-a-cryptocompare-api-key.html">Get a CryptoCompare API key</a></li>
       </ul>
     </li>
     <li><a href="importing-data.html">Importing data</a>


### PR DESCRIPTION
## Why

Production diagnosis (the "Real Profile"): the net-worth graph and income/expense reports have gaps for crypto tokens whose only deep-history price source is CryptoCompare. CryptoCompare's `min-api.cryptocompare.com` now **hard-requires an API key** (HTTP 401 keyless), and the app sent none — so every CryptoCompare fetch failed and deep history never backfilled. Tokens with a Binance pair (ETH/BTC/ENS/UNI/OP/TIA/STRK/LDO) were fine via keyless Binance klines; tokens without one (USDC, USDT, DAI, HEX, SAITABIT) were stuck.

## What

1. **Stablecoin $1 fallback** — a new `StablecoinPriceClient` appended **last** in the price-provider chain. It returns $1.00 for canonical USDC/USDT (recognised via `CanonicalTokenRegistry`, so impersonators get nothing) **only when every real provider has no data** for a date — so genuine prices (including depeg days) still win. **DAI is intentionally excluded** (crypto-collateralised, softer peg) and is instead fixed by the key below.
2. **CryptoCompare API key** — a per-request `@Sendable () -> String?` key provider (mirroring `LiveAlchemyClient`), keychain account `cryptocompare`, sent as the `api_key` query item. Restores deep history for DAI, HEX, and the rest. Takes effect with no restart.
3. **CoinGecko key now per-request across all consumers** — price client, token resolver, and the discovery catalog all read the key per request instead of once at session construction. Also fixes a latent bug: catalog refresh previously used hardcoded free-tier URLs and ignored a configured Pro key entirely.
4. **Settings UI** — a CryptoCompare API key field alongside the Alchemy/CoinGecko fields (plus accessibility-identifier + signup-link parity for the CoinGecko section).
5. **Help docs** — a new "Get a CryptoCompare API key" article (verified against the live CoinDesk Data developer portal) + updates to the crypto/privacy articles.

## Tests / review

- 4163 macOS tests pass; `just build-mac` warning-free; `just format-check` clean.
- New coverage: peg canonical/impersonator/native discrimination + last-resort-vs-real-price integration; CryptoCompare/CoinGecko `api_key` URL injection; per-request host/key flip for client, resolver, and catalog refresh; CryptoCompare key store round-trip.
- Reviewed by code-review, concurrency-review, instrument-conversion-review, ui-review, and help-review agents; all findings applied (incl. Rule 11 logging on the pre-existing USDT-rate fallback, DRY of host/date-string helpers, and keychain-read error logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)