### PR TITLE
Resolve Binance USDT rate via provider fallback + peg

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -5,14 +5,6 @@
 import CloudKit
 import Foundation
 import GRDB
-import OSLog
-
-/// File-scoped logger for the market-data factory wiring. A top-level
-/// `let` (not a `static` on the extension) so the `@Sendable`
-/// `usdtRateLookup` closure can capture it without crossing `ProfileSession`
-/// isolation. `Logger` is `Sendable`.
-private let factoriesLogger = Logger(
-  subsystem: "com.moolah.app", category: "ProfileSessionFactories")
 
 extension ProfileSession {
   // MARK: - Market Data Services
@@ -82,6 +74,17 @@ extension ProfileSession {
     let cryptoCompareClient = CryptoCompareClient(
       http: networking.client(forHost: "min-api.cryptocompare.com"),
       apiKeyProvider: { ProfileSession.resolveCryptoCompareApiKey() })
+    let coinGeckoClient = CoinGeckoClient(
+      apiKeyProvider: coinGeckoApiKeyProvider, networking: networking)
+    let stablecoinClient = StablecoinPriceClient()
+    // Binance prices are quoted in USDT; converting them to USD needs a
+    // USDT/USD rate. Resolve it through the same provider precedence the main
+    // chain uses, ending in the stablecoin peg — so a CryptoCompare outage
+    // falls to CoinGecko's real USDT price before assuming parity, and the $1
+    // last resort comes from the canonical peg rather than a literal here.
+    let usdtRateClients: [CryptoPriceClient] = [
+      cryptoCompareClient, coinGeckoClient, stablecoinClient,
+    ]
     let binanceClient = BinanceClient(
       http: networking.client(forHost: "api.binance.com"),
       usdtRateLookup: { date in
@@ -89,23 +92,15 @@ extension ProfileSession {
           instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
           coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
         )
-        do {
-          return try await cryptoCompareClient.dailyPrice(for: usdtMapping, on: date)
-        } catch {
-          factoriesLogger.warning(
-            "CryptoCompare USDT rate lookup failed; falling back to USDT=1: \(error.localizedDescription, privacy: .public)"
-          )
-          return Decimal(1)
-        }
+        return await CryptoRateLookup.firstAvailableRate(
+          for: usdtMapping, on: date, using: usdtRateClients, default: Decimal(1))
       })
     let priceClients: [CryptoPriceClient] = [
-      CoinGeckoClient(
-        apiKeyProvider: coinGeckoApiKeyProvider,
-        networking: networking),
+      coinGeckoClient,
       cryptoCompareClient,
       binanceClient,
       // Last-resort $1 fallback for canonical USDC/USDT only (peg).
-      StablecoinPriceClient(),
+      stablecoinClient,
     ]
 
     return CryptoPriceService(

--- a/MoolahTests/Shared/CryptoRateLookupTests.swift
+++ b/MoolahTests/Shared/CryptoRateLookupTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins the ordered first-success behaviour `CryptoRateLookup` gives the
+/// Binance USDT/USD conversion rate: try each client in turn, skip any that
+/// throws, and fall back to the supplied default only when every client fails.
+@Suite("CryptoRateLookup")
+struct CryptoRateLookupTests {
+  private let usdtMapping = CryptoProviderMapping(
+    instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
+    coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
+  )
+
+  private func day(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test("Returns the first client's rate when it succeeds")
+  func firstClientWins() async throws {
+    let date = try day("2024-01-01")
+    let first = FixedCryptoPriceClient(
+      prices: ["1:0xdac17f958d2ee523a2206206994597c13d831ec7": ["2024-01-01": dec("0.97")]],
+      syncProvider: .cryptoCompare)
+    let second = FixedCryptoPriceClient(
+      prices: ["1:0xdac17f958d2ee523a2206206994597c13d831ec7": ["2024-01-01": dec("1.50")]],
+      syncProvider: .coinGecko)
+
+    let rate = await CryptoRateLookup.firstAvailableRate(
+      for: usdtMapping, on: date, using: [first, second], default: Decimal(1))
+
+    #expect(rate == dec("0.97"))
+  }
+
+  @Test("Skips a failing client and uses the next that succeeds")
+  func fallsThroughToNextClient() async throws {
+    let date = try day("2024-01-01")
+    let failing = FixedCryptoPriceClient(shouldFail: true, syncProvider: .cryptoCompare)
+    let working = FixedCryptoPriceClient(
+      prices: ["1:0xdac17f958d2ee523a2206206994597c13d831ec7": ["2024-01-01": dec("0.99")]],
+      syncProvider: .coinGecko)
+
+    let rate = await CryptoRateLookup.firstAvailableRate(
+      for: usdtMapping, on: date, using: [failing, working], default: Decimal(1))
+
+    #expect(rate == dec("0.99"))
+  }
+
+  @Test("Returns the default when every client fails")
+  func allFailReturnsDefault() async throws {
+    let date = try day("2024-01-01")
+    let failingCC = FixedCryptoPriceClient(shouldFail: true, syncProvider: .cryptoCompare)
+    let failingCG = FixedCryptoPriceClient(shouldFail: true, syncProvider: .coinGecko)
+
+    let rate = await CryptoRateLookup.firstAvailableRate(
+      for: usdtMapping, on: date, using: [failingCC, failingCG], default: Decimal(42))
+
+    #expect(rate == Decimal(42))
+  }
+
+  @Test("The stablecoin peg supplies $1 for canonical USDT before the default")
+  func pegSuppliesOneForCanonicalUsdt() async throws {
+    let date = try day("2024-01-01")
+    let failingCC = FixedCryptoPriceClient(shouldFail: true, syncProvider: .cryptoCompare)
+    let failingCG = FixedCryptoPriceClient(shouldFail: true, syncProvider: .coinGecko)
+
+    // A deliberately wrong default proves the value came from the peg, not it.
+    let rate = await CryptoRateLookup.firstAvailableRate(
+      for: usdtMapping, on: date,
+      using: [failingCC, failingCG, StablecoinPriceClient()], default: Decimal(999))
+
+    #expect(rate == Decimal(1))
+  }
+}

--- a/Shared/CryptoRateLookup.swift
+++ b/Shared/CryptoRateLookup.swift
@@ -1,0 +1,40 @@
+import Foundation
+import OSLog
+
+/// Resolves a single USD rate for a token by trying an ordered list of price
+/// clients and returning the first that succeeds, skipping any that throws.
+///
+/// Used to price the Binance USDT/USD conversion rate through the same
+/// provider precedence the main price chain uses, ending in
+/// `StablecoinPriceClient`. That way a CryptoCompare outage falls through to
+/// CoinGecko's real USDT price before assuming parity, and the $1 last resort
+/// comes from the single canonical peg source rather than a literal at the
+/// call site. The `default` is a final safety net only — for a canonical
+/// stablecoin the peg always answers, so it is unreachable in practice; a
+/// `warning` is logged if it ever fires (every provider, including the peg,
+/// declined the token — a misconfiguration worth surfacing).
+enum CryptoRateLookup {
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "CryptoRateLookup")
+
+  static func firstAvailableRate(
+    for mapping: CryptoProviderMapping,
+    on date: Date,
+    using clients: [CryptoPriceClient],
+    default fallback: Decimal
+  ) async -> Decimal {
+    for client in clients {
+      do {
+        return try await client.dailyPrice(for: mapping, on: date)
+      } catch {
+        logger.debug(
+          "rate: \(client.syncProvider.displayName, privacy: .public) declined \(mapping.instrumentId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+    logger.warning(
+      "rate: every provider declined \(mapping.instrumentId, privacy: .public); using default \(fallback.description, privacy: .public)"
+    )
+    return fallback
+  }
+}


### PR DESCRIPTION
Stacked on #1138.

## Why

#1138 left the Binance USDT/USD conversion rate special-cased: it called CryptoCompare directly and, on any failure, logged a warning and returned a hardcoded `Decimal(1)`. Now that #1138 adds a `StablecoinPriceClient` that already encodes "USDC/USDT = $1", that magic literal is a third, redundant expression of the peg — and it assumed parity even when CoinGecko could have supplied a *real* USDT price (e.g. a depeg day with CryptoCompare down).

## What

Route the USDT rate through a new `CryptoRateLookup.firstAvailableRate(...)` helper over the ordered `[cryptoCompareClient, coinGeckoClient, stablecoinClient]` — the same first-success precedence the main price chain uses, ending in the peg. So:

- A CryptoCompare outage falls through to **CoinGecko's real USDT price** before assuming parity.
- The **$1 last resort comes from the single canonical peg** (`CanonicalTokenRegistry`), not a literal at the call site.
- The `Decimal(1)` default is now an unreachable safety net for canonical USDT; a `warning` logs if every provider (incl. the peg) ever declines a token — a misconfiguration worth surfacing.
- Removes the now-redundant call-site warning log + file-scoped logger; logging moves into the helper alongside the logic.
- Reuses single `coinGeckoClient` / `stablecoinClient` instances across the rate-lookup list and the main chain (kills two redundant allocations).

## Tests / review

- `just build-mac` warning-free, `just format-check` clean, new `CryptoRateLookupTests` (first-wins / fall-through / all-fail-default / peg-supplies-$1) + existing peg suite pass.
- code-review applied: added per-provider debug + all-declined warning logging (§8). Deferred (noted): a repo-wide `day()` test-helper extraction across ~12 files — out of scope for this change; happy to do it as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)