### PR TITLE
fix(price-cache): contiguous extension for crypto/stock/FX caches

### DIFF
--- a/Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift
+++ b/Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift
@@ -3,6 +3,23 @@
 import Foundation
 import GRDB
 
+// MARK: - v6 migration body
+//
+// Empties all six rate-cache tables in the profile-index database —
+// `crypto_price`, `crypto_token_meta`, `stock_price`,
+// `stock_ticker_meta`, `exchange_rate`, `exchange_rate_meta`.
+//
+// Why a one-shot purge: the caches were built by the pre-contiguous fetch
+// logic, which could leave arbitrary gaps between the recorded
+// `earliest_date` and `latest_date` bounds. Those bounds are now trusted as
+// contiguous by the fixed `ContiguousFetchPlanner`-driven services, so stale
+// gappy rows must be wiped before the new logic takes over.
+//
+// The tables are local, derived, and un-synced — safe to truncate. They
+// re-warm automatically as the price services serve requests.
+// `DATABASE_SCHEMA_GUIDE.md §9`'s "rate caches kept forever" retention rule
+// is unaffected — only the *rows* are purged, not the tables themselves.
+
 extension ProfileIndexSchema {
   /// Body of the `v6_purge_rate_caches` migration.
   ///

--- a/Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift
+++ b/Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift
@@ -1,0 +1,32 @@
+// Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift
+
+import Foundation
+import GRDB
+
+extension ProfileIndexSchema {
+  /// Body of the `v6_purge_rate_caches` migration.
+  ///
+  /// Deletes every row from all six rate-cache tables in the profile-index
+  /// database. The caches were built by the pre-contiguous fetch logic, which
+  /// could leave arbitrary gaps between the recorded `earliest_date` and
+  /// `latest_date` bounds; those bounds are now trusted as contiguous by the
+  /// fixed `ContiguousFetchPlanner`-driven services, so stale gappy rows must
+  /// be wiped before the new logic takes over.
+  ///
+  /// The tables are local, derived, and un-synced — safe to truncate. They
+  /// re-warm automatically as the price services serve requests. Schema
+  /// retention: `DATABASE_SCHEMA_GUIDE.md §9` (kept forever for historic
+  /// conversion correctness) still applies; only the *rows* are purged, not
+  /// the tables themselves.
+  static func purgeRateCaches(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        DELETE FROM crypto_price;
+        DELETE FROM crypto_token_meta;
+        DELETE FROM stock_price;
+        DELETE FROM stock_ticker_meta;
+        DELETE FROM exchange_rate;
+        DELETE FROM exchange_rate_meta;
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileIndexSchema.swift
+++ b/Backends/GRDB/ProfileIndexSchema.swift
@@ -28,6 +28,12 @@ import GRDB
 /// `v4_needs_push`                 — adds the local-only `needs_push`
 ///   dirty flag to the `profile` table (mirrors the per-profile v17
 ///   migration; issue #1081). See `ProfileIndexSchema+NeedsPush.swift`.
+/// `v5_deletion_journal`           — adds the `deletion_journal` table for
+///   durable CloudKit deletion intents (issue #1090). See
+///   `ProfileIndexSchema+DeletionJournal.swift`.
+/// `v6_purge_rate_caches`          — DELETE FROM all six rate-cache tables
+///   so gappy legacy rows are flushed before the contiguous-fill era. See
+///   `ProfileIndexSchema+PurgeRateCaches.swift`.
 ///
 /// Each migration body is registered here. Once shipped, migration IDs
 /// are frozen forever; splitting later is fine, merging post-ship is
@@ -41,7 +47,7 @@ enum ProfileIndexSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 5
+  static let version = 6
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -58,6 +64,7 @@ enum ProfileIndexSchema {
       migrate: createSharedInstrumentRegistryTables)
     migrator.registerMigration("v4_needs_push", migrate: addNeedsPush)
     migrator.registerMigration("v5_deletion_journal", migrate: addDeletionJournal)
+    migrator.registerMigration("v6_purge_rate_caches", migrate: purgeRateCaches)
 
     return migrator
   }

--- a/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
@@ -17,8 +17,8 @@ struct ProfileIndexSchemaV3Tests {
 
   @Test("schema version reflects the latest migration")
   func versionIsLatest() {
-    // Bumped to 5 by `v5_deletion_journal` (issue #1090).
-    #expect(ProfileIndexSchema.version == 5)
+    // Bumped to 6 by `v6_purge_rate_caches` (contiguous-price-cache branch).
+    #expect(ProfileIndexSchema.version == 6)
   }
 
   @Test("v3 creates the instrument table plus all six rate-cache tables")

--- a/MoolahTests/Backends/GRDB/PurgeIntradayCachesMigrationTests.swift
+++ b/MoolahTests/Backends/GRDB/PurgeIntradayCachesMigrationTests.swift
@@ -50,7 +50,7 @@ struct PurgeIntradayCachesMigrationTests {
         "stock_price", "stock_ticker_meta",
         "crypto_price", "crypto_token_meta",
       ] {
-        let count = try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM \(table)") ?? -1
+        let count = try Table(table).fetchCount(database)
         #expect(count == 0, "expected \(table) to be empty after v7, got \(count)")
       }
     }

--- a/MoolahTests/Backends/PurgeRateCachesMigrationTests.swift
+++ b/MoolahTests/Backends/PurgeRateCachesMigrationTests.swift
@@ -47,7 +47,7 @@ struct PurgeRateCachesMigrationTests {
         "stock_price", "stock_ticker_meta",
         "exchange_rate", "exchange_rate_meta",
       ] {
-        let count = try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM \(table)") ?? -1
+        let count = try Table(table).fetchCount(database)
         #expect(
           count == 0, "expected \(table) to be empty after v6_purge_rate_caches, got \(count)")
       }

--- a/MoolahTests/Backends/PurgeRateCachesMigrationTests.swift
+++ b/MoolahTests/Backends/PurgeRateCachesMigrationTests.swift
@@ -1,0 +1,80 @@
+// MoolahTests/Backends/PurgeRateCachesMigrationTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Confirms that `v6_purge_rate_caches` empties all six rate-cache tables in
+/// the profile-index database, so gappy legacy cache rows are not carried
+/// forward into the contiguous-fill era.
+@Suite("v6_purge_rate_caches migration")
+struct PurgeRateCachesMigrationTests {
+  @Test("seeded rows in all six cache tables are wiped by v6")
+  func purgesAllSixCacheTables() throws {
+    let dbQueue = try DatabaseQueue()
+
+    // Migrate to v5 (the state before the purge migration).
+    try ProfileIndexSchema.migrator.migrate(dbQueue, upTo: "v5_deletion_journal")
+
+    // Seed one row in each of the six rate-cache tables.
+    try dbQueue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO exchange_rate_meta (base, earliest_date, latest_date)
+          VALUES ('USD', '2025-01-01', '2025-12-31');
+          INSERT INTO exchange_rate (base, quote, date, rate)
+          VALUES ('USD', 'AUD', '2025-06-01', 1.55);
+
+          INSERT INTO stock_ticker_meta (ticker, instrument_id, earliest_date, latest_date)
+          VALUES ('VGS.AX', 'inst-1', '2025-01-01', '2025-12-31');
+          INSERT INTO stock_price (ticker, date, price)
+          VALUES ('VGS.AX', '2025-06-01', 149.82);
+
+          INSERT INTO crypto_token_meta (token_id, symbol, earliest_date, latest_date)
+          VALUES ('1:native', 'ETH', '2025-01-01', '2025-12-31');
+          INSERT INTO crypto_price (token_id, date, price_usd)
+          VALUES ('1:native', '2025-06-01', 2500.0);
+          """)
+    }
+
+    // Apply v6 — should empty every cache table.
+    try ProfileIndexSchema.migrator.migrate(dbQueue)
+
+    try dbQueue.read { database in
+      for table in [
+        "crypto_price", "crypto_token_meta",
+        "stock_price", "stock_ticker_meta",
+        "exchange_rate", "exchange_rate_meta",
+      ] {
+        let count = try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM \(table)") ?? -1
+        #expect(
+          count == 0, "expected \(table) to be empty after v6_purge_rate_caches, got \(count)")
+      }
+    }
+  }
+
+  @Test("schema is intact after v6 — re-inserts succeed")
+  func schemaIntactAfterPurge() throws {
+    let dbQueue = try DatabaseQueue()
+    try ProfileIndexSchema.migrator.migrate(dbQueue)
+
+    try dbQueue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO crypto_token_meta (token_id, symbol, earliest_date, latest_date)
+          VALUES ('1:native', 'ETH', '2026-01-01', '2026-06-01');
+          INSERT INTO crypto_price (token_id, date, price_usd)
+          VALUES ('1:native', '2026-06-01', 3000.0);
+          """)
+    }
+
+    let price: Double? = try dbQueue.read { database in
+      try Double.fetchOne(
+        database,
+        sql: "SELECT price_usd FROM crypto_price WHERE token_id = '1:native'"
+      )
+    }
+    #expect(price == 3000.0)
+  }
+}

--- a/MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite
+struct ContiguousExtensionCryptoTests {
+  /// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared by all
+  /// tests in this suite to keep date construction readable.
+  private func utcDay(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = .utc
+    guard let date = formatter.date(from: string) else {
+      fatalError("Could not parse ISO date: \(string)")
+    }
+    return date
+  }
+
+  /// Serves a daily price for every day in the requested range that is
+  /// within `horizonDays` of `today`; older days return empty (mimics
+  /// CoinGecko free tier's 365-day refusal collapsing to empty).
+  struct HorizonClient: CryptoPriceClient, Sendable {
+    let today: Date
+    let horizonDays: Int
+
+    var syncProvider: SyncProvider { .binance }
+
+    func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal { 1 }
+    func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
+      [:]
+    }
+
+    func dailyPrices(
+      for mapping: CryptoProviderMapping,
+      in range: ClosedRange<Date>
+    ) async throws -> [String: Decimal] {
+      let cal = Calendar.utc
+      guard let cutoff = cal.date(byAdding: .day, value: -horizonDays, to: today) else {
+        return [:]
+      }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = .utc
+      var out: [String: Decimal] = [:]
+      var day = range.lowerBound
+      while day <= range.upperBound {
+        if day >= cutoff { out[fmt.string(from: day)] = 100 }
+        guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+      return out
+    }
+  }
+
+  /// Serves any date without restriction — used to seed the cache with
+  /// deep history before switching to a horizon-restricted client.
+  struct AllServingClient: CryptoPriceClient, Sendable {
+    var syncProvider: SyncProvider { .binance }
+
+    func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal { 1 }
+    func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
+      [:]
+    }
+
+    func dailyPrices(
+      for mapping: CryptoProviderMapping,
+      in range: ClosedRange<Date>
+    ) async throws -> [String: Decimal] {
+      let cal = Calendar.utc
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = .utc
+      var out: [String: Decimal] = [:]
+      var day = range.lowerBound
+      while day <= range.upperBound {
+        out[fmt.string(from: day)] = 100
+        guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+      return out
+    }
+  }
+
+  private func makeTestInstrument(address: String, symbol: String) -> Instrument {
+    Instrument.crypto(
+      chainId: 1, contractAddress: address, symbol: symbol, name: "\(symbol) Token", decimals: 8)
+  }
+
+  private func makeMapping(for instrument: Instrument, binanceSymbol: String)
+    -> CryptoProviderMapping
+  {
+    CryptoProviderMapping(
+      instrumentId: instrument.id, coingeckoId: nil,
+      cryptocompareSymbol: nil, binanceSymbol: binanceSymbol
+    )
+  }
+
+  private func makeService(
+    clients: [any CryptoPriceClient],
+    database: any DatabaseWriter,
+    now: Date
+  ) -> CryptoPriceService {
+    CryptoPriceService(
+      clients: clients,
+      database: database,
+      resolutionClient: nil,
+      now: { now },
+      timeZone: .utc
+    )
+  }
+
+  // MARK: - Contiguity tests
+
+  /// Reproduces the interior-gap bug: a CoinGecko-like client that refuses
+  /// data older than 365 days causes the cache to jump its `latest` bound
+  /// forward over the un-served span, creating a permanent multi-month void.
+  ///
+  /// Trigger sequence:
+  ///   1. Seed the cache with a far-back date using an all-serving client
+  ///      (gives cache earliest≈2024-06-12, latest≈2024-07-12).
+  ///   2. Request today using a horizon client (only serves ≤365 days back).
+  ///      Old logic: forward extension = unbounded [latest…today].
+  ///      Provider serves 2025-06-17…today. mergeReturningDelta sets
+  ///      latest=today while earliest stays at 2024-07-12. Gap = ~11 months.
+  ///      New logic: extension bounded to 30-day windows; no jump.
+  @Test
+  func farBackRequestLeavesNoInteriorGap() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+    let instrument = makeTestInstrument(address: "0xtest", symbol: "TEST")
+    let mapping = makeMapping(for: instrument, binanceSymbol: "TESTUSDT")
+
+    // Step 1: Seed with an all-serving client so we get real far-back data.
+    // This populates earliest≈2024-06-12, latest≈2024-07-12 in the DB.
+    let seeder = makeService(clients: [AllServingClient()], database: database, now: today)
+    _ = try? await seeder.price(for: instrument, mapping: mapping, on: utcDay("2024-07-12"))
+
+    // Step 2: Fresh service with only the horizon-restricted client.
+    // Now request today. Old logic issues unbounded forward extension from
+    // 2024-07-12 to today; horizon client only serves 2025-06-17+; merge
+    // jumps latest to today leaving a ~11-month interior void.
+    let service = makeService(
+      clients: [HorizonClient(today: today, horizonDays: 365)],
+      database: database,
+      now: today
+    )
+    _ = try? await service.price(for: instrument, mapping: mapping, on: today)
+
+    // The cache bounds must not span an un-fetched interior region larger than
+    // one bounded window. With the old unbounded logic, the forward extension
+    // would jump `latest` from 2024-07-12 all the way to today, leaving
+    // an ~11-month void. The bounded loop keeps each step ≤ 30 days.
+    let maxGap = await service.debugMaxInteriorGapDays(tokenId: instrument.id)
+    #expect(maxGap <= 31)  // bounded window; never a multi-month void
+  }
+
+  // MARK: - Range contiguity
+
+  /// A `prices(in:)` range request using a horizon-restricted client must not
+  /// create an interior hole. The fix chunks the backward `uncoveredSubRanges`
+  /// entry into bounded 30-day windows so the bounds never span un-fetched days.
+  @Test
+  func rangeRequestLeavesNoInteriorGap() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+    let instrument = makeTestInstrument(address: "0xrange", symbol: "RNG")
+    let mapping = makeMapping(for: instrument, binanceSymbol: "RNGUSDT")
+
+    // Seed recent block so the cache has latest ≈ today.
+    let seeder = makeService(clients: [AllServingClient()], database: database, now: today)
+    _ = try? await seeder.price(for: instrument, mapping: mapping, on: today)
+
+    // Now request a range spanning far back using the horizon-restricted client.
+    // Old logic: prices(in:) issues one unbounded backward fetch [rangeStart...earliest-1];
+    // HorizonClient returns only ≥ 2025-06-17, leaving a void before that.
+    // New logic: backward extension is split into ≤30-day windows, so no interior gap forms.
+    let service = makeService(
+      clients: [HorizonClient(today: today, horizonDays: 365)],
+      database: database,
+      now: today
+    )
+    let rangeStart = utcDay("2024-01-01")
+    _ = try? await service.prices(for: instrument, mapping: mapping, in: rangeStart...today)
+    let maxGap = await service.debugMaxInteriorGapDays(tokenId: instrument.id)
+    #expect(maxGap <= 31)  // bounded windows; never a multi-month void
+  }
+}

--- a/MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
@@ -144,6 +144,57 @@ struct ContiguousExtensionCryptoTests {
     #expect(maxGap <= 31)  // bounded window; never a multi-month void
   }
 
+  // MARK: - Background warmer contiguity
+
+  /// `warmRange` with a horizon-restricted client must not create an interior
+  /// gap. Old logic precomputes ALL uncovered sub-ranges upfront; a later
+  /// chunk that falls outside the provider's 365-day horizon returns empty,
+  /// so `mergeReturningDelta` is never called for it and `earliest`/`latest`
+  /// never advance past it — but a chunk that IS served advances `latest` to
+  /// the served span, leaving a void between the cold cache tail and the
+  /// newly served segment.
+  ///
+  /// Concretely: cold cache, `warmRange(in: farBack...today)`. Old logic
+  /// chunks the whole range upfront. The last chunk (near today) is served by
+  /// the horizon client; earlier chunks return empty and do not move bounds.
+  /// `latest` jumps from nil to today; `earliest` stays at the served start.
+  /// Subsequent calls see `subRanges.isEmpty` for a range inside the served
+  /// segment, so the void is never filled.
+  ///
+  /// New logic (contiguous loop): each window anchors at the live cache
+  /// bounds; the first empty result in either direction stops that direction.
+  /// `earliest`/`latest` can only advance across days that were actually
+  /// served — the void can never form.
+  @Test
+  func warmRangeLeavesNoInteriorGap() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+    let instrument = makeTestInstrument(address: "0xwarm", symbol: "WARM")
+    let mapping = makeMapping(for: instrument, binanceSymbol: "WARMUSDT")
+
+    // Cold cache. `warmRange` across 2+ years with a provider that only serves
+    // the last 365 days. Old `uncoveredSubRanges` loop: chunks the entire span
+    // upfront; a recent chunk fills latest=today; earlier chunks return empty
+    // and never move earliest — interior gap = ~1 year. Bounded-window loop:
+    // forward direction stops as soon as a window returns nothing, so the
+    // cache only spans the actually-served segment.
+    let service = makeService(
+      clients: [HorizonClient(today: today, horizonDays: 365)],
+      database: database,
+      now: today
+    )
+    let farBack = utcDay("2024-01-01")
+    let outcome = await service.warmRange(
+      for: instrument, mapping: mapping, in: farBack...today)
+    // The outcome must reflect that some data was fetched (the recent segment).
+    #expect(outcome == .filled || outcome == .unavailable)
+
+    let maxGap = await service.debugMaxInteriorGapDays(tokenId: instrument.id)
+    // Bounded windows: no interior gap larger than one window (≤ 30 days).
+    // The old uncoveredSubRanges path produces a gap > 300 days here.
+    #expect(maxGap <= 31)
+  }
+
   // MARK: - Range contiguity
 
   /// A `prices(in:)` range request using a horizon-restricted client must not
@@ -151,7 +202,7 @@ struct ContiguousExtensionCryptoTests {
   /// forward/backward fetches; a horizon client returning only recent data
   /// would jump `latest` (or `earliest`) over un-served days, leaving a void.
   /// New logic: both forward and backward extensions go through
-  /// `uncoveredSubRanges` which chunks into ≤30-day windows.
+  /// `coverRangeContiguously`, which uses bounded 30-day windows.
   ///
   /// Trigger sequence (forward extension variant, mirrors `farBackRequestLeavesNoInteriorGap`):
   ///   1. Seed far-back data so cache has latest ≈ 2024-07-12.
@@ -159,8 +210,8 @@ struct ContiguousExtensionCryptoTests {
   ///      Old logic: `prices(in:)` computes forward sub-range [latest...fetchUpperBound]
   ///      in one unbounded call. Provider returns 2025-06-17…today; merge jumps
   ///      `latest` to today leaving an ~11-month void.
-  ///      New logic: `uncoveredSubRanges` chunks the forward span into ≤30-day
-  ///      windows, so bounds only advance across actually-returned data.
+  ///      New logic: `coverRangeContiguously` advances bounds one 30-day window
+  ///      at a time, so bounds only advance across actually-returned data.
   @Test
   func rangeRequestLeavesNoInteriorGap() async throws {
     let today = utcDay("2026-06-17")

--- a/MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
@@ -6,18 +6,6 @@ import Testing
 
 @Suite
 struct ContiguousExtensionCryptoTests {
-  /// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared by all
-  /// tests in this suite to keep date construction readable.
-  private func utcDay(_ string: String) -> Date {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    formatter.timeZone = .utc
-    guard let date = formatter.date(from: string) else {
-      fatalError("Could not parse ISO date: \(string)")
-    }
-    return date
-  }
-
   /// Serves a daily price for every day in the requested range that is
   /// within `horizonDays` of `today`; older days return empty (mimics
   /// CoinGecko free tier's 365-day refusal collapsing to empty).
@@ -159,8 +147,20 @@ struct ContiguousExtensionCryptoTests {
   // MARK: - Range contiguity
 
   /// A `prices(in:)` range request using a horizon-restricted client must not
-  /// create an interior hole. The fix chunks the backward `uncoveredSubRanges`
-  /// entry into bounded 30-day windows so the bounds never span un-fetched days.
+  /// create an interior hole. Old logic: `prices(in:)` issued unbounded
+  /// forward/backward fetches; a horizon client returning only recent data
+  /// would jump `latest` (or `earliest`) over un-served days, leaving a void.
+  /// New logic: both forward and backward extensions go through
+  /// `uncoveredSubRanges` which chunks into ≤30-day windows.
+  ///
+  /// Trigger sequence (forward extension variant, mirrors `farBackRequestLeavesNoInteriorGap`):
+  ///   1. Seed far-back data so cache has latest ≈ 2024-07-12.
+  ///   2. Request `rangeStart...today` with a horizon client (only serves ≥ 2025-06-17).
+  ///      Old logic: `prices(in:)` computes forward sub-range [latest...fetchUpperBound]
+  ///      in one unbounded call. Provider returns 2025-06-17…today; merge jumps
+  ///      `latest` to today leaving an ~11-month void.
+  ///      New logic: `uncoveredSubRanges` chunks the forward span into ≤30-day
+  ///      windows, so bounds only advance across actually-returned data.
   @Test
   func rangeRequestLeavesNoInteriorGap() async throws {
     let today = utcDay("2026-06-17")
@@ -168,14 +168,14 @@ struct ContiguousExtensionCryptoTests {
     let instrument = makeTestInstrument(address: "0xrange", symbol: "RNG")
     let mapping = makeMapping(for: instrument, binanceSymbol: "RNGUSDT")
 
-    // Seed recent block so the cache has latest ≈ today.
+    // Step 1: Seed a far-back date so the cache has latest ≈ 2024-07-12.
     let seeder = makeService(clients: [AllServingClient()], database: database, now: today)
-    _ = try? await seeder.price(for: instrument, mapping: mapping, on: today)
+    _ = try? await seeder.price(for: instrument, mapping: mapping, on: utcDay("2024-07-12"))
 
-    // Now request a range spanning far back using the horizon-restricted client.
-    // Old logic: prices(in:) issues one unbounded backward fetch [rangeStart...earliest-1];
-    // HorizonClient returns only ≥ 2025-06-17, leaving a void before that.
-    // New logic: backward extension is split into ≤30-day windows, so no interior gap forms.
+    // Step 2: Request rangeStart...today using a horizon-restricted client.
+    // Old logic emits an unbounded forward fetch [2024-07-12…today]; the
+    // horizon client returns data from 2025-06-17 onward; merge jumps
+    // `latest` to today leaving an ~11-month void inside the range.
     let service = makeService(
       clients: [HorizonClient(today: today, horizonDays: 365)],
       database: database,

--- a/MoolahTests/Shared/ContiguousExtensionFXTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionFXTests.swift
@@ -44,7 +44,7 @@ struct ContiguousExtensionFXTests {
         let weekday = cal.component(.weekday, from: day)
         // weekday 1 = Sunday, 7 = Saturday
         if day >= cutoff && weekday != 1 && weekday != 7 {
-          out[fmt.string(from: day)] = ["AUD": Decimal(string: "1.5")!]
+          out[fmt.string(from: day)] = ["AUD": 1.5]
         }
         guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
         day = next
@@ -67,7 +67,7 @@ struct ContiguousExtensionFXTests {
       while day <= to {
         let weekday = cal.component(.weekday, from: day)
         if weekday != 1 && weekday != 7 {
-          out[fmt.string(from: day)] = ["AUD": Decimal(string: "1.5")!]
+          out[fmt.string(from: day)] = ["AUD": 1.5]
         }
         guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
         day = next

--- a/MoolahTests/Shared/ContiguousExtensionFXTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionFXTests.swift
@@ -135,22 +135,40 @@ struct ContiguousExtensionFXTests {
 
   // MARK: - Range contiguity
 
-  /// A `rates(from:to:in:)` range request using a horizon-restricted client
-  /// must not create an interior hole larger than a long weekend.
+  /// A `rates(from:to:in:)` range request spanning a forward-horizon hole must
+  /// not create an interior gap larger than a long weekend.
+  ///
+  /// Trigger sequence (mirrors `farBackSeedThenTodayRequestLeavesOnlyWeekendGaps`
+  /// but via the range API instead of the single-rate API):
+  ///   1. Seed far-back date (2024-07-12) using an all-serving client so the
+  ///      cache has earliest≈2024-06-12, latest=2024-07-12.
+  ///   2. Request rangeStart…today with a horizon-restricted client
+  ///      (serves only the past 365 days, i.e. ≥ 2025-06-17).
+  ///      Old logic: `uncoveredSubRanges` precomputes ALL forward chunks
+  ///      from 2024-07-12 to 2026-06-16 upfront. The horizon client
+  ///      returns data starting at 2025-06-17; a later chunk that lands in
+  ///      the served window advances `latest` past earlier empty chunks,
+  ///      leaving an interior void of ~339 days.
+  ///      New logic: `coverRangeContiguously` steps one window at a time
+  ///      anchored at the live bounds; a window that returns no data stops
+  ///      the loop, so no jump occurs.
   @Test
-  func rangeRequestLeavesOnlyWeekendGaps() async throws {
+  func rangeRequestLeavesNoInteriorGap() async throws {
     let today = utcDay("2026-06-17")
     let database = try ProfileIndexDatabase.openInMemory()
 
-    // Seed today's data so the cache has a recent bound.
+    // Step 1: Seed a far-back date so the cache has latest ≈ 2024-07-12.
     let seeder = makeService(
       client: AllServingWeekdayRateClient(),
       database: database,
       now: today
     )
-    _ = try? await seeder.rate(from: .USD, to: .AUD, on: today)
+    _ = try? await seeder.rate(from: .USD, to: .AUD, on: utcDay("2024-07-12"))
 
-    // Request a range far back using a horizon-restricted client.
+    // Step 2: Request rangeStart…today using a horizon-restricted client.
+    // Old uncoveredSubRanges path precomputes all chunks; a later chunk that
+    // returns data jumps `latest` past earlier empty chunks, creating an
+    // ~11-month interior void.
     let service = makeService(
       client: WeekdayHorizonRateClient(today: today, horizonDays: 365),
       database: database,

--- a/MoolahTests/Shared/ContiguousExtensionFXTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionFXTests.swift
@@ -8,17 +8,6 @@ import Testing
 
 @Suite
 struct ContiguousExtensionFXTests {
-  /// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared by all
-  /// tests in this suite to keep date construction readable.
-  private func utcDay(_ string: String) -> Date {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    formatter.timeZone = .utc
-    guard let date = formatter.date(from: string) else {
-      fatalError("Could not parse ISO date: \(string)")
-    }
-    return date
-  }
 
   /// Serves a weekday rate for every day in the requested range that is
   /// within `horizonDays` of `today`; older days and weekends return empty.

--- a/MoolahTests/Shared/ContiguousExtensionFXTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionFXTests.swift
@@ -1,0 +1,176 @@
+// MoolahTests/Shared/ContiguousExtensionFXTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite
+struct ContiguousExtensionFXTests {
+  /// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared by all
+  /// tests in this suite to keep date construction readable.
+  private func utcDay(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = .utc
+    guard let date = formatter.date(from: string) else {
+      fatalError("Could not parse ISO date: \(string)")
+    }
+    return date
+  }
+
+  /// Serves a weekday rate for every day in the requested range that is
+  /// within `horizonDays` of `today`; older days and weekends return empty.
+  /// Mimics Frankfurter's behaviour: FX markets are closed on weekends and
+  /// data may only be available for a rolling window.
+  struct WeekdayHorizonRateClient: ExchangeRateClient, Sendable {
+    let today: Date
+    let horizonDays: Int
+
+    func fetchRates(
+      base: String, from: Date, to: Date
+    ) async throws -> [String: [String: Decimal]] {
+      let cal = Calendar.utc
+      guard let cutoff = cal.date(byAdding: .day, value: -horizonDays, to: today) else {
+        return [:]
+      }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = .utc
+      var out: [String: [String: Decimal]] = [:]
+      var day = from
+      while day <= to {
+        let weekday = cal.component(.weekday, from: day)
+        // weekday 1 = Sunday, 7 = Saturday
+        if day >= cutoff && weekday != 1 && weekday != 7 {
+          out[fmt.string(from: day)] = ["AUD": Decimal(string: "1.5")!]
+        }
+        guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+      return out
+    }
+  }
+
+  /// Serves weekday rates for any date without restriction.
+  struct AllServingWeekdayRateClient: ExchangeRateClient, Sendable {
+    func fetchRates(
+      base: String, from: Date, to: Date
+    ) async throws -> [String: [String: Decimal]] {
+      let cal = Calendar.utc
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = .utc
+      var out: [String: [String: Decimal]] = [:]
+      var day = from
+      while day <= to {
+        let weekday = cal.component(.weekday, from: day)
+        if weekday != 1 && weekday != 7 {
+          out[fmt.string(from: day)] = ["AUD": Decimal(string: "1.5")!]
+        }
+        guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+      return out
+    }
+  }
+
+  private func makeService(
+    client: any ExchangeRateClient,
+    database: any DatabaseWriter,
+    now: Date
+  ) -> ExchangeRateService {
+    ExchangeRateService(
+      client: client,
+      database: database,
+      now: { now },
+      timeZone: .utc
+    )
+  }
+
+  // MARK: - Contiguity tests
+
+  /// Reproduces the interior-gap bug for exchange rates: a horizon-restricted
+  /// client causes the unbounded forward-extension fetch to produce a large
+  /// interior void.
+  ///
+  /// Trigger sequence:
+  ///   1. Seed far-back date (2024-07-12) using an all-serving client so the
+  ///      cache has earliest≈2024-06-12, latest=2024-07-12.
+  ///   2. Request today (2026-06-17) with a horizon-restricted client
+  ///      (serves only the past 365 days, i.e. ≥ 2025-06-17).
+  ///      Old logic: forward extension = unbounded [2024-07-12…today] in
+  ///      year-sized chunks. Chunk 1 (2024-07-12…2025-07-12) returns data
+  ///      from 2025-06-17 onward; merge advances `latest` to 2025-07-12,
+  ///      leaving a ~11-month void (2024-07-12…2025-06-17).
+  ///      New logic: extension bounded to 30-day windows; bounds only advance
+  ///      across data that was actually returned.
+  ///
+  /// FX markets are closed weekends, so genuine 1–2 day gaps between
+  /// consecutive data points are expected. The invariant is that no
+  /// interior gap exceeds 4 days (a long weekend), never a multi-week void.
+  @Test
+  func farBackSeedThenTodayRequestLeavesOnlyWeekendGaps() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+
+    // Step 1: Seed a far-back date using an all-serving client.
+    // This populates earliest≈2024-06-12, latest=2024-07-12.
+    let seeder = makeService(
+      client: AllServingWeekdayRateClient(),
+      database: database,
+      now: today
+    )
+    _ = try? await seeder.rate(from: .USD, to: .AUD, on: utcDay("2024-07-12"))
+
+    // Step 2: Fresh service with a horizon-restricted client (only ≤ 365 days back).
+    // Request today → forward extension from 2024-07-12 to 2026-06-16 (yesterday).
+    // Old unbounded logic issues this in year-sized chunks; the first chunk
+    // (2024-07-12 → 2025-07-12) returns data only from 2025-06-17 onward,
+    // leaving a ~11-month interior void between the seeded latest and first
+    // served day.
+    let service = makeService(
+      client: WeekdayHorizonRateClient(today: today, horizonDays: 365),
+      database: database,
+      now: today
+    )
+    _ = try? await service.rate(from: .USD, to: .AUD, on: today)
+
+    // The largest gap between consecutive cached rates must not exceed a
+    // long-weekend span (4 days). A multi-week void indicates the
+    // bounded-loop invariant was violated.
+    let maxGap = await service.debugMaxInteriorGapDays(base: "USD")
+    #expect(maxGap <= 4)  // weekend/holiday only; never a multi-week void
+  }
+
+  // MARK: - Range contiguity
+
+  /// A `rates(from:to:in:)` range request using a horizon-restricted client
+  /// must not create an interior hole larger than a long weekend.
+  @Test
+  func rangeRequestLeavesOnlyWeekendGaps() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+
+    // Seed today's data so the cache has a recent bound.
+    let seeder = makeService(
+      client: AllServingWeekdayRateClient(),
+      database: database,
+      now: today
+    )
+    _ = try? await seeder.rate(from: .USD, to: .AUD, on: today)
+
+    // Request a range far back using a horizon-restricted client.
+    let service = makeService(
+      client: WeekdayHorizonRateClient(today: today, horizonDays: 365),
+      database: database,
+      now: today
+    )
+    let rangeStart = utcDay("2024-01-01")
+    _ = try? await service.rates(from: .USD, to: .AUD, in: rangeStart...today)
+
+    let maxGap = await service.debugMaxInteriorGapDays(base: "USD")
+    #expect(maxGap <= 4)  // weekend/holiday only; never a multi-week void
+  }
+}

--- a/MoolahTests/Shared/ContiguousExtensionStockTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionStockTests.swift
@@ -8,17 +8,6 @@ import Testing
 
 @Suite
 struct ContiguousExtensionStockTests {
-  /// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared by all
-  /// tests in this suite to keep date construction readable.
-  private func utcDay(_ string: String) -> Date {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    formatter.timeZone = .utc
-    guard let date = formatter.date(from: string) else {
-      fatalError("Could not parse ISO date: \(string)")
-    }
-    return date
-  }
 
   /// Serves a daily price for every weekday in the requested range that is
   /// within `horizonDays` of `today`; older days and weekends return empty.

--- a/MoolahTests/Shared/ContiguousExtensionStockTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionStockTests.swift
@@ -1,0 +1,179 @@
+// MoolahTests/Shared/ContiguousExtensionStockTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite
+struct ContiguousExtensionStockTests {
+  /// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared by all
+  /// tests in this suite to keep date construction readable.
+  private func utcDay(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = .utc
+    guard let date = formatter.date(from: string) else {
+      fatalError("Could not parse ISO date: \(string)")
+    }
+    return date
+  }
+
+  /// Serves a daily price for every weekday in the requested range that is
+  /// within `horizonDays` of `today`; older days and weekends return empty.
+  /// Mimics Yahoo Finance's behaviour: stock markets are closed on weekends
+  /// and data may only be available for a rolling window.
+  struct WeekdayHorizonClient: StockPriceClient, Sendable {
+    let today: Date
+    let horizonDays: Int
+
+    func fetchDailyPrices(ticker: String, from: Date, to: Date) async throws -> StockPriceResponse {
+      let cal = Calendar.utc
+      guard let cutoff = cal.date(byAdding: .day, value: -horizonDays, to: today) else {
+        return StockPriceResponse(instrument: .fiat(code: "AUD"), prices: [:])
+      }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = .utc
+      var out: [String: Decimal] = [:]
+      var day = from
+      while day <= to {
+        let weekday = cal.component(.weekday, from: day)
+        // weekday 1 = Sunday, 7 = Saturday
+        if day >= cutoff && weekday != 1 && weekday != 7 {
+          out[fmt.string(from: day)] = 50
+        }
+        guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+      return StockPriceResponse(instrument: .fiat(code: "AUD"), prices: out)
+    }
+  }
+
+  /// Serves weekday prices for any date without restriction.
+  struct AllServingWeekdayClient: StockPriceClient, Sendable {
+    func fetchDailyPrices(ticker: String, from: Date, to: Date) async throws -> StockPriceResponse {
+      let cal = Calendar.utc
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = .utc
+      var out: [String: Decimal] = [:]
+      var day = from
+      while day <= to {
+        let weekday = cal.component(.weekday, from: day)
+        if weekday != 1 && weekday != 7 {
+          out[fmt.string(from: day)] = 50
+        }
+        guard let next = cal.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+      return StockPriceResponse(instrument: .fiat(code: "AUD"), prices: out)
+    }
+  }
+
+  private func makeService(
+    client: any StockPriceClient,
+    database: any DatabaseWriter,
+    now: Date
+  ) -> StockPriceService {
+    StockPriceService(
+      client: client,
+      database: database,
+      now: { now },
+      timeZone: .utc
+    )
+  }
+
+  // MARK: - Contiguity tests
+
+  /// Reproduces the interior-gap bug for stock prices: a Yahoo-like client
+  /// that refuses data older than `horizonDays` causes the unbounded
+  /// forward-extension fetch to produce a large interior void.
+  ///
+  /// Trigger sequence:
+  ///   1. Seed far-back date (2024-07-12) using an all-serving client so the
+  ///      cache has earliest≈2024-06-12, latest=2024-07-12.
+  ///   2. Request today (2026-06-17) with a horizon-restricted client
+  ///      (serves only the past 365 days, i.e. ≥ 2025-06-17).
+  ///      Old logic: forward extension = unbounded [2024-07-12…today] in
+  ///      year-sized chunks. Chunk 1 (2024-07-12…2025-07-12) returns data
+  ///      from 2025-06-17 onward; merge advances `latest` to 2025-07-12,
+  ///      leaving a ~11-month void (2024-07-12…2025-06-17).
+  ///      New logic: extension bounded to 30-day windows; bounds only advance
+  ///      across data that was actually returned.
+  ///
+  /// Stock markets are closed weekends/holidays, so genuine 1–3 day gaps
+  /// between consecutive data points are expected. The invariant is that no
+  /// interior gap exceeds 4 days (a long weekend), never a multi-week void.
+  @Test
+  func farBackSeedThenTodayRequestLeavesOnlyWeekendGaps() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+
+    // Step 1: Seed a far-back date using an all-serving client.
+    // This populates earliest≈2024-06-12, latest=2024-07-12.
+    let seeder = makeService(
+      client: AllServingWeekdayClient(),
+      database: database,
+      now: today
+    )
+    _ = try? await seeder.price(ticker: "BHP.AX", on: utcDay("2024-07-12"))
+
+    // Step 2: Fresh service with a horizon-restricted client (only ≤ 365 days back).
+    // Request today → forward extension from 2024-07-12 to 2026-06-16 (yesterday).
+    // Old unbounded logic issues this in year-sized chunks; the first chunk
+    // (2024-07-12 → 2025-07-12) returns data only from 2025-06-17 onward,
+    // leaving a ~11-month interior void between the seeded latest and first
+    // served day.
+    let service = makeService(
+      client: WeekdayHorizonClient(today: today, horizonDays: 365),
+      database: database,
+      now: today
+    )
+    _ = try? await service.price(ticker: "BHP.AX", on: today)
+
+    // The largest gap between consecutive cached prices must not exceed a
+    // long-weekend span (4 days). A multi-week void indicates the
+    // bounded-loop invariant was violated.
+    let maxGap = await service.debugMaxInteriorGapDays(ticker: "BHP.AX")
+    #expect(maxGap <= 4)  // weekend/holiday only; never a multi-week void
+  }
+
+  // MARK: - Range contiguity
+
+  /// A `prices(ticker:in:)` range request using a horizon-restricted client
+  /// must not create an interior hole larger than a long weekend.
+  @Test
+  func rangeRequestLeavesOnlyWeekendGaps() async throws {
+    let today = utcDay("2026-06-17")
+    let database = try ProfileIndexDatabase.openInMemory()
+
+    // Seed today's data so the cache has a recent bound.
+    let seeder = makeService(
+      client: AllServingWeekdayClient(),
+      database: database,
+      now: today
+    )
+    _ = try? await seeder.price(ticker: "BHP.AX", on: today)
+
+    // Request a range far back using a horizon-restricted client.
+    // Old logic emits one large backward fetch [2024-01-01 … earliest-1];
+    // the horizon client returns nothing for dates before 2025-06-17.
+    // Since backward fetch returns empty for the pre-horizon range, the
+    // bounds don't advance backward — so this test may trivially pass for
+    // the backward direction. The main regression to prevent is a forward
+    // extension creating an interior gap, which this test catches when
+    // combined with farBackSeedThenTodayRequestLeavesOnlyWeekendGaps.
+    let service = makeService(
+      client: WeekdayHorizonClient(today: today, horizonDays: 365),
+      database: database,
+      now: today
+    )
+    let rangeStart = utcDay("2024-01-01")
+    _ = try? await service.prices(ticker: "BHP.AX", in: rangeStart...today)
+
+    let maxGap = await service.debugMaxInteriorGapDays(ticker: "BHP.AX")
+    #expect(maxGap <= 4)  // weekend/holiday only; never a multi-week void
+  }
+}

--- a/MoolahTests/Shared/ContiguousExtensionStockTests.swift
+++ b/MoolahTests/Shared/ContiguousExtensionStockTests.swift
@@ -131,29 +131,40 @@ struct ContiguousExtensionStockTests {
 
   // MARK: - Range contiguity
 
-  /// A `prices(ticker:in:)` range request using a horizon-restricted client
-  /// must not create an interior hole larger than a long weekend.
+  /// A `prices(ticker:in:)` range request spanning a forward-horizon hole must
+  /// not create an interior gap larger than a long weekend.
+  ///
+  /// Trigger sequence (mirrors `farBackSeedThenTodayRequestLeavesOnlyWeekendGaps`
+  /// but via the range API instead of the single-price API):
+  ///   1. Seed far-back date (2024-07-12) using an all-serving client so the
+  ///      cache has earliest≈2024-06-12, latest=2024-07-12.
+  ///   2. Request rangeStart…today with a horizon-restricted client
+  ///      (serves only the past 365 days, i.e. ≥ 2025-06-17).
+  ///      Old logic: `uncoveredSubRanges` precomputes ALL forward chunks
+  ///      from 2024-07-12 to 2026-06-16 upfront. The horizon client
+  ///      returns data starting at 2025-06-17; the chunks that span
+  ///      2025-06-17 advance `latest` past the immediately-preceding empty
+  ///      chunks, leaving an interior void of ~339 days.
+  ///      New logic: `coverRangeContiguously` steps one window at a time
+  ///      anchored at the live bounds; a window that returns no data stops
+  ///      the loop, so no jump occurs.
   @Test
-  func rangeRequestLeavesOnlyWeekendGaps() async throws {
+  func rangeRequestLeavesNoInteriorGap() async throws {
     let today = utcDay("2026-06-17")
     let database = try ProfileIndexDatabase.openInMemory()
 
-    // Seed today's data so the cache has a recent bound.
+    // Step 1: Seed a far-back date so the cache has latest ≈ 2024-07-12.
     let seeder = makeService(
       client: AllServingWeekdayClient(),
       database: database,
       now: today
     )
-    _ = try? await seeder.price(ticker: "BHP.AX", on: today)
+    _ = try? await seeder.price(ticker: "BHP.AX", on: utcDay("2024-07-12"))
 
-    // Request a range far back using a horizon-restricted client.
-    // Old logic emits one large backward fetch [2024-01-01 … earliest-1];
-    // the horizon client returns nothing for dates before 2025-06-17.
-    // Since backward fetch returns empty for the pre-horizon range, the
-    // bounds don't advance backward — so this test may trivially pass for
-    // the backward direction. The main regression to prevent is a forward
-    // extension creating an interior gap, which this test catches when
-    // combined with farBackSeedThenTodayRequestLeavesOnlyWeekendGaps.
+    // Step 2: Request rangeStart…today using a horizon-restricted client.
+    // Old uncoveredSubRanges path precomputes all chunks; a later chunk that
+    // returns data jumps `latest` past earlier empty chunks, creating an
+    // ~11-month interior void.
     let service = makeService(
       client: WeekdayHorizonClient(today: today, horizonDays: 365),
       database: database,

--- a/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+++ b/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
@@ -22,4 +22,30 @@ import Testing
     #expect(ContiguousFetchPlanner.addingDays(-1, to: 20_240_301) == 20_240_229)  // leap year
     #expect(ContiguousFetchPlanner.addingDays(30, to: 20_240_101) == 20_240_131)
   }
+
+  @Test func forwardWindowIsBoundedAndAnchoredAtLatest() {
+    // latest=Jan15, requested far ahead → window [Jan15 … Jan15+30], not [Jan15 … requested].
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_101, latest: 20_240_115,
+      requested: 20_240_601, today: 20_240_601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20_240_115...20_240_214)  // includes latest (re-query to overwrite stale), spans 30 days
+  }
+
+  @Test func forwardWindowStopsAtRequestedWhenNearer() {
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_101, latest: 20_240_115,
+      requested: 20_240_120, today: 20_240_601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20_240_115...20_240_120)
+  }
+
+  @Test func forwardWindowCappedAtTodayPlusBuffer() {
+    // requested beyond today → cap at today+buffer, never an arbitrary future date.
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_101, latest: 20_240_115,
+      requested: 20_240_601, today: 20_240_118,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20_240_115...20_240_120)  // today(18)+buffer(2)=20
+  }
 }

--- a/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+++ b/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
@@ -2,50 +2,112 @@ import Testing
 
 @testable import Moolah
 
-@Suite struct ContiguousFetchPlannerTests {
+@Suite
+struct ContiguousFetchPlannerTests {
   // DateKeys are yyyymmdd ints; use real calendar days so +1 day math is exercised.
   static let jan01: Int32 = 20_240_101
   static let jan15: Int32 = 20_240_115
   static let jan31: Int32 = 20_240_131
   static let feb15: Int32 = 20_240_215
 
-  @Test func requestedInsideBoundsReturnsNil() {
+  static let defaultConfig = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+
+  @Test
+  func requestedInsideBoundsReturnsNil() {
     let window = ContiguousFetchPlanner.nextWindow(
-      earliest: Self.jan01, latest: Self.jan31,
-      requested: Self.jan15, today: Self.feb15,
-      windowDays: 30, forwardBuffer: 2)
+      earliest: Self.jan01,
+      latest: Self.jan31,
+      requested: Self.jan15,
+      today: Self.feb15,
+      config: Self.defaultConfig)
     #expect(window == nil)
   }
 
-  @Test func addingDaysCrossesMonthBoundary() {
+  @Test
+  func addingDaysCrossesMonthBoundary() {
     #expect(ContiguousFetchPlanner.addingDays(1, to: 20_240_131) == 20_240_201)
     #expect(ContiguousFetchPlanner.addingDays(-1, to: 20_240_301) == 20_240_229)  // leap year
     #expect(ContiguousFetchPlanner.addingDays(30, to: 20_240_101) == 20_240_131)
   }
 
-  @Test func forwardWindowIsBoundedAndAnchoredAtLatest() {
+  @Test
+  func forwardWindowIsBoundedAndAnchoredAtLatest() {
     // latest=Jan15, requested far ahead → window [Jan15 … Jan15+30], not [Jan15 … requested].
-    let w = ContiguousFetchPlanner.nextWindow(
-      earliest: 20_240_101, latest: 20_240_115,
-      requested: 20_240_601, today: 20_240_601,
-      windowDays: 30, forwardBuffer: 2)
-    #expect(w == 20_240_115...20_240_214)  // includes latest (re-query to overwrite stale), spans 30 days
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_101,
+      latest: 20_240_115,
+      requested: 20_240_601,
+      today: 20_240_601,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_115...20_240_214)  // includes latest (re-query to overwrite stale), spans 30 days
   }
 
-  @Test func forwardWindowStopsAtRequestedWhenNearer() {
-    let w = ContiguousFetchPlanner.nextWindow(
-      earliest: 20_240_101, latest: 20_240_115,
-      requested: 20_240_120, today: 20_240_601,
-      windowDays: 30, forwardBuffer: 2)
-    #expect(w == 20_240_115...20_240_120)
+  @Test
+  func forwardWindowStopsAtRequestedWhenNearer() {
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_101,
+      latest: 20_240_115,
+      requested: 20_240_120,
+      today: 20_240_601,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_115...20_240_120)
   }
 
-  @Test func forwardWindowCappedAtTodayPlusBuffer() {
+  @Test
+  func forwardWindowCappedAtTodayPlusBuffer() {
     // requested beyond today → cap at today+buffer, never an arbitrary future date.
-    let w = ContiguousFetchPlanner.nextWindow(
-      earliest: 20_240_101, latest: 20_240_115,
-      requested: 20_240_601, today: 20_240_118,
-      windowDays: 30, forwardBuffer: 2)
-    #expect(w == 20_240_115...20_240_120)  // today(18)+buffer(2)=20
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_101,
+      latest: 20_240_115,
+      requested: 20_240_601,
+      today: 20_240_118,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_115...20_240_120)  // today(18)+buffer(2)=20
+  }
+
+  @Test
+  func backwardWindowIsBoundedAndAnchoredAtEarliest() {
+    // requested far before earliest → window [earliest-30 … earliest-1], not [requested … earliest-1].
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_201,
+      latest: 20_240_301,
+      requested: 20_230_101,
+      today: 20_240_601,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_102...20_240_131)  // earliest-1 = Jan31, back 30 days = Jan02
+  }
+
+  @Test
+  func backwardWindowStopsAtRequestedWhenNearer() {
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: 20_240_201,
+      latest: 20_240_301,
+      requested: 20_240_120,
+      today: 20_240_601,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_120...20_240_131)
+  }
+
+  @Test
+  func coldCacheWindowEndsAtRequestedWithPriorContext() {
+    // empty cache: window ends at min(requested, today+buffer), reaches back windowDays for fallback context.
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: nil,
+      latest: nil,
+      requested: 20_240_215,
+      today: 20_240_601,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_116...20_240_215)
+  }
+
+  @Test
+  func coldCacheWindowCapsFutureRequestAtToday() {
+    let win = ContiguousFetchPlanner.nextWindow(
+      earliest: nil,
+      latest: nil,
+      requested: 20_240_601,
+      today: 20_240_215,
+      config: Self.defaultConfig)
+    #expect(win == 20_240_118...20_240_217)  // end=today+buffer=Feb17, back 30 = Jan18
   }
 }

--- a/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+++ b/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import Moolah
@@ -109,5 +110,52 @@ struct ContiguousFetchPlannerTests {
       today: 20_240_215,
       config: Self.defaultConfig)
     #expect(win == 20_240_118...20_240_217)  // end=today+buffer=Feb17, back 30 = Jan18
+  }
+
+  // MARK: - chunked
+
+  /// Midnight-UTC anchor for `YYYY-MM-DD`.
+  private func day(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = .utc
+    return formatter.date(from: string) ?? Date(timeIntervalSince1970: 0)
+  }
+
+  @Test
+  func chunkedSplitsLongRangeIntoBoundedWindows() {
+    // 2024-01-01 … 2024-03-31 (91 days) at ≤30-day windows. Each window spans
+    // 30 day-components ([Jan1…Jan31], [Feb1…Mar2], [Mar3…Mar31]) → 3
+    // sub-ranges, consecutive and non-overlapping.
+    let chunks = ContiguousFetchPlanner.chunked(
+      day("2024-01-01")...day("2024-03-31"), days: 30)
+    #expect(chunks.count == 3)
+    #expect(chunks.first?.lowerBound == day("2024-01-01"))
+    #expect(chunks.last?.upperBound == day("2024-03-31"))
+    let cal = Calendar.utc
+    for chunk in chunks {
+      let span = cal.dateComponents([.day], from: chunk.lowerBound, to: chunk.upperBound).day ?? 0
+      #expect(span <= 30)
+    }
+    // Each chunk starts the day after the previous one ends (contiguous, no gap).
+    for idx in 1..<chunks.count {
+      let prevEnd = chunks[idx - 1].upperBound
+      let expectedStart = cal.date(byAdding: .day, value: 1, to: prevEnd)
+      #expect(chunks[idx].lowerBound == expectedStart)
+    }
+  }
+
+  @Test
+  func chunkedShortRangeIsSingleWindow() {
+    let chunks = ContiguousFetchPlanner.chunked(
+      day("2024-01-01")...day("2024-01-10"), days: 30)
+    #expect(chunks == [day("2024-01-01")...day("2024-01-10")])
+  }
+
+  @Test
+  func chunkedSingleDayRangeIsSingleWindow() {
+    let chunks = ContiguousFetchPlanner.chunked(
+      day("2024-01-01")...day("2024-01-01"), days: 30)
+    #expect(chunks == [day("2024-01-01")...day("2024-01-01")])
   }
 }

--- a/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+++ b/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
@@ -1,0 +1,19 @@
+import Testing
+
+@testable import Moolah
+
+@Suite struct ContiguousFetchPlannerTests {
+  // DateKeys are yyyymmdd ints; use real calendar days so +1 day math is exercised.
+  static let jan01: Int32 = 20_240_101
+  static let jan15: Int32 = 20_240_115
+  static let jan31: Int32 = 20_240_131
+  static let feb15: Int32 = 20_240_215
+
+  @Test func requestedInsideBoundsReturnsNil() {
+    let window = ContiguousFetchPlanner.nextWindow(
+      earliest: Self.jan01, latest: Self.jan31,
+      requested: Self.jan15, today: Self.feb15,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(window == nil)
+  }
+}

--- a/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+++ b/MoolahTests/Shared/ContiguousFetchPlannerTests.swift
@@ -16,4 +16,10 @@ import Testing
       windowDays: 30, forwardBuffer: 2)
     #expect(window == nil)
   }
+
+  @Test func addingDaysCrossesMonthBoundary() {
+    #expect(ContiguousFetchPlanner.addingDays(1, to: 20_240_131) == 20_240_201)
+    #expect(ContiguousFetchPlanner.addingDays(-1, to: 20_240_301) == 20_240_229)  // leap year
+    #expect(ContiguousFetchPlanner.addingDays(30, to: 20_240_101) == 20_240_131)
+  }
 }

--- a/MoolahTests/Shared/CryptoPriceServiceBoundaryRangeTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceBoundaryRangeTests.swift
@@ -5,15 +5,16 @@ import Testing
 
 @testable import Moolah
 
-/// Regression cover for the inverted-range trap in
-/// `CryptoPriceService.extensionWindow`. The backward extension built
-/// `requestedDate...fetchEnd`, where `fetchEnd` is midnight of
-/// (`earliestDate` − 1) while `requestedDate` is a noon-anchored day
-/// token from the daily-balance walk. When the requested day is exactly
-/// that boundary day, `requestedDate` (noon) > `fetchEnd` (midnight of the
-/// same calendar day), so the `ClosedRange` initializer trapped
-/// (`EXC_BREAKPOINT`) — crashing on launch for any profile whose chart
-/// history reaches the day before a crypto price cache begins.
+/// Regression cover for the inverted-range trap in the crypto cache
+/// backward-extension path. The extension built `requestedDate...fetchEnd`,
+/// where `fetchEnd` is midnight of (`earliestDate` − 1) while
+/// `requestedDate` is a noon-anchored day token from the daily-balance walk.
+/// When the requested day is exactly that boundary day, `requestedDate`
+/// (noon) > `fetchEnd` (midnight of the same calendar day), so the
+/// `ClosedRange` initializer trapped (`EXC_BREAKPOINT`) — crashing on launch
+/// for any profile whose chart history reaches the day before a crypto price
+/// cache begins. The bounded `extendContiguously` /
+/// `ContiguousFetchPlanner`-driven path no longer builds such a range.
 @Suite("CryptoPriceService — boundary range")
 struct CryptoPriceServiceBoundaryRangeTests {
   private let ethInstrument = Instrument.crypto(

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -67,10 +67,21 @@ struct CryptoPriceServiceTestsMore {
 
   @Test
   func prefetchUpdatesCacheForRegisteredItems() async throws {
-    let service = try makeService(prices: [
-      "1:native": ["2026-04-11": dec("1640.00")],
-      "0:native": ["2026-04-11": dec("67890.00")],
-    ])
+    // Pin `now` to 2026-04-12 so `prefetchLatest` tags the live tick as
+    // yesterday (2026-04-11), making `price(on: 2026-04-11)` a cache hit
+    // rather than a bounded backward-extension fetch. The bounded loop
+    // (introduced in the contiguous-extension fix) makes no progress when
+    // the client only knows 2026-04-11 but the current bounds start at
+    // 2026-06-16 (today's yesterday with wall-clock `now`) — so the test
+    // must pin `now` to align the prefetch date with the requested date.
+    let frozen = date("2026-04-12")
+    let service = try makeService(
+      prices: [
+        "1:native": ["2026-04-11": dec("1640.00")],
+        "0:native": ["2026-04-11": dec("67890.00")],
+      ],
+      now: { frozen }
+    )
     await service.prefetchLatest(for: [ethRegistration, btcRegistration])
     let ethPrice = try await service.price(
       for: ethInstrument, mapping: ethMapping, on: date("2026-04-11"))

--- a/MoolahTests/Support/UTCDay.swift
+++ b/MoolahTests/Support/UTCDay.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@testable import Moolah
+
+/// Parses a `YYYY-MM-DD` string to a midnight-UTC `Date`. Shared across the
+/// price/rate contiguity test suites to keep date construction readable.
+///
+/// Intended for compile-time string literals; a failure means the test
+/// source itself contains a malformed date — a programmer error the run
+/// cannot proceed past.
+func utcDay(
+  _ string: String,
+  file: StaticString = #file,
+  line: UInt = #line
+) -> Date {
+  let formatter = ISO8601DateFormatter()
+  formatter.formatOptions = [.withFullDate]
+  formatter.timeZone = .utc
+  guard let date = formatter.date(from: string) else {
+    preconditionFailure("Could not parse ISO date: \(string)", file: file, line: line)
+  }
+  return date
+}

--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -14,22 +14,40 @@ enum ContiguousFetchPlanner {
   struct Config {
     /// Max span of a single window (≈30 days). Large enough to clear a
     /// weekend/holiday run, small enough that a provider serves it wholesale.
-    var windowDays: Int
+    let windowDays: Int
     /// Days past `today` a forward window may reach (≈2). Providers tolerate
     /// slight future dates and clamp, so this never withholds a
     /// forward-timezone market's already-published close.
-    var forwardBuffer: Int
+    let forwardBuffer: Int
   }
+
+  /// Shared formatter for `addingDays` — `[.withFullDate]`, UTC. Hoisted to a
+  /// static so the hot per-window loop does not allocate an
+  /// `ISO8601DateFormatter` on every call. `ISO8601DateFormatter`'s
+  /// `date(from:)` / `string(from:)` are documented thread-safe and the
+  /// formatter is configured once and never mutated, so `nonisolated(unsafe)`
+  /// is sound here.
+  nonisolated(unsafe) private static let dateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = TimeZone.utc
+    return formatter
+  }()
 
   /// Returns the next fetch window to issue, or `nil` when the requested date
   /// is already inside `[earliest, latest]` (read via prior-trading-day
   /// fallback, no fetch needed).
   ///
-  /// - earliest/latest: current contiguous bounds as `DateKey`, or `nil`
-  ///   when the series is empty (cold cache).
-  /// - requested: the `DateKey` the caller needs.
-  /// - today: the `DateKey` for "now" (callers pass `now()`'s day).
-  /// - config: window sizing and forward-buffer constants.
+  /// - Parameters:
+  ///   - earliest: current contiguous lower bound as `DateKey`, or `nil`
+  ///     when the series is empty (cold cache).
+  ///   - latest: current contiguous upper bound as `DateKey`, or `nil`
+  ///     when the series is empty (cold cache).
+  ///   - requested: the `DateKey` the caller needs.
+  ///   - today: the `DateKey` for "now" (callers pass `now()`'s day).
+  ///   - config: window sizing and forward-buffer constants.
+  /// - Returns: the next fetch window as a `ClosedRange<Int32>`, or `nil`
+  ///   when the requested date is already inside `[earliest, latest]`.
   static func nextWindow(
     earliest: Int32?,
     latest: Int32?,
@@ -60,14 +78,34 @@ enum ContiguousFetchPlanner {
   /// `DateKey` — the encoding is not contiguous across month ends.
   static func addingDays(_ days: Int, to key: Int32) -> Int32 {
     let iso = DateKey.isoString(key)
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    formatter.timeZone = TimeZone.utc
     guard
-      let date = formatter.date(from: iso),
+      let date = dateFormatter.date(from: iso),
       let shifted = Calendar.utc.date(byAdding: .day, value: days, to: date),
-      let result = DateKey.from(isoString: formatter.string(from: shifted))
+      let result = DateKey.from(isoString: dateFormatter.string(from: shifted))
     else { return key }
+    return result
+  }
+
+  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
+  /// days (UTC). Used by the price/rate services' `uncoveredSubRanges` to
+  /// cap individual fetches so a horizon-restricted provider cannot jump the
+  /// cache bounds over a void.
+  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
+    let cal = Calendar.utc
+    var result: [ClosedRange<Date>] = []
+    var start = range.lowerBound
+    while start <= range.upperBound {
+      let end: Date
+      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
+        end = min(candidate, range.upperBound)
+      } else {
+        end = range.upperBound
+      }
+      result.append(start...end)
+      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
+      if next > range.upperBound { break }
+      start = next
+    }
     return result
   }
 

--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -31,7 +31,14 @@ enum ContiguousFetchPlanner {
         windowDays: windowDays, forwardBuffer: forwardBuffer)
     }
     if requested >= earliest && requested <= latest { return nil }
-    return nil  // filled in by later tasks
+    if requested > latest {
+      let cap = min(requested, addingDays(forwardBuffer, to: today))
+      let upper = min(addingDays(windowDays, to: latest), cap)
+      // Anchor at `latest` itself so a stale latest-day tick is overwritten.
+      guard latest <= upper else { return nil }
+      return latest...upper
+    }
+    return nil  // filled in by Task 4 (backward branch)
   }
 
   /// Adds `days` calendar days to a `DateKey` (`Int32` yyyymmdd), crossing

--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -10,35 +10,49 @@ import Foundation
 /// `nil` means "the requested date is already inside `[earliest, latest]`"
 /// — the caller reads it via the prior-trading-day fallback, no fetch.
 enum ContiguousFetchPlanner {
+  /// Configuration shared across all window calculations for a given service.
+  struct Config {
+    /// Max span of a single window (≈30 days). Large enough to clear a
+    /// weekend/holiday run, small enough that a provider serves it wholesale.
+    var windowDays: Int
+    /// Days past `today` a forward window may reach (≈2). Providers tolerate
+    /// slight future dates and clamp, so this never withholds a
+    /// forward-timezone market's already-published close.
+    var forwardBuffer: Int
+  }
+
+  /// Returns the next fetch window to issue, or `nil` when the requested date
+  /// is already inside `[earliest, latest]` (read via prior-trading-day
+  /// fallback, no fetch needed).
+  ///
   /// - earliest/latest: current contiguous bounds as `DateKey`, or `nil`
   ///   when the series is empty (cold cache).
   /// - requested: the `DateKey` the caller needs.
-  /// - today: the `DateKey` for "now" (callers pass `now()`'s day). Forward
-  ///   windows may extend up to `today + forwardBuffer` — providers tolerate
-  ///   slight future dates and clamp, so this never withholds a
-  ///   forward-timezone market's already-published close.
-  /// - windowDays: max span of a single window (≈30). Large enough to clear
-  ///   a weekend/holiday run, small enough that a provider serves it whole.
-  /// - forwardBuffer: days past `today` a forward window may reach (≈2).
+  /// - today: the `DateKey` for "now" (callers pass `now()`'s day).
+  /// - config: window sizing and forward-buffer constants.
   static func nextWindow(
-    earliest: Int32?, latest: Int32?,
-    requested: Int32, today: Int32,
-    windowDays: Int, forwardBuffer: Int
+    earliest: Int32?,
+    latest: Int32?,
+    requested: Int32,
+    today: Int32,
+    config: Config
   ) -> ClosedRange<Int32>? {
     guard let earliest, let latest else {
-      return coldWindow(
-        requested: requested, today: today,
-        windowDays: windowDays, forwardBuffer: forwardBuffer)
+      return coldWindow(requested: requested, today: today, config: config)
     }
     if requested >= earliest && requested <= latest { return nil }
     if requested > latest {
-      let cap = min(requested, addingDays(forwardBuffer, to: today))
-      let upper = min(addingDays(windowDays, to: latest), cap)
+      let cap = min(requested, addingDays(config.forwardBuffer, to: today))
+      let upper = min(addingDays(config.windowDays, to: latest), cap)
       // Anchor at `latest` itself so a stale latest-day tick is overwritten.
       guard latest <= upper else { return nil }
       return latest...upper
     }
-    return nil  // filled in by Task 4 (backward branch)
+    // requested < earliest: backward branch
+    let lower = max(requested, addingDays(-config.windowDays, to: earliest))
+    let upper = addingDays(-1, to: earliest)
+    guard lower <= upper else { return nil }
+    return lower...upper
   }
 
   /// Adds `days` calendar days to a `DateKey` (`Int32` yyyymmdd), crossing
@@ -49,7 +63,8 @@ enum ContiguousFetchPlanner {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withFullDate]
     formatter.timeZone = TimeZone.utc
-    guard let date = formatter.date(from: iso),
+    guard
+      let date = formatter.date(from: iso),
       let shifted = Calendar.utc.date(byAdding: .day, value: days, to: date),
       let result = DateKey.from(isoString: formatter.string(from: shifted))
     else { return key }
@@ -57,8 +72,13 @@ enum ContiguousFetchPlanner {
   }
 
   private static func coldWindow(
-    requested: Int32, today: Int32, windowDays: Int, forwardBuffer: Int
+    requested: Int32,
+    today: Int32,
+    config: Config
   ) -> ClosedRange<Int32>? {
-    return nil  // filled in by Task 4
+    let end = min(requested, addingDays(config.forwardBuffer, to: today))
+    let start = addingDays(-config.windowDays, to: end)
+    guard start <= end else { return nil }
+    return start...end
   }
 }

--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Plans the next **bounded, boundary-anchored** fetch window for a
+/// contiguous date-keyed price/rate cache. Pure arithmetic on `DateKey`
+/// (`Int32` yyyymmdd) — no I/O. Bounding the window is what keeps a cache
+/// contiguous: a provider can only ever serve days inside a window the
+/// planner already declared queried, so the cache's `[earliest, latest]`
+/// can never advance past a day that was never fetched.
+///
+/// `nil` means "the requested date is already inside `[earliest, latest]`"
+/// — the caller reads it via the prior-trading-day fallback, no fetch.
+enum ContiguousFetchPlanner {
+  /// - earliest/latest: current contiguous bounds as `DateKey`, or `nil`
+  ///   when the series is empty (cold cache).
+  /// - requested: the `DateKey` the caller needs.
+  /// - today: the `DateKey` for "now" (callers pass `now()`'s day). Forward
+  ///   windows may extend up to `today + forwardBuffer` — providers tolerate
+  ///   slight future dates and clamp, so this never withholds a
+  ///   forward-timezone market's already-published close.
+  /// - windowDays: max span of a single window (≈30). Large enough to clear
+  ///   a weekend/holiday run, small enough that a provider serves it whole.
+  /// - forwardBuffer: days past `today` a forward window may reach (≈2).
+  static func nextWindow(
+    earliest: Int32?, latest: Int32?,
+    requested: Int32, today: Int32,
+    windowDays: Int, forwardBuffer: Int
+  ) -> ClosedRange<Int32>? {
+    guard let earliest, let latest else {
+      return coldWindow(
+        requested: requested, today: today,
+        windowDays: windowDays, forwardBuffer: forwardBuffer)
+    }
+    if requested >= earliest && requested <= latest { return nil }
+    return nil  // filled in by later tasks
+  }
+
+  private static func coldWindow(
+    requested: Int32, today: Int32, windowDays: Int, forwardBuffer: Int
+  ) -> ClosedRange<Int32>? {
+    return nil  // filled in by Task 4
+  }
+}

--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -87,8 +87,8 @@ enum ContiguousFetchPlanner {
   }
 
   /// Splits `range` into consecutive sub-ranges of at most `days` calendar
-  /// days (UTC). Used by the price/rate services' `uncoveredSubRanges` to
-  /// cap individual fetches so a horizon-restricted provider cannot jump the
+  /// days (UTC). Used by the exchange-rate and stock-price services to cap
+  /// individual fetches so a horizon-restricted provider cannot jump the
   /// cache bounds over a void.
   static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
     let cal = Calendar.utc

--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -34,6 +34,21 @@ enum ContiguousFetchPlanner {
     return nil  // filled in by later tasks
   }
 
+  /// Adds `days` calendar days to a `DateKey` (`Int32` yyyymmdd), crossing
+  /// month and year boundaries correctly. Never use raw `Int32 ± n` on a
+  /// `DateKey` — the encoding is not contiguous across month ends.
+  static func addingDays(_ days: Int, to key: Int32) -> Int32 {
+    let iso = DateKey.isoString(key)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = TimeZone.utc
+    guard let date = formatter.date(from: iso),
+      let shifted = Calendar.utc.date(byAdding: .day, value: days, to: date),
+      let result = DateKey.from(isoString: formatter.string(from: shifted))
+    else { return key }
+    return result
+  }
+
   private static func coldWindow(
     requested: Int32, today: Int32, windowDays: Int, forwardBuffer: Int
   ) -> ClosedRange<Int32>? {

--- a/Shared/CryptoPriceService+Debug.swift
+++ b/Shared/CryptoPriceService+Debug.swift
@@ -9,22 +9,7 @@
     /// are N − 1 un-fetched interior days between two adjacent data points.
     /// Used by contiguity tests to assert the bounded-window invariant.
     func debugMaxInteriorGapDays(tokenId: String) -> Int {
-      guard let cache = caches[tokenId] else { return 0 }
-      let keys = cache.prices.sortedKeys
-      guard keys.count > 1 else { return 0 }
-      let fmt = ISO8601DateFormatter()
-      fmt.formatOptions = [.withFullDate]
-      fmt.timeZone = TimeZone.utc
-      var maxGap = 0
-      for idx in 1..<keys.count {
-        let prev = DateKey.isoString(keys[idx - 1])
-        let curr = DateKey.isoString(keys[idx])
-        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
-          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
-          if gap - 1 > maxGap { maxGap = gap - 1 }
-        }
-      }
-      return maxGap
+      caches[tokenId]?.prices.maxInteriorGapDays ?? 0
     }
   }
 #endif

--- a/Shared/CryptoPriceService+Debug.swift
+++ b/Shared/CryptoPriceService+Debug.swift
@@ -1,0 +1,30 @@
+// Shared/CryptoPriceService+Debug.swift
+
+#if DEBUG
+  import Foundation
+
+  extension CryptoPriceService {
+    /// Returns the largest gap (in calendar days) between consecutive price
+    /// entries in the in-memory cache for `tokenId`. A gap of N means there
+    /// are N − 1 un-fetched interior days between two adjacent data points.
+    /// Used by contiguity tests to assert the bounded-window invariant.
+    func debugMaxInteriorGapDays(tokenId: String) -> Int {
+      guard let cache = caches[tokenId] else { return 0 }
+      let keys = cache.prices.sortedKeys
+      guard keys.count > 1 else { return 0 }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = TimeZone.utc
+      var maxGap = 0
+      for idx in 1..<keys.count {
+        let prev = DateKey.isoString(keys[idx - 1])
+        let curr = DateKey.isoString(keys[idx])
+        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
+          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
+          if gap - 1 > maxGap { maxGap = gap - 1 }
+        }
+      }
+      return maxGap
+    }
+  }
+#endif

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -80,6 +80,7 @@ extension CryptoPriceService {
     let todayKey =
       DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
     let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    var lastFetchError: (any Error)?
     // Forward first, then backward; each window anchors at the live cache bounds.
     for requestedKey in [upperKey, lowerKey] {
       var guardSteps = 0
@@ -103,7 +104,8 @@ extension CryptoPriceService {
         } catch is CancellationError {
           throw CancellationError()
         } catch {
-          // Provider chain failed; stop this direction (cached data is used).
+          // Provider chain failed; capture error and stop this direction.
+          lastFetchError = error
           break
         }
         if boundsKeys(tokenId: tokenId) == before { break }  // no progress — stop
@@ -113,6 +115,20 @@ extension CryptoPriceService {
           "coverRangeContiguously: guard limit reached for \(tokenId, privacy: .public)"
         )
       }
+    }
+    // Surface the last provider error if any endpoint is still uncovered —
+    // mirrors resolveAfterExtension so prices(in:) matches price(on:)'s contract.
+    if let lastFetchError {
+      let bounds = boundsKeys(tokenId: tokenId)
+      let stillUncovered = [upperKey, lowerKey].contains { key in
+        ContiguousFetchPlanner.nextWindow(
+          earliest: bounds.earliest,
+          latest: bounds.latest,
+          requested: key,
+          today: todayKey,
+          config: config) != nil
+      }
+      if stillUncovered { throw lastFetchError }
     }
   }
 
@@ -153,7 +169,7 @@ extension CryptoPriceService {
   /// Converts a `ClosedRange<String>` of ISO `YYYY-MM-DD` bounds into a
   /// `ClosedRange<Date>`. Falls back to `now()` for any unparseable bound
   /// and ensures the result is non-inverted.
-  private func parseInterval(_ iso: ClosedRange<String>) -> ClosedRange<Date> {
+  func parseInterval(_ iso: ClosedRange<String>) -> ClosedRange<Date> {
     let lower = dateFormatter.date(from: iso.lowerBound) ?? now()
     let upper = dateFormatter.date(from: iso.upperBound) ?? now()
     return lower...max(lower, upper)
@@ -247,151 +263,5 @@ extension CryptoPriceService {
         provider: lastProvider,
         kind: .network(underlyingDescription: String(describing: error)))
     }
-  }
-}
-
-// MARK: - Background warming
-
-extension CryptoPriceService {
-  /// Background-warm a token's prices over `range` using the same contiguous
-  /// bounded-window loop as `coverRangeContiguously`. Covers both endpoints,
-  /// anchoring each window at the live cache bounds and stopping the moment a
-  /// window returns no new data — preventing interior gaps from horizon-
-  /// restricted providers. Surfaces `RateLimitGateError.cooldown` so
-  /// `CryptoPriceWarmer` can sleep precisely. Idempotent. See issue #1075.
-  func warmRange(
-    for instrument: Instrument,
-    mapping: CryptoProviderMapping,
-    in range: ClosedRange<Date>
-  ) async -> WarmOutcome {
-    let tokenId = instrument.id
-    if !hydratedTokenIds.contains(tokenId) {
-      do { try await loadCache(tokenId: tokenId) } catch {
-        logger.warning(
-          "warmRange: loadCache failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
-        )
-      }
-    }
-    let fetchUpperBound = cappedToYesterday(range.upperBound, now: now, timeZone: timeZone)
-    guard range.lowerBound <= fetchUpperBound else { return .filled }
-    guard
-      let upperKey = DateKey.from(isoString: dateFormatter.string(from: fetchUpperBound)),
-      let lowerKey = DateKey.from(isoString: dateFormatter.string(from: range.lowerBound))
-    else { return .unavailable }
-    let todayKey =
-      DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
-    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
-
-    // Fast-path: if both endpoints are already within the cached range, there
-    // is nothing to fetch. Mirrors the old `subRanges.isEmpty` early exit.
-    let existingBounds = boundsKeys(tokenId: tokenId)
-    if let earliest = existingBounds.earliest, let latest = existingBounds.latest,
-      lowerKey >= earliest, upperKey <= latest
-    {
-      return .filled
-    }
-
-    var filledAny = false
-    // Cover forward endpoint first, then backward — mirrors `coverRangeContiguously`.
-    for requestedKey in [upperKey, lowerKey] {
-      let step = await warmStep(
-        instrument: instrument,
-        mapping: mapping,
-        requestedKey: requestedKey,
-        todayKey: todayKey,
-        config: config)
-      switch step {
-      case .filled: filledAny = true
-      case .cooledDown: return step
-      case .unavailable: continue
-      }
-    }
-    return filledAny ? .filled : .unavailable
-  }
-
-  /// Contiguous bounded-window loop toward `requestedKey`, anchored at the
-  /// live cache bounds. Returns `.filled` if any window filled data,
-  /// `.cooledDown` on a provider rate limit, or `.unavailable` when no window
-  /// served data (provider horizon reached). Used by `warmRange`.
-  private func warmStep(
-    instrument: Instrument,
-    mapping: CryptoProviderMapping,
-    requestedKey: Int32,
-    todayKey: Int32,
-    config: ContiguousFetchPlanner.Config
-  ) async -> WarmOutcome {
-    let tokenId = instrument.id
-    var guardSteps = 0
-    var filledAny = false
-    warmLoop: while guardSteps < 250 {
-      guardSteps += 1
-      let bounds = boundsKeys(tokenId: tokenId)
-      guard
-        let window = ContiguousFetchPlanner.nextWindow(
-          earliest: bounds.earliest,
-          latest: bounds.latest,
-          requested: requestedKey,
-          today: todayKey,
-          config: config)
-      else { break warmLoop }  // endpoint already covered
-      let before = bounds
-      let fetchInterval = parseInterval(
-        DateKey.isoString(window.lowerBound)...DateKey.isoString(window.upperBound))
-      switch await fetchSubRangeWarming(
-        instrument: instrument, mapping: mapping, range: fetchInterval)
-      {
-      case .filled:
-        filledAny = true
-      case .cooledDown(let until):
-        return .cooledDown(until: until)
-      case .unavailable:
-        break warmLoop
-      }
-      if boundsKeys(tokenId: tokenId) == before { break warmLoop }
-    }
-    if guardSteps >= 250 {
-      logger.warning("warmRange: guard limit reached for \(tokenId, privacy: .public)")
-    }
-    return filledAny ? .filled : .unavailable
-  }
-
-  /// Runs the provider fallback chain for one sub-range, surfacing the
-  /// soonest cooldown deadline rather than wrapping it into a
-  /// `WalletSyncError` the way `fetchRange` does. Returns `.unavailable`
-  /// when every client returned empty / a non-cooldown failure.
-  private func fetchSubRangeWarming(
-    instrument: Instrument, mapping: CryptoProviderMapping, range: ClosedRange<Date>
-  ) async -> WarmOutcome {
-    let tokenId = instrument.id
-    let symbol = instrument.ticker ?? instrument.name
-    var soonestCooldown: Date?
-    for client in clients {
-      do {
-        let fetched = try await client.dailyPrices(for: mapping, in: range)
-        if !fetched.isEmpty {
-          let delta = mergeReturningDelta(tokenId: tokenId, symbol: symbol, newPrices: fetched)
-          if !delta.isEmpty {
-            try await persistDelta(tokenId: tokenId, deltaRecords: delta)
-          }
-          return .filled
-        }
-      } catch let cooldown as RateLimitGateError {
-        if case .cooldown(let until) = cooldown {
-          soonestCooldown = soonestCooldown.map { min($0, until) } ?? until
-        }
-        continue
-      } catch CryptoPriceError.noProviderMapping {
-        // Routing decision — this client has no symbol for the token
-        // (e.g. USDT on Binance). Skip silently, same as `fetchRange`.
-        continue
-      } catch {
-        logger.warning(
-          "fetchSubRangeWarming: fetch/persist failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
-        )
-        continue
-      }
-    }
-    if let soonestCooldown { return .cooledDown(until: soonestCooldown) }
-    return .unavailable
   }
 }

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -2,69 +2,156 @@
 
 import Foundation
 
-// MARK: - CryptoPriceService provider fallback
+// MARK: - Contiguous bounded extension (single price)
 
 extension CryptoPriceService {
-  /// Runs the provider fallback chain
-  /// (CoinGecko → CryptoCompare → Binance) for the date enclosed by
-  /// `dateString`, persists any new prices, and returns the requested
-  /// day's value (or the prior-trading-day fallback). Throws a
-  /// `WalletSyncError` attributed to the most recent *real* provider
-  /// failure when no provider could fill the date — `noProviderMapping`
-  /// errors are routing decisions (e.g. USDT has no Binance pair), not
-  /// runtime failures, so they never become the attribution.
-  func fetchAndExtendCache(
+  /// Extends the cache contiguously toward `dateString` using bounded
+  /// 30-day windows driven by `ContiguousFetchPlanner`. Each iteration
+  /// fetches one window anchored at the current cache boundary, so the
+  /// cache never jumps its bounds over un-fetched interior days (the
+  /// interior-gap bug fixed here). The loop exits when the date is covered,
+  /// when no progress was made (provider genuinely has no data for this
+  /// window), or when a provider error occurs on every window attempt.
+  ///
+  /// Unlike the old unbounded `extensionWindow`, a horizon-restricted
+  /// provider (e.g. CoinGecko free tier: 365 days) causes the loop to stop
+  /// at the edge of its coverage window rather than jumping `latest` all
+  /// the way to the requested date and leaving a void.
+  func extendContiguously(
     instrument: Instrument,
     mapping: CryptoProviderMapping,
-    fetchInterval: ClosedRange<Date>,
+    tokenId: String,
     dateString: String
   ) async throws -> Decimal {
-    let tokenId = instrument.id
-    let symbol = instrument.ticker ?? instrument.name
-    var lastError: (any Error)?
-    var lastProvider: SyncProvider?
-    for client in clients {
+    let requestedKey = DateKey.from(isoString: dateString) ?? Int32.max
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? requestedKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    var lastFetchError: (any Error)?
+    var guardSteps = 0
+    while guardSteps < 64 {
+      guardSteps += 1
+      let bounds = boundsKeys(tokenId: tokenId)
+      guard
+        let window = ContiguousFetchPlanner.nextWindow(
+          earliest: bounds.earliest,
+          latest: bounds.latest,
+          requested: requestedKey,
+          today: todayKey,
+          config: config)
+      else { break }  // requested date now in range
+      let before = bounds
+      let fetchInterval = parseInterval(
+        DateKey.isoString(window.lowerBound)...DateKey.isoString(window.upperBound))
       do {
-        let fetched = try await client.dailyPrices(for: mapping, in: fetchInterval)
-        if !fetched.isEmpty {
-          let delta = mergeReturningDelta(
-            tokenId: tokenId, symbol: symbol, newPrices: fetched)
-          if !delta.isEmpty {
-            try await persistDelta(tokenId: tokenId, deltaRecords: delta)
-          }
-          if let price = lookupPrice(tokenId: tokenId, dateString: dateString) {
-            return price
-          }
-        }
+        try await fetchWindowCoalesced(
+          instrument: instrument, mapping: mapping, fetchInterval: fetchInterval)
       } catch is CancellationError {
-        // Cooperative cancellation must surface as `CancellationError`, not
-        // be wrapped into a provider outage — the coalescing owner cancels
-        // this shared task and aggregation callers special-case cancellation.
         throw CancellationError()
-      } catch CryptoPriceError.noProviderMapping {
-        // Routing decision — this client has no symbol for the token
-        // (e.g. USDT on Binance). Skip silently rather than attributing
-        // a non-existent outage to a provider that's behaving as designed.
-        continue
       } catch {
-        lastError = error
-        lastProvider = client.syncProvider
-        continue
+        // Provider chain fully failed for this window; surface error below.
+        lastFetchError = error
+        break
       }
+      if let cached = lookupPrice(tokenId: tokenId, dateString: dateString) {
+        return cached
+      }
+      if let inRange = try inRangeFallback(tokenId: tokenId, dateString: dateString) {
+        return inRange
+      }
+      // No progress (bounds unchanged) means genuine no-more-data; stop and
+      // let a later call re-query the boundary (recent data may publish later).
+      if boundsKeys(tokenId: tokenId) == before { break }
+    }
+    return try resolveAfterExtension(
+      tokenId: tokenId, dateString: dateString, fetchError: lastFetchError)
+  }
+
+  /// Final resolution after the bounded extension loop exits: checks cached
+  /// exact hit, prior-trading-day fallback, in-range fallback, and finally
+  /// re-throws the last provider error or `noPriceAvailable`. Extracted to
+  /// keep `extendContiguously`'s cyclomatic complexity in bounds.
+  private func resolveAfterExtension(
+    tokenId: String,
+    dateString: String,
+    fetchError: (any Error)?
+  ) throws -> Decimal {
+    if let cached = lookupPrice(tokenId: tokenId, dateString: dateString) {
+      return cached
     }
     if let fallback = fallbackPrice(tokenId: tokenId, dateString: dateString) {
       return fallback
     }
-    let underlyingDescription =
-      lastError.map { String(describing: $0) }
-      ?? String(
-        describing: CryptoPriceError.noPriceAvailable(
-          tokenId: tokenId, date: dateString))
-    throw WalletSyncError(
-      provider: lastProvider,
-      kind: .network(underlyingDescription: underlyingDescription))
+    if let inRange = try inRangeFallback(tokenId: tokenId, dateString: dateString) {
+      return inRange
+    }
+    if let fetchError {
+      throw fetchError
+    }
+    throw CryptoPriceError.noPriceAvailable(tokenId: tokenId, date: dateString)
   }
 
+  /// Returns the current cache bounds for `tokenId` as `DateKey` (`Int32`
+  /// yyyymmdd) values. Returns `(nil, nil)` when the cache is cold.
+  func boundsKeys(tokenId: String) -> (earliest: Int32?, latest: Int32?) {
+    guard let cache = caches[tokenId] else { return (nil, nil) }
+    return (
+      DateKey.from(isoString: cache.earliestDate),
+      DateKey.from(isoString: cache.latestDate)
+    )
+  }
+
+  /// Converts a `ClosedRange<String>` of ISO `YYYY-MM-DD` bounds into a
+  /// `ClosedRange<Date>`. Falls back to `now()` for any unparseable bound
+  /// and ensures the result is non-inverted.
+  private func parseInterval(_ iso: ClosedRange<String>) -> ClosedRange<Date> {
+    let lower = dateFormatter.date(from: iso.lowerBound) ?? now()
+    let upper = dateFormatter.date(from: iso.upperBound) ?? now()
+    return lower...max(lower, upper)
+  }
+
+  /// Coalesces concurrent per-window fetches for the same token: if a fetch
+  /// is already in flight, await its result (sharing the round-trip) and
+  /// return. Otherwise starts a new `Task`, registers it in `extensionTasks`
+  /// for sharing, and awaits the result with cooperative-cancellation
+  /// forwarding. The coalescing key is the token id — callers must ensure
+  /// they only issue one window fetch at a time per token.
+  func fetchWindowCoalesced(
+    instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    fetchInterval: ClosedRange<Date>
+  ) async throws {
+    let tokenId = instrument.id
+    if let inFlight = extensionTasks[tokenId] {
+      _ = try? await inFlight.task.value
+      return
+    }
+    let requestId = UUID()
+    let task = Task<Decimal, Error> { [self] in
+      try await self.fetchRange(
+        instrument: instrument,
+        mapping: mapping,
+        from: fetchInterval.lowerBound,
+        to: fetchInterval.upperBound)
+      return 0
+    }
+    extensionTasks[tokenId] = (requestId, task)
+    defer {
+      if extensionTasks[tokenId]?.id == requestId {
+        extensionTasks.removeValue(forKey: tokenId)
+      }
+    }
+    _ = try await withTaskCancellationHandler {
+      try await task.value
+    } onCancel: {
+      task.cancel()
+    }
+  }
+}
+
+// MARK: - Provider fallback for a date range
+
+extension CryptoPriceService {
   /// Runs the provider fallback chain
   /// (CoinGecko → CryptoCompare → Binance) for a date range, tolerating
   /// per-provider failures and only throwing when every client errored.
@@ -91,7 +178,7 @@ extension CryptoPriceService {
         }
       } catch is CancellationError {
         // Surface cooperative cancellation unchanged rather than wrapping it
-        // into a provider outage. Mirrors `fetchAndExtendCache`.
+        // into a provider outage. Mirrors `fetchWindowCoalesced`.
         throw CancellationError()
       } catch CryptoPriceError.noProviderMapping {
         // Routing decision — this client has no symbol for the token
@@ -153,8 +240,9 @@ extension CryptoPriceService {
     return filledAny ? .filled : .unavailable
   }
 
-  /// The sub-ranges of `range` not already covered by the token's cache.
-  /// Mirrors the backward/forward extension decision in
+  /// The sub-ranges of `range` not already covered by the token's cache,
+  /// chunked into at most 30-day windows so no single fetch spans an
+  /// un-served interior. Mirrors the backward/forward extension decision in
   /// `prices(for:mapping:in:)` — including its boundary-day inversion
   /// guards (`range.lowerBound <= backEnd` and `forwardStart <=
   /// fetchUpperBound`) so a noon-anchored day token immediately adjacent
@@ -168,7 +256,7 @@ extension CryptoPriceService {
     let fetchEndString = dateFormatter.string(from: fetchUpperBound)
     let gregorian = Calendar.utc
     guard let cache = caches[tokenId] else {
-      return [range.lowerBound...fetchUpperBound]  // cold cache: whole range
+      return Self.chunked(range.lowerBound...fetchUpperBound, days: 30)
     }
     var result: [ClosedRange<Date>] = []
     if rangeStart < cache.earliestDate,
@@ -176,13 +264,35 @@ extension CryptoPriceService {
       let backEnd = gregorian.date(byAdding: .day, value: -1, to: earliest),
       range.lowerBound <= backEnd
     {
-      result.append(range.lowerBound...backEnd)
+      result += Self.chunked(range.lowerBound...backEnd, days: 30)
     }
     if fetchEndString > cache.latestDate,
       let forwardStart = dateFormatter.date(from: cache.latestDate),
       forwardStart <= fetchUpperBound
     {
-      result.append(forwardStart...fetchUpperBound)
+      result += Self.chunked(forwardStart...fetchUpperBound, days: 30)
+    }
+    return result
+  }
+
+  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
+  /// days (UTC). Used by `uncoveredSubRanges` to cap individual fetches so
+  /// a horizon-restricted provider cannot jump the cache bounds over a void.
+  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
+    let cal = Calendar.utc
+    var result: [ClosedRange<Date>] = []
+    var start = range.lowerBound
+    while start <= range.upperBound {
+      let end: Date
+      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
+        end = min(candidate, range.upperBound)
+      } else {
+        end = range.upperBound
+      }
+      result.append(start...end)
+      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
+      if next > range.upperBound { break }
+      start = next
     }
     return result
   }

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -13,10 +13,10 @@ extension CryptoPriceService {
   /// when no progress was made (provider genuinely has no data for this
   /// window), or when a provider error occurs on every window attempt.
   ///
-  /// Unlike the old unbounded `extensionWindow`, a horizon-restricted
-  /// provider (e.g. CoinGecko free tier: 365 days) causes the loop to stop
-  /// at the edge of its coverage window rather than jumping `latest` all
-  /// the way to the requested date and leaving a void.
+  /// Unlike an unbounded extension, a horizon-restricted provider (e.g.
+  /// CoinGecko free tier: 365 days) causes the loop to stop at the edge of
+  /// its coverage window rather than jumping `latest` all the way to the
+  /// requested date and leaving a void.
   func extendContiguously(
     instrument: Instrument,
     mapping: CryptoProviderMapping,
@@ -29,7 +29,7 @@ extension CryptoPriceService {
     let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
     var lastFetchError: (any Error)?
     var guardSteps = 0
-    while guardSteps < 64 {
+    while guardSteps < 250 {
       guardSteps += 1
       let bounds = boundsKeys(tokenId: tokenId)
       guard
@@ -63,8 +63,71 @@ extension CryptoPriceService {
       // let a later call re-query the boundary (recent data may publish later).
       if boundsKeys(tokenId: tokenId) == before { break }
     }
+    if guardSteps >= 250 {
+      logger.warning(
+        "extendContiguously: guard limit reached for \(tokenId, privacy: .public) on \(dateString, privacy: .public)"
+      )
+    }
     return try resolveAfterExtension(
       tokenId: tokenId, dateString: dateString, fetchError: lastFetchError)
+  }
+
+  /// Covers `[lowerKey, upperKey]` contiguously by running the bounded
+  /// planner loop toward each endpoint with a no-progress guard. Unlike a
+  /// precomputed chunk list (which fetches every window upfront and so can
+  /// leave an interior gap when a horizon-restricted provider serves only a
+  /// recent subset), this stops a direction the moment a window yields no
+  /// boundary progress — keeping `[earliest, latest]` contiguous exactly as
+  /// the single-price `extendContiguously` does. Used by
+  /// `prices(for:mapping:in:)`.
+  func coverRangeContiguously(
+    instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    tokenId: String,
+    lowerKey: Int32,
+    upperKey: Int32
+  ) async throws {
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    // Cover the forward endpoint first, then the backward one. Each call
+    // anchors at the live cache bounds, so order does not create a gap.
+    for requestedKey in [upperKey, lowerKey] {
+      var guardSteps = 0
+      while guardSteps < 250 {
+        guardSteps += 1
+        let bounds = boundsKeys(tokenId: tokenId)
+        guard
+          let window = ContiguousFetchPlanner.nextWindow(
+            earliest: bounds.earliest,
+            latest: bounds.latest,
+            requested: requestedKey,
+            today: todayKey,
+            config: config)
+        else { break }  // endpoint now in range
+        let before = bounds
+        let fetchInterval = parseInterval(
+          DateKey.isoString(window.lowerBound)...DateKey.isoString(window.upperBound))
+        do {
+          try await fetchWindowCoalesced(
+            instrument: instrument, mapping: mapping, fetchInterval: fetchInterval)
+        } catch is CancellationError {
+          throw CancellationError()
+        } catch {
+          // Provider chain fully failed for this window; stop this direction
+          // and fall through to the result series (cached data is used).
+          break
+        }
+        // No progress (bounds unchanged) means genuine no-more-data; stop and
+        // let a later call re-query the boundary (data may publish later).
+        if boundsKeys(tokenId: tokenId) == before { break }
+      }
+      if guardSteps >= 250 {
+        logger.warning(
+          "coverRangeContiguously: guard limit reached for \(tokenId, privacy: .public)"
+        )
+      }
+    }
   }
 
   /// Final resolution after the bounded extension loop exits: checks cached
@@ -123,17 +186,23 @@ extension CryptoPriceService {
   ) async throws {
     let tokenId = instrument.id
     if let inFlight = extensionTasks[tokenId] {
-      _ = try? await inFlight.task.value
+      do {
+        try await inFlight.task.value
+      } catch is CancellationError {
+        throw CancellationError()
+      } catch {
+        // Owner's provider error; the no-progress guard in
+        // `extendContiguously` handles it.
+      }
       return
     }
     let requestId = UUID()
-    let task = Task<Decimal, Error> { [self] in
+    let task = Task<Void, Error> { [self] in
       try await self.fetchRange(
         instrument: instrument,
         mapping: mapping,
         from: fetchInterval.lowerBound,
         to: fetchInterval.upperBound)
-      return 0
     }
     extensionTasks[tokenId] = (requestId, task)
     defer {
@@ -242,11 +311,13 @@ extension CryptoPriceService {
 
   /// The sub-ranges of `range` not already covered by the token's cache,
   /// chunked into at most 30-day windows so no single fetch spans an
-  /// un-served interior. Mirrors the backward/forward extension decision in
-  /// `prices(for:mapping:in:)` — including its boundary-day inversion
-  /// guards (`range.lowerBound <= backEnd` and `forwardStart <=
-  /// fetchUpperBound`) so a noon-anchored day token immediately adjacent
-  /// to a cache bound never builds an inverted `ClosedRange`.
+  /// un-served interior. Boundary-day inversion guards
+  /// (`range.lowerBound <= backEnd` and `forwardStart <= fetchUpperBound`)
+  /// ensure a noon-anchored day token immediately adjacent to a cache bound
+  /// never builds an inverted `ClosedRange`. Used by `warmRange`, which
+  /// intentionally fills every uncovered sub-range (it backfills holes); the
+  /// contiguity-preserving `prices(for:mapping:in:)` path uses
+  /// `coverRangeContiguously` instead.
   private func uncoveredSubRanges(
     tokenId: String, range: ClosedRange<Date>
   ) -> [ClosedRange<Date>] {
@@ -256,7 +327,7 @@ extension CryptoPriceService {
     let fetchEndString = dateFormatter.string(from: fetchUpperBound)
     let gregorian = Calendar.utc
     guard let cache = caches[tokenId] else {
-      return Self.chunked(range.lowerBound...fetchUpperBound, days: 30)
+      return ContiguousFetchPlanner.chunked(range.lowerBound...fetchUpperBound, days: 30)
     }
     var result: [ClosedRange<Date>] = []
     if rangeStart < cache.earliestDate,
@@ -264,35 +335,13 @@ extension CryptoPriceService {
       let backEnd = gregorian.date(byAdding: .day, value: -1, to: earliest),
       range.lowerBound <= backEnd
     {
-      result += Self.chunked(range.lowerBound...backEnd, days: 30)
+      result += ContiguousFetchPlanner.chunked(range.lowerBound...backEnd, days: 30)
     }
     if fetchEndString > cache.latestDate,
       let forwardStart = dateFormatter.date(from: cache.latestDate),
       forwardStart <= fetchUpperBound
     {
-      result += Self.chunked(forwardStart...fetchUpperBound, days: 30)
-    }
-    return result
-  }
-
-  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
-  /// days (UTC). Used by `uncoveredSubRanges` to cap individual fetches so
-  /// a horizon-restricted provider cannot jump the cache bounds over a void.
-  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
-    let cal = Calendar.utc
-    var result: [ClosedRange<Date>] = []
-    var start = range.lowerBound
-    while start <= range.upperBound {
-      let end: Date
-      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
-        end = min(candidate, range.upperBound)
-      } else {
-        end = range.upperBound
-      }
-      result.append(start...end)
-      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
-      if next > range.upperBound { break }
-      start = next
+      result += ContiguousFetchPlanner.chunked(forwardStart...fetchUpperBound, days: 30)
     }
     return result
   }

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -5,18 +5,12 @@ import Foundation
 // MARK: - Contiguous bounded extension (single price)
 
 extension CryptoPriceService {
-  /// Extends the cache contiguously toward `dateString` using bounded
-  /// 30-day windows driven by `ContiguousFetchPlanner`. Each iteration
-  /// fetches one window anchored at the current cache boundary, so the
-  /// cache never jumps its bounds over un-fetched interior days (the
-  /// interior-gap bug fixed here). The loop exits when the date is covered,
-  /// when no progress was made (provider genuinely has no data for this
-  /// window), or when a provider error occurs on every window attempt.
-  ///
-  /// Unlike an unbounded extension, a horizon-restricted provider (e.g.
-  /// CoinGecko free tier: 365 days) causes the loop to stop at the edge of
-  /// its coverage window rather than jumping `latest` all the way to the
-  /// requested date and leaving a void.
+  /// Extends the cache contiguously toward `dateString` using bounded 30-day
+  /// windows driven by `ContiguousFetchPlanner`, anchored at the current cache
+  /// boundary. The loop exits when the date is covered, when no progress was
+  /// made (provider genuinely has no data for this window — horizon-restricted
+  /// providers stop here rather than jumping `latest` over a void), or when a
+  /// provider error occurs on every window attempt.
   func extendContiguously(
     instrument: Instrument,
     mapping: CryptoProviderMapping,
@@ -72,14 +66,10 @@ extension CryptoPriceService {
       tokenId: tokenId, dateString: dateString, fetchError: lastFetchError)
   }
 
-  /// Covers `[lowerKey, upperKey]` contiguously by running the bounded
-  /// planner loop toward each endpoint with a no-progress guard. Unlike a
-  /// precomputed chunk list (which fetches every window upfront and so can
-  /// leave an interior gap when a horizon-restricted provider serves only a
-  /// recent subset), this stops a direction the moment a window yields no
-  /// boundary progress — keeping `[earliest, latest]` contiguous exactly as
-  /// the single-price `extendContiguously` does. Used by
-  /// `prices(for:mapping:in:)`.
+  /// Covers `[lowerKey, upperKey]` contiguously: bounded planner loop toward
+  /// each endpoint with a no-progress guard — stops a direction the moment a
+  /// window yields no boundary progress so a horizon-restricted provider
+  /// cannot leave an interior gap. Used by `prices(for:mapping:in:)`.
   func coverRangeContiguously(
     instrument: Instrument,
     mapping: CryptoProviderMapping,
@@ -90,8 +80,7 @@ extension CryptoPriceService {
     let todayKey =
       DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
     let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
-    // Cover the forward endpoint first, then the backward one. Each call
-    // anchors at the live cache bounds, so order does not create a gap.
+    // Forward first, then backward; each window anchors at the live cache bounds.
     for requestedKey in [upperKey, lowerKey] {
       var guardSteps = 0
       while guardSteps < 250 {
@@ -114,13 +103,10 @@ extension CryptoPriceService {
         } catch is CancellationError {
           throw CancellationError()
         } catch {
-          // Provider chain fully failed for this window; stop this direction
-          // and fall through to the result series (cached data is used).
+          // Provider chain failed; stop this direction (cached data is used).
           break
         }
-        // No progress (bounds unchanged) means genuine no-more-data; stop and
-        // let a later call re-query the boundary (data may publish later).
-        if boundsKeys(tokenId: tokenId) == before { break }
+        if boundsKeys(tokenId: tokenId) == before { break }  // no progress — stop
       }
       if guardSteps >= 250 {
         logger.warning(
@@ -191,8 +177,7 @@ extension CryptoPriceService {
       } catch is CancellationError {
         throw CancellationError()
       } catch {
-        // Owner's provider error; the no-progress guard in
-        // `extendContiguously` handles it.
+        // Owner's provider error; the no-progress guard handles it.
       }
       return
     }
@@ -221,12 +206,9 @@ extension CryptoPriceService {
 // MARK: - Provider fallback for a date range
 
 extension CryptoPriceService {
-  /// Runs the provider fallback chain
-  /// (CoinGecko → CryptoCompare → Binance) for a date range, tolerating
-  /// per-provider failures and only throwing when every client errored.
-  /// It is `internal` (not `private`) because it is called from
-  /// `prices(for:mapping:in:)` in `CryptoPriceService.swift`; it remains
-  /// actor-isolated.
+  /// Runs the provider fallback chain for a date range, tolerating per-provider
+  /// failures and only throwing when every client errored. `internal` (called
+  /// from `prices(for:mapping:in:)` in `CryptoPriceService.swift`).
   func fetchRange(
     instrument: Instrument, mapping: CryptoProviderMapping, from: Date, to: Date
   ) async throws {
@@ -271,12 +253,12 @@ extension CryptoPriceService {
 // MARK: - Background warming
 
 extension CryptoPriceService {
-  /// Background-warm a token's prices over `range`, fetching only the
-  /// sub-ranges the in-memory/on-disk cache does not already cover.
-  /// Unlike `fetchRange`, surfaces a provider `RateLimitGateError.cooldown`
-  /// deadline (so a background warmer can sleep precisely) instead of
-  /// wrapping it into a `WalletSyncError`. Idempotent: an already-covered
-  /// range fetches nothing and returns `.filled`. See issue #1075.
+  /// Background-warm a token's prices over `range` using the same contiguous
+  /// bounded-window loop as `coverRangeContiguously`. Covers both endpoints,
+  /// anchoring each window at the live cache bounds and stopping the moment a
+  /// window returns no new data — preventing interior gaps from horizon-
+  /// restricted providers. Surfaces `RateLimitGateError.cooldown` so
+  /// `CryptoPriceWarmer` can sleep precisely. Idempotent. See issue #1075.
   func warmRange(
     for instrument: Instrument,
     mapping: CryptoProviderMapping,
@@ -290,60 +272,87 @@ extension CryptoPriceService {
         )
       }
     }
-    let subRanges = uncoveredSubRanges(tokenId: tokenId, range: range)
-    if subRanges.isEmpty { return .filled }
+    let fetchUpperBound = cappedToYesterday(range.upperBound, now: now, timeZone: timeZone)
+    guard range.lowerBound <= fetchUpperBound else { return .filled }
+    guard
+      let upperKey = DateKey.from(isoString: dateFormatter.string(from: fetchUpperBound)),
+      let lowerKey = DateKey.from(isoString: dateFormatter.string(from: range.lowerBound))
+    else { return .unavailable }
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
 
-    var soonestCooldown: Date?
+    // Fast-path: if both endpoints are already within the cached range, there
+    // is nothing to fetch. Mirrors the old `subRanges.isEmpty` early exit.
+    let existingBounds = boundsKeys(tokenId: tokenId)
+    if let earliest = existingBounds.earliest, let latest = existingBounds.latest,
+      lowerKey >= earliest, upperKey <= latest
+    {
+      return .filled
+    }
+
     var filledAny = false
-    for sub in subRanges {
-      switch await fetchSubRangeWarming(instrument: instrument, mapping: mapping, range: sub) {
-      case .filled:
-        filledAny = true
-      case .cooledDown(let until):
-        soonestCooldown = soonestCooldown.map { min($0, until) } ?? until
-      case .unavailable:
-        continue
+    // Cover forward endpoint first, then backward — mirrors `coverRangeContiguously`.
+    for requestedKey in [upperKey, lowerKey] {
+      let step = await warmStep(
+        instrument: instrument,
+        mapping: mapping,
+        requestedKey: requestedKey,
+        todayKey: todayKey,
+        config: config)
+      switch step {
+      case .filled: filledAny = true
+      case .cooledDown: return step
+      case .unavailable: continue
       }
     }
-    if let soonestCooldown { return .cooledDown(until: soonestCooldown) }
     return filledAny ? .filled : .unavailable
   }
 
-  /// The sub-ranges of `range` not already covered by the token's cache,
-  /// chunked into at most 30-day windows so no single fetch spans an
-  /// un-served interior. Boundary-day inversion guards
-  /// (`range.lowerBound <= backEnd` and `forwardStart <= fetchUpperBound`)
-  /// ensure a noon-anchored day token immediately adjacent to a cache bound
-  /// never builds an inverted `ClosedRange`. Used by `warmRange`, which
-  /// intentionally fills every uncovered sub-range (it backfills holes); the
-  /// contiguity-preserving `prices(for:mapping:in:)` path uses
-  /// `coverRangeContiguously` instead.
-  private func uncoveredSubRanges(
-    tokenId: String, range: ClosedRange<Date>
-  ) -> [ClosedRange<Date>] {
-    let fetchUpperBound = cappedToYesterday(range.upperBound, now: now, timeZone: timeZone)
-    guard range.lowerBound <= fetchUpperBound else { return [] }
-    let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
-    let gregorian = Calendar.utc
-    guard let cache = caches[tokenId] else {
-      return ContiguousFetchPlanner.chunked(range.lowerBound...fetchUpperBound, days: 30)
+  /// Contiguous bounded-window loop toward `requestedKey`, anchored at the
+  /// live cache bounds. Returns `.filled` if any window filled data,
+  /// `.cooledDown` on a provider rate limit, or `.unavailable` when no window
+  /// served data (provider horizon reached). Used by `warmRange`.
+  private func warmStep(
+    instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    requestedKey: Int32,
+    todayKey: Int32,
+    config: ContiguousFetchPlanner.Config
+  ) async -> WarmOutcome {
+    let tokenId = instrument.id
+    var guardSteps = 0
+    var filledAny = false
+    warmLoop: while guardSteps < 250 {
+      guardSteps += 1
+      let bounds = boundsKeys(tokenId: tokenId)
+      guard
+        let window = ContiguousFetchPlanner.nextWindow(
+          earliest: bounds.earliest,
+          latest: bounds.latest,
+          requested: requestedKey,
+          today: todayKey,
+          config: config)
+      else { break warmLoop }  // endpoint already covered
+      let before = bounds
+      let fetchInterval = parseInterval(
+        DateKey.isoString(window.lowerBound)...DateKey.isoString(window.upperBound))
+      switch await fetchSubRangeWarming(
+        instrument: instrument, mapping: mapping, range: fetchInterval)
+      {
+      case .filled:
+        filledAny = true
+      case .cooledDown(let until):
+        return .cooledDown(until: until)
+      case .unavailable:
+        break warmLoop
+      }
+      if boundsKeys(tokenId: tokenId) == before { break warmLoop }
     }
-    var result: [ClosedRange<Date>] = []
-    if rangeStart < cache.earliestDate,
-      let earliest = dateFormatter.date(from: cache.earliestDate),
-      let backEnd = gregorian.date(byAdding: .day, value: -1, to: earliest),
-      range.lowerBound <= backEnd
-    {
-      result += ContiguousFetchPlanner.chunked(range.lowerBound...backEnd, days: 30)
+    if guardSteps >= 250 {
+      logger.warning("warmRange: guard limit reached for \(tokenId, privacy: .public)")
     }
-    if fetchEndString > cache.latestDate,
-      let forwardStart = dateFormatter.date(from: cache.latestDate),
-      forwardStart <= fetchUpperBound
-    {
-      result += ContiguousFetchPlanner.chunked(forwardStart...fetchUpperBound, days: 30)
-    }
-    return result
+    return filledAny ? .filled : .unavailable
   }
 
   /// Runs the provider fallback chain for one sub-range, surfacing the

--- a/Shared/CryptoPriceService+Warming.swift
+++ b/Shared/CryptoPriceService+Warming.swift
@@ -1,0 +1,149 @@
+// Shared/CryptoPriceService+Warming.swift
+
+import Foundation
+
+// MARK: - Background warming
+
+extension CryptoPriceService {
+  /// Background-warm a token's prices over `range` using the same contiguous
+  /// bounded-window loop as `coverRangeContiguously`. Covers both endpoints,
+  /// anchoring each window at the live cache bounds and stopping the moment a
+  /// window returns no new data — preventing interior gaps from horizon-
+  /// restricted providers. Surfaces `RateLimitGateError.cooldown` so
+  /// `CryptoPriceWarmer` can sleep precisely. Idempotent. See issue #1075.
+  func warmRange(
+    for instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    in range: ClosedRange<Date>
+  ) async -> WarmOutcome {
+    let tokenId = instrument.id
+    if !hydratedTokenIds.contains(tokenId) {
+      do { try await loadCache(tokenId: tokenId) } catch {
+        logger.warning(
+          "warmRange: loadCache failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+    let fetchUpperBound = cappedToYesterday(range.upperBound, now: now, timeZone: timeZone)
+    guard range.lowerBound <= fetchUpperBound else { return .filled }
+    guard
+      let upperKey = DateKey.from(isoString: dateFormatter.string(from: fetchUpperBound)),
+      let lowerKey = DateKey.from(isoString: dateFormatter.string(from: range.lowerBound))
+    else { return .unavailable }
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+
+    // Fast-path: if both endpoints are already within the cached range, there
+    // is nothing to fetch. Mirrors the old `subRanges.isEmpty` early exit.
+    let existingBounds = boundsKeys(tokenId: tokenId)
+    if let earliest = existingBounds.earliest, let latest = existingBounds.latest,
+      lowerKey >= earliest, upperKey <= latest
+    {
+      return .filled
+    }
+
+    var filledAny = false
+    // Cover forward endpoint first, then backward — mirrors `coverRangeContiguously`.
+    for requestedKey in [upperKey, lowerKey] {
+      let step = await warmStep(
+        instrument: instrument,
+        mapping: mapping,
+        requestedKey: requestedKey,
+        todayKey: todayKey,
+        config: config)
+      switch step {
+      case .filled: filledAny = true
+      case .cooledDown: return step
+      case .unavailable: continue
+      }
+    }
+    return filledAny ? .filled : .unavailable
+  }
+
+  /// Contiguous bounded-window loop toward `requestedKey`, anchored at the
+  /// live cache bounds. Returns `.filled` if any window filled data,
+  /// `.cooledDown` on a provider rate limit, or `.unavailable` when no window
+  /// served data (provider horizon reached). Used by `warmRange`.
+  private func warmStep(
+    instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    requestedKey: Int32,
+    todayKey: Int32,
+    config: ContiguousFetchPlanner.Config
+  ) async -> WarmOutcome {
+    let tokenId = instrument.id
+    var guardSteps = 0
+    var filledAny = false
+    warmLoop: while guardSteps < 250 {
+      guardSteps += 1
+      let bounds = boundsKeys(tokenId: tokenId)
+      guard
+        let window = ContiguousFetchPlanner.nextWindow(
+          earliest: bounds.earliest,
+          latest: bounds.latest,
+          requested: requestedKey,
+          today: todayKey,
+          config: config)
+      else { break warmLoop }  // endpoint already covered
+      let before = bounds
+      let fetchInterval = parseInterval(
+        DateKey.isoString(window.lowerBound)...DateKey.isoString(window.upperBound))
+      switch await fetchSubRangeWarming(
+        instrument: instrument, mapping: mapping, range: fetchInterval)
+      {
+      case .filled:
+        filledAny = true
+      case .cooledDown(let until):
+        return .cooledDown(until: until)
+      case .unavailable:
+        break warmLoop
+      }
+      if boundsKeys(tokenId: tokenId) == before { break warmLoop }
+    }
+    if guardSteps >= 250 {
+      logger.warning("warmRange: guard limit reached for \(tokenId, privacy: .public)")
+    }
+    return filledAny ? .filled : .unavailable
+  }
+
+  /// Runs the provider fallback chain for one sub-range, surfacing the
+  /// soonest cooldown deadline rather than wrapping it into a
+  /// `WalletSyncError` the way `fetchRange` does. Returns `.unavailable`
+  /// when every client returned empty / a non-cooldown failure.
+  private func fetchSubRangeWarming(
+    instrument: Instrument, mapping: CryptoProviderMapping, range: ClosedRange<Date>
+  ) async -> WarmOutcome {
+    let tokenId = instrument.id
+    let symbol = instrument.ticker ?? instrument.name
+    var soonestCooldown: Date?
+    for client in clients {
+      do {
+        let fetched = try await client.dailyPrices(for: mapping, in: range)
+        if !fetched.isEmpty {
+          let delta = mergeReturningDelta(tokenId: tokenId, symbol: symbol, newPrices: fetched)
+          if !delta.isEmpty {
+            try await persistDelta(tokenId: tokenId, deltaRecords: delta)
+          }
+          return .filled
+        }
+      } catch let cooldown as RateLimitGateError {
+        if case .cooldown(let until) = cooldown {
+          soonestCooldown = soonestCooldown.map { min($0, until) } ?? until
+        }
+        continue
+      } catch CryptoPriceError.noProviderMapping {
+        // Routing decision — this client has no symbol for the token
+        // (e.g. USDT on Binance). Skip silently, same as `fetchRange`.
+        continue
+      } catch {
+        logger.warning(
+          "fetchSubRangeWarming: fetch/persist failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+        continue
+      }
+    }
+    if let soonestCooldown { return .cooledDown(until: soonestCooldown) }
+    return .unavailable
+  }
+}

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -341,6 +341,7 @@ actor CryptoPriceService {
   // `currentPrices(for:)` (the live / spot endpoint) and
   // `prefetchLatest(for:)` (the live-tick writer) live in
   // `CryptoPriceService+Live.swift`.
+
 }
 
 // MARK: - Cache lookup & merge

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -27,9 +27,11 @@ actor CryptoPriceService {
   /// In-flight cache-extension fetches, keyed by token id, so concurrent
   /// `price(...)` requests for the same token share one provider round-trip
   /// instead of each issuing its own. The `id` tags the owning request so a
-  /// completing fetch only clears its own entry, never a successor's. See
-  /// `price(for:mapping:on:)`.
-  private var extensionTasks: [String: (id: UUID, task: Task<Decimal, Error>)] = [:]
+  /// completing fetch only clears its own entry, never a successor's.
+  /// `internal` (not `private`) so `fetchWindowCoalesced` in
+  /// `CryptoPriceService+FetchRange.swift` can read and mutate it from the
+  /// sibling-file extension. It remains actor-isolated.
+  var extensionTasks: [String: (id: UUID, task: Task<Decimal, Error>)] = [:]
   let database: any DatabaseWriter
   let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoPriceService")
@@ -153,50 +155,12 @@ actor CryptoPriceService {
       return inRange
     }
 
-    // Out of cached range — extend toward the requested date and try
-    // each provider in order. Continues past providers that return
-    // empty so a fallback chain (CoinGecko → CryptoCompare → Binance)
-    // can collectively fill in the dates one of them has.
-    //
-    // Coalesce concurrent extensions for the same token: if a fetch is
-    // already in flight, await it and re-resolve from the freshly-extended
-    // cache rather than issuing a duplicate provider round-trip. Only fall
-    // through to our own fetch when the shared one didn't reach our date (a
-    // wider / older range), preserving each request's eventual coverage.
-    if let inFlight = extensionTasks[tokenId] {
-      _ = try? await inFlight.task.value
-      if let cached = lookupPrice(tokenId: tokenId, dateString: dateString) {
-        return cached
-      }
-      if let inRange = try inRangeFallback(tokenId: tokenId, dateString: dateString) {
-        return inRange
-      }
-    }
-    let fetchInterval = extensionWindow(
-      for: tokenId, requestedDate: date, dateString: dateString)
-    let requestId = UUID()
-    let task = Task<Decimal, Error> { [self] in
-      try await self.fetchAndExtendCache(
-        instrument: instrument,
-        mapping: mapping,
-        fetchInterval: fetchInterval,
-        dateString: dateString)
-    }
-    extensionTasks[tokenId] = (requestId, task)
-    defer {
-      if extensionTasks[tokenId]?.id == requestId {
-        extensionTasks.removeValue(forKey: tokenId)
-      }
-    }
-    // Propagate the owner's cancellation into the shared fetch so a cancelled
-    // request doesn't block on a network round-trip it no longer needs. Any
-    // request still coalescing on this task observes the cancellation and
-    // re-fetches its own range above.
-    return try await withTaskCancellationHandler {
-      try await task.value
-    } onCancel: {
-      task.cancel()
-    }
+    // Out of cached range: extend contiguously toward the requested date.
+    return try await extendContiguously(
+      instrument: instrument,
+      mapping: mapping,
+      tokenId: tokenId,
+      dateString: dateString)
   }
 
   /// Resolves the request from the in-memory cache when the requested
@@ -211,7 +175,11 @@ actor CryptoPriceService {
   /// chart's visible range dispatched a network probe and a `saveCache`
   /// rewrite, saturating the GRDB queue. Mirrors
   /// `ExchangeRateService.rate(...)`'s in-range branch.
-  private func inRangeFallback(tokenId: String, dateString: String) throws -> Decimal? {
+  ///
+  /// `internal` (not `private`) because `extendContiguously` in
+  /// `CryptoPriceService+FetchRange.swift` calls it from a sibling
+  /// extension on the same actor.
+  func inRangeFallback(tokenId: String, dateString: String) throws -> Decimal? {
     guard let cache = caches[tokenId],
       dateString >= cache.earliestDate, dateString <= cache.latestDate
     else { return nil }
@@ -219,55 +187,6 @@ actor CryptoPriceService {
       return fallback
     }
     throw CryptoPriceError.noPriceAvailable(tokenId: tokenId, date: dateString)
-  }
-
-  /// Returns the date range a fetch should cover when the cache cannot
-  /// satisfy the request directly. Mirrors the extension shape used by
-  /// `StockPriceService.fetchToCoverDate` and `ExchangeRateService`:
-  ///
-  /// - **Cache exists, requested date past `latestDate`:** forward
-  ///   extension *including* `latestDate` so a stale value (e.g. an
-  ///   intraday tick persisted by an older build) is overwritten by
-  ///   the next finalised close.
-  /// - **Cache exists, requested date before `earliestDate`:** backward
-  ///   extension from the requested date to the day before
-  ///   `earliestDate`. Guarded by `requestedDate <= fetchEnd` so that when
-  ///   the requested day is the one *immediately* before `earliestDate` —
-  ///   where `requestedDate` is a noon-anchored day token but `fetchEnd` is
-  ///   midnight of that same calendar day — the branch falls through to the
-  ///   single-day window instead of building an inverted (lower > upper)
-  ///   `ClosedRange`, which would trap.
-  /// - **Cold cache (no entry for token):** 30-day surrounding window so
-  ///   a first-ever request on a non-trading day can still fall back
-  ///   to a recent prior price.
-  ///
-  /// The in-range case is unreachable here — `price(...)` short-circuits
-  /// before calling this — but a defensive single-day window is returned
-  /// just in case.
-  ///
-  /// `requestedDate` is already capped at yesterday by `price(...)`.
-  private func extensionWindow(
-    for tokenId: String, requestedDate: Date, dateString: String
-  ) -> ClosedRange<Date> {
-    let calendar = Calendar.utc
-    if let cache = caches[tokenId] {
-      if dateString > cache.latestDate,
-        let fetchStart = dateFormatter.date(from: cache.latestDate),
-        fetchStart <= requestedDate
-      {
-        return fetchStart...requestedDate
-      }
-      if dateString < cache.earliestDate,
-        let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = calendar.date(byAdding: .day, value: -1, to: earliestDate),
-        requestedDate <= fetchEnd
-      {
-        return requestedDate...fetchEnd
-      }
-      return requestedDate...requestedDate
-    }
-    let fetchStart = calendar.date(byAdding: .day, value: -30, to: requestedDate) ?? requestedDate
-    return fetchStart...requestedDate
   }
 
   // MARK: - Date range
@@ -374,7 +293,8 @@ extension CryptoPriceService {
     return dates
   }
 
-  // `fetchAndExtendCache(instrument:mapping:fetchInterval:dateString:)`
+  // `extendContiguously(instrument:mapping:tokenId:dateString:)`,
+  // `boundsKeys(tokenId:)`, `parseInterval(_:)`, `fetchWindowCoalesced(...)`,
   // and `fetchRange(instrument:mapping:from:to:)` live in
   // `CryptoPriceService+FetchRange.swift`, `mergeReturningDelta` lives
   // in `CryptoPriceService+Merge.swift`, and `NoOpTokenResolutionClient`

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -38,11 +38,11 @@ actor CryptoPriceService {
 
   // `dateFormatter`, `now`, and `timeZone` are `internal` (not `private`)
   // because the warm path in `CryptoPriceService+FetchRange.swift`
-  // (`warmRange` and its `uncoveredSubRanges` helper) reuses the same
-  // ISO day formatting, injected clock, and zone the in-file
-  // cache-extension decision uses, so the sibling-file extension must see
-  // them. They remain actor-isolated; the access modifier is internal so
-  // the sibling-file extension can read them.
+  // (`warmRange` and its bounded-window loop) reuses the same ISO day
+  // formatting, injected clock, and zone the in-file cache-extension
+  // decision uses, so the sibling-file extension must see them. They
+  // remain actor-isolated; the access modifier is internal so the
+  // sibling-file extension can read them.
   let dateFormatter: ISO8601DateFormatter
   private let resolutionClient: TokenResolutionClient
   /// Injected clock so tests can pin "today" deterministically.

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -31,7 +31,7 @@ actor CryptoPriceService {
   /// `internal` (not `private`) so `fetchWindowCoalesced` in
   /// `CryptoPriceService+FetchRange.swift` can read and mutate it from the
   /// sibling-file extension. It remains actor-isolated.
-  var extensionTasks: [String: (id: UUID, task: Task<Decimal, Error>)] = [:]
+  var extensionTasks: [String: (id: UUID, task: Task<Void, Error>)] = [:]
   let database: any DatabaseWriter
   let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoPriceService")
@@ -206,36 +206,22 @@ actor CryptoPriceService {
     // `price(for:mapping:on:)`. The result series below still walks the
     // caller-supplied range; today's slot fills via `lastKnownPrice`.
     let fetchUpperBound = cappedToYesterday(range.upperBound, now: now, timeZone: timeZone)
-    let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
 
-    let gregorian = Calendar.utc
-    if let cache = caches[tokenId] {
-      if rangeStart < cache.earliestDate,
-        let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate),
-        range.lowerBound <= fetchEnd
-      {
-        // `fetchRange` builds `from...to` as a `ClosedRange` literal, so the
-        // same boundary-day inversion that traps `extensionWindow` (a
-        // noon-anchored `range.lowerBound` on the day immediately before
-        // `earliestDate`, where `fetchEnd` is midnight of that day) is
-        // guarded here too.
-        try await fetchRange(
-          instrument: instrument, mapping: mapping, from: range.lowerBound, to: fetchEnd)
-      }
-      // Forward extension overlaps the existing latest entry — same
-      // rationale as `extensionWindow`.
-      if fetchEndString > cache.latestDate,
-        let fetchStart = dateFormatter.date(from: cache.latestDate),
-        fetchStart <= fetchUpperBound
-      {
-        try await fetchRange(
-          instrument: instrument, mapping: mapping, from: fetchStart, to: fetchUpperBound)
-      }
-    } else if range.lowerBound <= fetchUpperBound {
-      try await fetchRange(
-        instrument: instrument, mapping: mapping, from: range.lowerBound, to: fetchUpperBound)
+    // Extend the cache contiguously toward both endpoints using the bounded
+    // planner loop (no-progress guard), so a horizon-restricted provider
+    // cannot jump `earliest`/`latest` over un-fetched days (the interior-gap
+    // bug). `coverRangeContiguously` lives in
+    // `CryptoPriceService+FetchRange.swift`.
+    if range.lowerBound <= fetchUpperBound,
+      let lowerKey = DateKey.from(isoString: dateFormatter.string(from: range.lowerBound)),
+      let upperKey = DateKey.from(isoString: dateFormatter.string(from: fetchUpperBound))
+    {
+      try await coverRangeContiguously(
+        instrument: instrument,
+        mapping: mapping,
+        tokenId: tokenId,
+        lowerKey: lowerKey,
+        upperKey: upperKey)
     }
 
     let dates = generateDateSeries(in: range)
@@ -266,7 +252,7 @@ actor CryptoPriceService {
 // MARK: - Cache lookup & merge
 
 extension CryptoPriceService {
-  /// Internal (not private) so `fetchAndExtendCache` in
+  /// Internal (not private) so `extendContiguously` in
   /// `CryptoPriceService+FetchRange.swift` can call it from the sibling
   /// extension — same actor isolation, just different file.
   func lookupPrice(tokenId: String, dateString: String) -> Decimal? {

--- a/Shared/ExchangeRateService+Debug.swift
+++ b/Shared/ExchangeRateService+Debug.swift
@@ -9,22 +9,7 @@
     /// are N − 1 un-fetched interior days between two adjacent data points.
     /// Used by contiguity tests to assert the bounded-window invariant.
     func debugMaxInteriorGapDays(base: String) -> Int {
-      guard let cache = caches[base] else { return 0 }
-      let keys = cache.rates.sortedKeys
-      guard keys.count > 1 else { return 0 }
-      let fmt = ISO8601DateFormatter()
-      fmt.formatOptions = [.withFullDate]
-      fmt.timeZone = TimeZone.utc
-      var maxGap = 0
-      for idx in 1..<keys.count {
-        let prev = DateKey.isoString(keys[idx - 1])
-        let curr = DateKey.isoString(keys[idx])
-        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
-          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
-          if gap - 1 > maxGap { maxGap = gap - 1 }
-        }
-      }
-      return maxGap
+      caches[base]?.rates.maxInteriorGapDays ?? 0
     }
   }
 #endif

--- a/Shared/ExchangeRateService+Debug.swift
+++ b/Shared/ExchangeRateService+Debug.swift
@@ -1,0 +1,30 @@
+// Shared/ExchangeRateService+Debug.swift
+
+#if DEBUG
+  import Foundation
+
+  extension ExchangeRateService {
+    /// Returns the largest gap (in calendar days) between consecutive rate
+    /// entries in the in-memory cache for `base`. A gap of N means there
+    /// are N − 1 un-fetched interior days between two adjacent data points.
+    /// Used by contiguity tests to assert the bounded-window invariant.
+    func debugMaxInteriorGapDays(base: String) -> Int {
+      guard let cache = caches[base] else { return 0 }
+      let keys = cache.rates.sortedKeys
+      guard keys.count > 1 else { return 0 }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = TimeZone.utc
+      var maxGap = 0
+      for idx in 1..<keys.count {
+        let prev = DateKey.isoString(keys[idx - 1])
+        let curr = DateKey.isoString(keys[idx])
+        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
+          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
+          if gap - 1 > maxGap { maxGap = gap - 1 }
+        }
+      }
+      return maxGap
+    }
+  }
+#endif

--- a/Shared/ExchangeRateService+FetchRange.swift
+++ b/Shared/ExchangeRateService+FetchRange.swift
@@ -21,13 +21,13 @@ extension ExchangeRateService {
   /// Errors are swallowed (FX falls back to cached on failure), mirroring
   /// the original `fetchToCoverDate` contract. `date` is already capped at
   /// yesterday by `rate()`.
-  func fetchToCoverDate(base: String, date: Date, dateString: String) async {
+  func fetchToCoverDate(base: String, date: Date, dateString: String) async throws {
     let requestedKey = DateKey.from(isoString: dateString) ?? Int32.max
     let todayKey =
       DateKey.from(isoString: dateFormatter.string(from: now())) ?? requestedKey
     let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
     var guardSteps = 0
-    while guardSteps < 64 {
+    while guardSteps < 250 {
       guardSteps += 1
       let bounds = boundsKeys(base: base)
       guard
@@ -45,8 +45,10 @@ extension ExchangeRateService {
         dateFormatter.date(from: DateKey.isoString(window.upperBound)) ?? date
       do {
         try await fetchAndMerge(base: base, from: fetchStart, to: fetchEnd)
+      } catch is CancellationError {
+        throw CancellationError()
       } catch {
-        // Fetch failed — errors are swallowed; caller falls back to cached.
+        // Fetch failed — provider errors are swallowed; caller falls back to cached.
         logger.warning(
           "fetchToCoverDate window failed for base \(base, privacy: .public) on \(dateString, privacy: .public): \(error.localizedDescription, privacy: .public)"
         )
@@ -55,6 +57,11 @@ extension ExchangeRateService {
       // No progress (bounds unchanged) means genuine no-more-data; stop and
       // let a later call re-query the boundary (recent data may publish later).
       if boundsKeys(base: base) == before { break }
+    }
+    if guardSteps >= 250 {
+      logger.warning(
+        "fetchToCoverDate: guard limit reached for base \(base, privacy: .public) on \(dateString, privacy: .public)"
+      )
     }
   }
 
@@ -84,7 +91,7 @@ extension ExchangeRateService {
     let rangeEnd = dateFormatter.string(from: fetchEnd)
     let cal = Calendar.utc
     guard let cache = caches[base] else {
-      return Self.chunked(fetchStart...fetchEnd, days: 30)
+      return ContiguousFetchPlanner.chunked(fetchStart...fetchEnd, days: 30)
     }
     var result: [ClosedRange<Date>] = []
     if rangeStart < cache.earliestDate,
@@ -92,35 +99,13 @@ extension ExchangeRateService {
       let backEnd = cal.date(byAdding: .day, value: -1, to: earliest),
       fetchStart <= backEnd
     {
-      result += Self.chunked(fetchStart...backEnd, days: 30)
+      result += ContiguousFetchPlanner.chunked(fetchStart...backEnd, days: 30)
     }
     if rangeEnd > cache.latestDate,
       let forwardStart = dateFormatter.date(from: cache.latestDate),
       forwardStart <= fetchEnd
     {
-      result += Self.chunked(forwardStart...fetchEnd, days: 30)
-    }
-    return result
-  }
-
-  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
-  /// days (UTC). Used by `uncoveredSubRanges` to cap individual fetches so
-  /// a horizon-restricted provider cannot jump the cache bounds over a void.
-  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
-    let cal = Calendar.utc
-    var result: [ClosedRange<Date>] = []
-    var start = range.lowerBound
-    while start <= range.upperBound {
-      let end: Date
-      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
-        end = min(candidate, range.upperBound)
-      } else {
-        end = range.upperBound
-      }
-      result.append(start...end)
-      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
-      if next > range.upperBound { break }
-      start = next
+      result += ContiguousFetchPlanner.chunked(forwardStart...fetchEnd, days: 30)
     }
     return result
   }

--- a/Shared/ExchangeRateService+FetchRange.swift
+++ b/Shared/ExchangeRateService+FetchRange.swift
@@ -76,37 +76,73 @@ extension ExchangeRateService {
   }
 }
 
-// MARK: - Sub-range chunking for rates(from:to:in:)
+// MARK: - Contiguous range extension for rates(from:to:in:)
 
 extension ExchangeRateService {
-  /// Returns the uncovered sub-ranges of `[fetchStart, fetchEnd]` not
-  /// already in the cache, split into at most 30-day windows. No single
-  /// fetch can span an un-served interior, keeping the cache bounds
-  /// contiguous and preventing a horizon-restricted provider from jumping
-  /// `latest` over un-fetched days.
-  func uncoveredSubRanges(
-    base: String, fetchStart: Date, fetchEnd: Date
-  ) -> [ClosedRange<Date>] {
-    let rangeStart = dateFormatter.string(from: fetchStart)
-    let rangeEnd = dateFormatter.string(from: fetchEnd)
-    let cal = Calendar.utc
-    guard let cache = caches[base] else {
-      return ContiguousFetchPlanner.chunked(fetchStart...fetchEnd, days: 30)
+  /// Covers `[lowerKey, upperKey]` contiguously by running the bounded
+  /// planner loop toward each endpoint with a no-progress guard. Unlike a
+  /// precomputed chunk list (which fetches every window upfront and so can
+  /// leave an interior gap when a horizon-restricted provider serves only a
+  /// recent subset), this stops a direction the moment a window yields no
+  /// boundary progress — keeping `[earliest, latest]` contiguous exactly as
+  /// the single-rate `fetchToCoverDate` does. Used by
+  /// `rates(from:to:in:)`.
+  ///
+  /// Errors are swallowed (FX falls back to cached on failure), mirroring
+  /// the existing `fetchToCoverDate` contract. `CancellationError` is
+  /// re-thrown to preserve cooperative-cancellation semantics.
+  func coverRangeContiguously(
+    base: String,
+    lowerKey: Int32,
+    upperKey: Int32
+  ) async throws {
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    // Cover the forward endpoint first, then the backward one. Each call
+    // anchors at the live cache bounds, so order does not create a gap.
+    for requestedKey in [upperKey, lowerKey] {
+      var guardSteps = 0
+      while guardSteps < 250 {
+        guardSteps += 1
+        let bounds = boundsKeys(base: base)
+        guard
+          let window = ContiguousFetchPlanner.nextWindow(
+            earliest: bounds.earliest,
+            latest: bounds.latest,
+            requested: requestedKey,
+            today: todayKey,
+            config: config)
+        else { break }  // endpoint now in range
+        let before = bounds
+        let fetchStart =
+          dateFormatter.date(from: DateKey.isoString(window.lowerBound))
+          ?? dateFormatter.date(from: DateKey.isoString(requestedKey))
+          ?? now()
+        let fetchEnd =
+          dateFormatter.date(from: DateKey.isoString(window.upperBound))
+          ?? dateFormatter.date(from: DateKey.isoString(requestedKey))
+          ?? now()
+        do {
+          try await fetchAndMerge(base: base, from: fetchStart, to: fetchEnd)
+        } catch is CancellationError {
+          throw CancellationError()
+        } catch {
+          // Fetch failed — provider errors are swallowed; caller falls back to cached.
+          logger.warning(
+            "coverRangeContiguously window failed for base \(base, privacy: .public): \(error.localizedDescription, privacy: .public)"
+          )
+          break
+        }
+        // No progress (bounds unchanged) means genuine no-more-data; stop and
+        // let a later call re-query the boundary (data may publish later).
+        if boundsKeys(base: base) == before { break }
+      }
+      if guardSteps >= 250 {
+        logger.warning(
+          "coverRangeContiguously: guard limit reached for base \(base, privacy: .public)"
+        )
+      }
     }
-    var result: [ClosedRange<Date>] = []
-    if rangeStart < cache.earliestDate,
-      let earliest = dateFormatter.date(from: cache.earliestDate),
-      let backEnd = cal.date(byAdding: .day, value: -1, to: earliest),
-      fetchStart <= backEnd
-    {
-      result += ContiguousFetchPlanner.chunked(fetchStart...backEnd, days: 30)
-    }
-    if rangeEnd > cache.latestDate,
-      let forwardStart = dateFormatter.date(from: cache.latestDate),
-      forwardStart <= fetchEnd
-    {
-      result += ContiguousFetchPlanner.chunked(forwardStart...fetchEnd, days: 30)
-    }
-    return result
   }
 }

--- a/Shared/ExchangeRateService+FetchRange.swift
+++ b/Shared/ExchangeRateService+FetchRange.swift
@@ -1,0 +1,127 @@
+// Shared/ExchangeRateService+FetchRange.swift
+
+import Foundation
+
+// MARK: - Contiguous bounded extension (single rate)
+
+extension ExchangeRateService {
+  /// Extends the cache contiguously toward `dateString` using bounded
+  /// 30-day windows driven by `ContiguousFetchPlanner`. Each iteration
+  /// fetches one window anchored at the current cache boundary, so the
+  /// cache never jumps its bounds over un-fetched interior days (the
+  /// interior-gap bug fixed here). The loop exits when the date is covered,
+  /// when no progress was made (provider genuinely has no data for this
+  /// window), or when a fetch error occurs.
+  ///
+  /// Unlike the old unbounded year-chunk approach, a horizon-restricted
+  /// provider (e.g. Frankfurter with a rolling window) causes the loop to
+  /// stop at the edge of its coverage window rather than jumping `latest`
+  /// all the way to the requested date and leaving a void.
+  ///
+  /// Errors are swallowed (FX falls back to cached on failure), mirroring
+  /// the original `fetchToCoverDate` contract. `date` is already capped at
+  /// yesterday by `rate()`.
+  func fetchToCoverDate(base: String, date: Date, dateString: String) async {
+    let requestedKey = DateKey.from(isoString: dateString) ?? Int32.max
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? requestedKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    var guardSteps = 0
+    while guardSteps < 64 {
+      guardSteps += 1
+      let bounds = boundsKeys(base: base)
+      guard
+        let window = ContiguousFetchPlanner.nextWindow(
+          earliest: bounds.earliest,
+          latest: bounds.latest,
+          requested: requestedKey,
+          today: todayKey,
+          config: config)
+      else { break }  // requested date now in range
+      let before = bounds
+      let fetchStart =
+        dateFormatter.date(from: DateKey.isoString(window.lowerBound)) ?? date
+      let fetchEnd =
+        dateFormatter.date(from: DateKey.isoString(window.upperBound)) ?? date
+      do {
+        try await fetchAndMerge(base: base, from: fetchStart, to: fetchEnd)
+      } catch {
+        // Fetch failed — errors are swallowed; caller falls back to cached.
+        logger.warning(
+          "fetchToCoverDate window failed for base \(base, privacy: .public) on \(dateString, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+        break
+      }
+      // No progress (bounds unchanged) means genuine no-more-data; stop and
+      // let a later call re-query the boundary (recent data may publish later).
+      if boundsKeys(base: base) == before { break }
+    }
+  }
+
+  /// Returns the current cache bounds for `base` as `DateKey` (`Int32`
+  /// yyyymmdd) values. Returns `(nil, nil)` when the cache is cold.
+  func boundsKeys(base: String) -> (earliest: Int32?, latest: Int32?) {
+    guard let cache = caches[base] else { return (nil, nil) }
+    return (
+      DateKey.from(isoString: cache.earliestDate),
+      DateKey.from(isoString: cache.latestDate)
+    )
+  }
+}
+
+// MARK: - Sub-range chunking for rates(from:to:in:)
+
+extension ExchangeRateService {
+  /// Returns the uncovered sub-ranges of `[fetchStart, fetchEnd]` not
+  /// already in the cache, split into at most 30-day windows. No single
+  /// fetch can span an un-served interior, keeping the cache bounds
+  /// contiguous and preventing a horizon-restricted provider from jumping
+  /// `latest` over un-fetched days.
+  func uncoveredSubRanges(
+    base: String, fetchStart: Date, fetchEnd: Date
+  ) -> [ClosedRange<Date>] {
+    let rangeStart = dateFormatter.string(from: fetchStart)
+    let rangeEnd = dateFormatter.string(from: fetchEnd)
+    let cal = Calendar.utc
+    guard let cache = caches[base] else {
+      return Self.chunked(fetchStart...fetchEnd, days: 30)
+    }
+    var result: [ClosedRange<Date>] = []
+    if rangeStart < cache.earliestDate,
+      let earliest = dateFormatter.date(from: cache.earliestDate),
+      let backEnd = cal.date(byAdding: .day, value: -1, to: earliest),
+      fetchStart <= backEnd
+    {
+      result += Self.chunked(fetchStart...backEnd, days: 30)
+    }
+    if rangeEnd > cache.latestDate,
+      let forwardStart = dateFormatter.date(from: cache.latestDate),
+      forwardStart <= fetchEnd
+    {
+      result += Self.chunked(forwardStart...fetchEnd, days: 30)
+    }
+    return result
+  }
+
+  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
+  /// days (UTC). Used by `uncoveredSubRanges` to cap individual fetches so
+  /// a horizon-restricted provider cannot jump the cache bounds over a void.
+  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
+    let cal = Calendar.utc
+    var result: [ClosedRange<Date>] = []
+    var start = range.lowerBound
+    while start <= range.upperBound {
+      let end: Date
+      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
+        end = min(candidate, range.upperBound)
+      } else {
+        end = range.upperBound
+      }
+      result.append(start...end)
+      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
+      if next > range.upperBound { break }
+      start = next
+    }
+    return result
+  }
+}

--- a/Shared/ExchangeRateService+Prefetch.swift
+++ b/Shared/ExchangeRateService+Prefetch.swift
@@ -1,7 +1,6 @@
 // Shared/ExchangeRateService+Prefetch.swift
 
 import Foundation
-import GRDB
 
 // MARK: - ExchangeRateService prefetch
 
@@ -25,7 +24,6 @@ extension ExchangeRateService {
       }
     }
 
-    let calendar = Calendar(identifier: .gregorian)
     let target = cappedToYesterday(now(), now: now, timeZone: timeZone)
     let targetString = dateFormatter.string(from: target)
 
@@ -33,26 +31,10 @@ extension ExchangeRateService {
       return  // Already up to date
     }
 
-    let fetchFrom: Date
-    if let cache = caches[code],
-      let latestDate = dateFormatter.date(from: cache.latestDate),
-      latestDate <= target
-    {
-      fetchFrom = latestDate
-    } else if let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: target) {
-      fetchFrom = thirtyDaysAgo
-    } else {
-      fetchFrom = target
-    }
-
-    do {
-      try await fetchAndMerge(base: code, from: fetchFrom, to: target)
-    } catch {
-      // Prefetch is best-effort — log so disk-write failures (which would
-      // otherwise be conflated with expected network errors) are observable.
-      logger.warning(
-        "prefetchLatest: fetchAndMerge failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
-      )
-    }
+    // Extend toward `target` using bounded 30-day windows driven by
+    // `ContiguousFetchPlanner`. Uses the same fetch path as
+    // `fetchToCoverDate` to keep cache bounds contiguous. Errors are
+    // best-effort — log so disk-write failures are observable.
+    await fetchToCoverDate(base: code, date: target, dateString: targetString)
   }
 }

--- a/Shared/ExchangeRateService+Prefetch.swift
+++ b/Shared/ExchangeRateService+Prefetch.swift
@@ -33,8 +33,9 @@ extension ExchangeRateService {
 
     // Extend toward `target` using bounded 30-day windows driven by
     // `ContiguousFetchPlanner`. Uses the same fetch path as
-    // `fetchToCoverDate` to keep cache bounds contiguous. Errors are
-    // best-effort — log so disk-write failures are observable.
-    await fetchToCoverDate(base: code, date: target, dateString: targetString)
+    // `fetchToCoverDate` to keep cache bounds contiguous. Best-effort:
+    // `fetchToCoverDate` only throws on cooperative cancellation, which is
+    // benign here (prefetch is fire-and-forget); swallow it with `try?`.
+    try? await fetchToCoverDate(base: code, date: target, dateString: targetString)
   }
 }

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -107,45 +107,8 @@ actor ExchangeRateService {
     throw ExchangeRateError.noRateAvailable(base: base, quote: quote, date: dateString)
   }
 
-  /// Extends the cached range toward `date`, fetching only the gap between
-  /// the requested date and the existing `[earliestDate, latestDate]`
-  /// window. `rate()` short-circuits in-range requests before calling
-  /// this, so we only ever extend the boundary. The forward branch
-  /// overlaps the existing latest entry by one day so a stale value
-  /// (e.g. an intraday partial bar persisted by an older build) is
-  /// overwritten by the next finalised close — `mergeReturningDelta`
-  /// is a no-op when the re-fetched value matches what's cached.
-  /// Errors are swallowed; callers fall back to cached rates when the
-  /// fetch fails. `date` is already capped at yesterday by `rate()`.
-  private func fetchToCoverDate(base: String, date: Date, dateString: String) async {
-    let calendar = Calendar(identifier: .gregorian)
-    do {
-      if let cache = caches[base] {
-        if dateString > cache.latestDate,
-          let fetchStart = dateFormatter.date(from: cache.latestDate),
-          fetchStart <= date
-        {
-          try await fetchInChunks(base: base, from: fetchStart, to: date)
-        } else if dateString < cache.earliestDate,
-          let earliestDate = dateFormatter.date(from: cache.earliestDate),
-          let fetchEnd = calendar.date(byAdding: .day, value: -1, to: earliestDate)
-        {
-          try await fetchInChunks(base: base, from: date, to: fetchEnd)
-        }
-      } else if let fetchStart = calendar.date(byAdding: .day, value: -30, to: date) {
-        // Cold cache: fetch a month-wide surrounding range so we pick up
-        // at least one trading day alongside the requested date.
-        try await fetchInChunks(base: base, from: fetchStart, to: date)
-      }
-    } catch {
-      // Fetch failed — proceed to fallback lookup. Logged so disk-write
-      // failures (which would otherwise be silently swallowed alongside
-      // expected network 404s) are still observable.
-      logger.warning(
-        "fetchToCoverDate failed for base \(base, privacy: .public) on \(dateString, privacy: .public): \(error.localizedDescription, privacy: .public)"
-      )
-    }
-  }
+  // `fetchToCoverDate(base:date:dateString:)` lives in
+  // `ExchangeRateService+FetchRange.swift`.
 
   /// See `Shared/PriceCacheCap.swift` for the rationale.
   private func cappedDate(_ date: Date) -> Date {
@@ -171,27 +134,16 @@ actor ExchangeRateService {
     // `rate()`. The result series below still walks the caller-supplied
     // range; today's slot fills via `lastKnownRate` carry-forward.
     let fetchUpperBound = cappedDate(range.upperBound)
-    let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
 
-    let gregorian = Calendar(identifier: .gregorian)
-    if let cache = caches[base] {
-      if rangeStart < cache.earliestDate,
-        let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate)
-      {
-        try await fetchInChunks(base: base, from: range.lowerBound, to: fetchEnd)
+    // Fetch only the uncovered sub-ranges, chunked into ≤30-day windows so
+    // a horizon-restricted provider cannot jump `latest` over un-fetched days.
+    // `uncoveredSubRanges` lives in `ExchangeRateService+FetchRange.swift`.
+    if range.lowerBound <= fetchUpperBound {
+      let subRanges = uncoveredSubRanges(
+        base: base, fetchStart: range.lowerBound, fetchEnd: fetchUpperBound)
+      for sub in subRanges {
+        try await fetchAndMerge(base: base, from: sub.lowerBound, to: sub.upperBound)
       }
-      // Forward extension overlaps the existing latest entry — same
-      // rationale as `fetchToCoverDate`.
-      if fetchEndString > cache.latestDate,
-        let fetchStart = dateFormatter.date(from: cache.latestDate),
-        fetchStart <= fetchUpperBound
-      {
-        try await fetchInChunks(base: base, from: fetchStart, to: fetchUpperBound)
-      }
-    } else if range.lowerBound <= fetchUpperBound {
-      try await fetchInChunks(base: base, from: range.lowerBound, to: fetchUpperBound)
     }
 
     // Build result series
@@ -260,19 +212,8 @@ actor ExchangeRateService {
     return dates
   }
 
-  private func fetchInChunks(base: String, from: Date, to: Date) async throws {
-    let calendar = Calendar(identifier: .gregorian)
-    var chunkStart = from
-    while chunkStart <= to {
-      let nextYear = calendar.date(byAdding: .year, value: 1, to: chunkStart) ?? to
-      let chunkEnd = min(nextYear, to)
-      try await fetchAndMerge(base: base, from: chunkStart, to: chunkEnd)
-      guard let next = calendar.date(byAdding: .day, value: 1, to: chunkEnd) else { break }
-      chunkStart = next
-    }
-  }
-
-  // internal: called from `ExchangeRateService+Prefetch.swift` and tests.
+  // `fetchAndMerge` is internal: called from `ExchangeRateService+Prefetch.swift`,
+  // `ExchangeRateService+FetchRange.swift`, and tests.
   func fetchAndMerge(base: String, from: Date, to: Date) async throws {
     let fetched = try await client.fetchRates(base: base, from: from, to: to)
     // Frankfurter (and the chunked extension call sites in this service)

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -135,15 +135,17 @@ actor ExchangeRateService {
     // range; today's slot fills via `lastKnownRate` carry-forward.
     let fetchUpperBound = cappedDate(range.upperBound)
 
-    // Fetch only the uncovered sub-ranges, chunked into ≤30-day windows so
-    // a horizon-restricted provider cannot jump `latest` over un-fetched days.
-    // `uncoveredSubRanges` lives in `ExchangeRateService+FetchRange.swift`.
-    if range.lowerBound <= fetchUpperBound {
-      let subRanges = uncoveredSubRanges(
-        base: base, fetchStart: range.lowerBound, fetchEnd: fetchUpperBound)
-      for sub in subRanges {
-        try await fetchAndMerge(base: base, from: sub.lowerBound, to: sub.upperBound)
-      }
+    // Cover the requested range contiguously using bounded 30-day windows
+    // driven by `ContiguousFetchPlanner`. Unlike a precomputed chunk list,
+    // the loop anchors each window at the live cache bounds and stops as
+    // soon as a window yields no progress — preventing a horizon-restricted
+    // provider from jumping `latest` over un-fetched interior days.
+    // `coverRangeContiguously` lives in `ExchangeRateService+FetchRange.swift`.
+    if range.lowerBound <= fetchUpperBound,
+      let lowerKey = DateKey.from(isoString: dateFormatter.string(from: range.lowerBound)),
+      let upperKey = DateKey.from(isoString: dateFormatter.string(from: fetchUpperBound))
+    {
+      try await coverRangeContiguously(base: base, lowerKey: lowerKey, upperKey: upperKey)
     }
 
     // Build result series

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -92,7 +92,7 @@ actor ExchangeRateService {
     }
 
     // Out of cached range — extend toward the requested date.
-    await fetchToCoverDate(base: base, date: date, dateString: dateString)
+    try await fetchToCoverDate(base: base, date: date, dateString: dateString)
 
     // Exact hit after fetch?
     if let cached = lookupRate(base: base, quote: quote, dateString: dateString) {

--- a/Shared/SortedDateSeries+DebugGaps.swift
+++ b/Shared/SortedDateSeries+DebugGaps.swift
@@ -1,0 +1,29 @@
+// Shared/SortedDateSeries+DebugGaps.swift
+
+#if DEBUG
+  import Foundation
+
+  extension SortedDateSeries {
+    /// Returns the largest gap (in calendar days) between consecutive entries
+    /// in the series. A gap of N means there are N − 1 un-fetched interior
+    /// days between two adjacent data points. Used by the price/rate
+    /// contiguity tests to assert the bounded-window invariant.
+    var maxInteriorGapDays: Int {
+      let keys = sortedKeys
+      guard keys.count > 1 else { return 0 }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = TimeZone.utc
+      var maxGap = 0
+      for idx in 1..<keys.count {
+        let prev = DateKey.isoString(keys[idx - 1])
+        let curr = DateKey.isoString(keys[idx])
+        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
+          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
+          if gap - 1 > maxGap { maxGap = gap - 1 }
+        }
+      }
+      return maxGap
+    }
+  }
+#endif

--- a/Shared/StockPriceService+Debug.swift
+++ b/Shared/StockPriceService+Debug.swift
@@ -9,22 +9,7 @@
     /// are N − 1 un-fetched interior days between two adjacent data points.
     /// Used by contiguity tests to assert the bounded-window invariant.
     func debugMaxInteriorGapDays(ticker: String) -> Int {
-      guard let cache = caches[ticker] else { return 0 }
-      let keys = cache.prices.sortedKeys
-      guard keys.count > 1 else { return 0 }
-      let fmt = ISO8601DateFormatter()
-      fmt.formatOptions = [.withFullDate]
-      fmt.timeZone = TimeZone.utc
-      var maxGap = 0
-      for idx in 1..<keys.count {
-        let prev = DateKey.isoString(keys[idx - 1])
-        let curr = DateKey.isoString(keys[idx])
-        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
-          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
-          if gap - 1 > maxGap { maxGap = gap - 1 }
-        }
-      }
-      return maxGap
+      caches[ticker]?.prices.maxInteriorGapDays ?? 0
     }
   }
 #endif

--- a/Shared/StockPriceService+Debug.swift
+++ b/Shared/StockPriceService+Debug.swift
@@ -1,0 +1,30 @@
+// Shared/StockPriceService+Debug.swift
+
+#if DEBUG
+  import Foundation
+
+  extension StockPriceService {
+    /// Returns the largest gap (in calendar days) between consecutive price
+    /// entries in the in-memory cache for `ticker`. A gap of N means there
+    /// are N − 1 un-fetched interior days between two adjacent data points.
+    /// Used by contiguity tests to assert the bounded-window invariant.
+    func debugMaxInteriorGapDays(ticker: String) -> Int {
+      guard let cache = caches[ticker] else { return 0 }
+      let keys = cache.prices.sortedKeys
+      guard keys.count > 1 else { return 0 }
+      let fmt = ISO8601DateFormatter()
+      fmt.formatOptions = [.withFullDate]
+      fmt.timeZone = TimeZone.utc
+      var maxGap = 0
+      for idx in 1..<keys.count {
+        let prev = DateKey.isoString(keys[idx - 1])
+        let curr = DateKey.isoString(keys[idx])
+        if let prevDate = fmt.date(from: prev), let currDate = fmt.date(from: curr) {
+          let gap = Calendar.utc.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
+          if gap - 1 > maxGap { maxGap = gap - 1 }
+        }
+      }
+      return maxGap
+    }
+  }
+#endif

--- a/Shared/StockPriceService+FetchRange.swift
+++ b/Shared/StockPriceService+FetchRange.swift
@@ -1,0 +1,117 @@
+// Shared/StockPriceService+FetchRange.swift
+
+import Foundation
+
+// MARK: - Contiguous bounded extension (single price)
+
+extension StockPriceService {
+  /// Extends the cache contiguously toward `dateString` using bounded
+  /// 30-day windows driven by `ContiguousFetchPlanner`. Each iteration
+  /// fetches one window anchored at the current cache boundary, so the
+  /// cache never jumps its bounds over un-fetched interior days (the
+  /// interior-gap bug fixed here). The loop exits when the date is covered,
+  /// when no progress was made (provider genuinely has no data for this
+  /// window), or when a fetch error occurs.
+  ///
+  /// Unlike the old unbounded year-chunk approach, a horizon-restricted
+  /// provider (e.g. Yahoo Finance with a rolling window) causes the loop to
+  /// stop at the edge of its coverage window rather than jumping `latest`
+  /// all the way to the requested date and leaving a void.
+  ///
+  /// `date` is already capped at yesterday by `price(ticker:on:)`.
+  func fetchToCoverDate(ticker: String, date: Date, dateString: String) async throws {
+    let requestedKey = DateKey.from(isoString: dateString) ?? Int32.max
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? requestedKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    var guardSteps = 0
+    while guardSteps < 64 {
+      guardSteps += 1
+      let bounds = boundsKeys(ticker: ticker)
+      guard
+        let window = ContiguousFetchPlanner.nextWindow(
+          earliest: bounds.earliest,
+          latest: bounds.latest,
+          requested: requestedKey,
+          today: todayKey,
+          config: config)
+      else { break }  // requested date now in range
+      let before = bounds
+      let fetchStart = dateFormatter.date(from: DateKey.isoString(window.lowerBound)) ?? date
+      let fetchEnd = dateFormatter.date(from: DateKey.isoString(window.upperBound)) ?? date
+      try await fetchAndMerge(ticker: ticker, from: fetchStart, to: fetchEnd)
+      if lookupPrice(ticker: ticker, dateString: dateString) != nil { break }
+      if fallbackPrice(ticker: ticker, dateString: dateString) != nil { break }
+      // No progress (bounds unchanged) means genuine no-more-data; stop and
+      // let a later call re-query the boundary (recent data may publish later).
+      if boundsKeys(ticker: ticker) == before { break }
+    }
+  }
+
+  /// Returns the current cache bounds for `ticker` as `DateKey` (`Int32`
+  /// yyyymmdd) values. Returns `(nil, nil)` when the cache is cold.
+  func boundsKeys(ticker: String) -> (earliest: Int32?, latest: Int32?) {
+    guard let cache = caches[ticker] else { return (nil, nil) }
+    return (
+      DateKey.from(isoString: cache.earliestDate),
+      DateKey.from(isoString: cache.latestDate)
+    )
+  }
+}
+
+// MARK: - Sub-range chunking for prices(ticker:in:)
+
+extension StockPriceService {
+  /// Returns the uncovered sub-ranges of `[fetchStart, fetchEnd]` not
+  /// already in the cache, split into at most 30-day windows. No single
+  /// fetch can span an un-served interior, keeping the cache bounds
+  /// contiguous and preventing a horizon-restricted provider from jumping
+  /// `latest` over un-fetched days.
+  func uncoveredSubRanges(
+    ticker: String, fetchStart: Date, fetchEnd: Date
+  ) -> [ClosedRange<Date>] {
+    let rangeStart = dateFormatter.string(from: fetchStart)
+    let rangeEnd = dateFormatter.string(from: fetchEnd)
+    let cal = Calendar.utc
+    guard let cache = caches[ticker] else {
+      return Self.chunked(fetchStart...fetchEnd, days: 30)
+    }
+    var result: [ClosedRange<Date>] = []
+    if rangeStart < cache.earliestDate,
+      let earliest = dateFormatter.date(from: cache.earliestDate),
+      let backEnd = cal.date(byAdding: .day, value: -1, to: earliest),
+      fetchStart <= backEnd
+    {
+      result += Self.chunked(fetchStart...backEnd, days: 30)
+    }
+    if rangeEnd > cache.latestDate,
+      let forwardStart = dateFormatter.date(from: cache.latestDate),
+      forwardStart <= fetchEnd
+    {
+      result += Self.chunked(forwardStart...fetchEnd, days: 30)
+    }
+    return result
+  }
+
+  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
+  /// days (UTC). Used by `uncoveredSubRanges` to cap individual fetches so
+  /// a horizon-restricted provider cannot jump the cache bounds over a void.
+  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
+    let cal = Calendar.utc
+    var result: [ClosedRange<Date>] = []
+    var start = range.lowerBound
+    while start <= range.upperBound {
+      let end: Date
+      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
+        end = min(candidate, range.upperBound)
+      } else {
+        end = range.upperBound
+      }
+      result.append(start...end)
+      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
+      if next > range.upperBound { break }
+      start = next
+    }
+    return result
+  }
+}

--- a/Shared/StockPriceService+FetchRange.swift
+++ b/Shared/StockPriceService+FetchRange.swift
@@ -25,7 +25,7 @@ extension StockPriceService {
       DateKey.from(isoString: dateFormatter.string(from: now())) ?? requestedKey
     let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
     var guardSteps = 0
-    while guardSteps < 64 {
+    while guardSteps < 250 {
       guardSteps += 1
       let bounds = boundsKeys(ticker: ticker)
       guard
@@ -45,6 +45,11 @@ extension StockPriceService {
       // No progress (bounds unchanged) means genuine no-more-data; stop and
       // let a later call re-query the boundary (recent data may publish later).
       if boundsKeys(ticker: ticker) == before { break }
+    }
+    if guardSteps >= 250 {
+      logger.warning(
+        "fetchToCoverDate: guard limit reached for ticker \(ticker, privacy: .public) on \(dateString, privacy: .public)"
+      )
     }
   }
 
@@ -74,7 +79,7 @@ extension StockPriceService {
     let rangeEnd = dateFormatter.string(from: fetchEnd)
     let cal = Calendar.utc
     guard let cache = caches[ticker] else {
-      return Self.chunked(fetchStart...fetchEnd, days: 30)
+      return ContiguousFetchPlanner.chunked(fetchStart...fetchEnd, days: 30)
     }
     var result: [ClosedRange<Date>] = []
     if rangeStart < cache.earliestDate,
@@ -82,35 +87,13 @@ extension StockPriceService {
       let backEnd = cal.date(byAdding: .day, value: -1, to: earliest),
       fetchStart <= backEnd
     {
-      result += Self.chunked(fetchStart...backEnd, days: 30)
+      result += ContiguousFetchPlanner.chunked(fetchStart...backEnd, days: 30)
     }
     if rangeEnd > cache.latestDate,
       let forwardStart = dateFormatter.date(from: cache.latestDate),
       forwardStart <= fetchEnd
     {
-      result += Self.chunked(forwardStart...fetchEnd, days: 30)
-    }
-    return result
-  }
-
-  /// Splits `range` into consecutive sub-ranges of at most `days` calendar
-  /// days (UTC). Used by `uncoveredSubRanges` to cap individual fetches so
-  /// a horizon-restricted provider cannot jump the cache bounds over a void.
-  static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>] {
-    let cal = Calendar.utc
-    var result: [ClosedRange<Date>] = []
-    var start = range.lowerBound
-    while start <= range.upperBound {
-      let end: Date
-      if let candidate = cal.date(byAdding: .day, value: days, to: start) {
-        end = min(candidate, range.upperBound)
-      } else {
-        end = range.upperBound
-      }
-      result.append(start...end)
-      guard let next = cal.date(byAdding: .day, value: 1, to: end) else { break }
-      if next > range.upperBound { break }
-      start = next
+      result += ContiguousFetchPlanner.chunked(forwardStart...fetchEnd, days: 30)
     }
     return result
   }

--- a/Shared/StockPriceService+FetchRange.swift
+++ b/Shared/StockPriceService+FetchRange.swift
@@ -64,37 +64,59 @@ extension StockPriceService {
   }
 }
 
-// MARK: - Sub-range chunking for prices(ticker:in:)
+// MARK: - Contiguous range extension for prices(ticker:in:)
 
 extension StockPriceService {
-  /// Returns the uncovered sub-ranges of `[fetchStart, fetchEnd]` not
-  /// already in the cache, split into at most 30-day windows. No single
-  /// fetch can span an un-served interior, keeping the cache bounds
-  /// contiguous and preventing a horizon-restricted provider from jumping
-  /// `latest` over un-fetched days.
-  func uncoveredSubRanges(
-    ticker: String, fetchStart: Date, fetchEnd: Date
-  ) -> [ClosedRange<Date>] {
-    let rangeStart = dateFormatter.string(from: fetchStart)
-    let rangeEnd = dateFormatter.string(from: fetchEnd)
-    let cal = Calendar.utc
-    guard let cache = caches[ticker] else {
-      return ContiguousFetchPlanner.chunked(fetchStart...fetchEnd, days: 30)
+  /// Covers `[lowerKey, upperKey]` contiguously by running the bounded
+  /// planner loop toward each endpoint with a no-progress guard. Unlike a
+  /// precomputed chunk list (which fetches every window upfront and so can
+  /// leave an interior gap when a horizon-restricted provider serves only a
+  /// recent subset), this stops a direction the moment a window yields no
+  /// boundary progress — keeping `[earliest, latest]` contiguous exactly as
+  /// the single-price `fetchToCoverDate` does. Used by
+  /// `prices(ticker:in:)`.
+  func coverRangeContiguously(
+    ticker: String,
+    lowerKey: Int32,
+    upperKey: Int32
+  ) async throws {
+    let todayKey =
+      DateKey.from(isoString: dateFormatter.string(from: now())) ?? upperKey
+    let config = ContiguousFetchPlanner.Config(windowDays: 30, forwardBuffer: 2)
+    // Cover the forward endpoint first, then the backward one. Each call
+    // anchors at the live cache bounds, so order does not create a gap.
+    for requestedKey in [upperKey, lowerKey] {
+      var guardSteps = 0
+      while guardSteps < 250 {
+        guardSteps += 1
+        let bounds = boundsKeys(ticker: ticker)
+        guard
+          let window = ContiguousFetchPlanner.nextWindow(
+            earliest: bounds.earliest,
+            latest: bounds.latest,
+            requested: requestedKey,
+            today: todayKey,
+            config: config)
+        else { break }  // endpoint now in range
+        let before = bounds
+        let fetchStart =
+          dateFormatter.date(from: DateKey.isoString(window.lowerBound))
+          ?? dateFormatter.date(from: DateKey.isoString(requestedKey))
+          ?? now()
+        let fetchEnd =
+          dateFormatter.date(from: DateKey.isoString(window.upperBound))
+          ?? dateFormatter.date(from: DateKey.isoString(requestedKey))
+          ?? now()
+        try await fetchAndMerge(ticker: ticker, from: fetchStart, to: fetchEnd)
+        // No progress (bounds unchanged) means genuine no-more-data; stop and
+        // let a later call re-query the boundary (data may publish later).
+        if boundsKeys(ticker: ticker) == before { break }
+      }
+      if guardSteps >= 250 {
+        logger.warning(
+          "coverRangeContiguously: guard limit reached for ticker \(ticker, privacy: .public)"
+        )
+      }
     }
-    var result: [ClosedRange<Date>] = []
-    if rangeStart < cache.earliestDate,
-      let earliest = dateFormatter.date(from: cache.earliestDate),
-      let backEnd = cal.date(byAdding: .day, value: -1, to: earliest),
-      fetchStart <= backEnd
-    {
-      result += ContiguousFetchPlanner.chunked(fetchStart...backEnd, days: 30)
-    }
-    if rangeEnd > cache.latestDate,
-      let forwardStart = dateFormatter.date(from: cache.latestDate),
-      forwardStart <= fetchEnd
-    {
-      result += ContiguousFetchPlanner.chunked(forwardStart...fetchEnd, days: 30)
-    }
-    return result
   }
 }

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -22,13 +22,13 @@ actor StockPriceService {
   /// the cache is genuinely empty.
   private var hydratedTickers: Set<String> = []
   private let database: any DatabaseWriter
-  private let dateFormatter: ISO8601DateFormatter
+  let dateFormatter: ISO8601DateFormatter
   /// Injected clock so tests can pin "today" deterministically.
-  private let now: @Sendable () -> Date
+  let now: @Sendable () -> Date
   /// Injected zone used by `cappedToYesterday` to compute "yesterday".
   /// Production defaults to `TimeZone.current`; tests asserting on a
   /// specific `YYYY-MM-DD` label pin to `UTC`.
-  private let timeZone: TimeZone
+  let timeZone: TimeZone
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "StockPriceService")
 
@@ -102,31 +102,72 @@ actor StockPriceService {
     // caller-supplied range; today's slot fills via `lastKnownPrice`
     // carry-forward (which lands on yesterday's close).
     let fetchUpperBound = cappedDate(range.upperBound)
-    let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
 
-    let gregorian = Calendar(identifier: .gregorian)
-    if let cache = caches[ticker] {
-      if rangeStart < cache.earliestDate,
-        let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate)
-      {
-        try await fetchInChunks(ticker: ticker, from: range.lowerBound, to: fetchEnd)
-      }
-      // Forward extension overlaps the existing latest entry by one day so
-      // a stale value (e.g. an intraday partial bar persisted by an older
-      // build) is overwritten by the next finalised close.
-      if fetchEndString > cache.latestDate,
-        let fetchStart = dateFormatter.date(from: cache.latestDate),
-        fetchStart <= fetchUpperBound
-      {
-        try await fetchInChunks(ticker: ticker, from: fetchStart, to: fetchUpperBound)
-      }
-    } else if range.lowerBound <= fetchUpperBound {
-      try await fetchInChunks(ticker: ticker, from: range.lowerBound, to: fetchUpperBound)
+    guard range.lowerBound <= fetchUpperBound else {
+      return buildResultSeries(ticker: ticker, in: range)
     }
 
-    // Build result series
+    // Fetch uncovered sub-ranges using bounded 30-day windows so a
+    // horizon-restricted provider cannot advance bounds over un-fetched days.
+    let subRanges = uncoveredSubRanges(
+      ticker: ticker,
+      fetchStart: range.lowerBound,
+      fetchEnd: fetchUpperBound)
+    for sub in subRanges {
+      try await fetchAndMerge(ticker: ticker, from: sub.lowerBound, to: sub.upperBound)
+    }
+
+    return buildResultSeries(ticker: ticker, in: range)
+  }
+
+  func instrument(for ticker: String) async throws -> Instrument {
+    if let cache = caches[ticker] {
+      return cache.instrument
+    }
+    if !hydratedTickers.contains(ticker) {
+      try await loadCache(ticker: ticker)
+    }
+    if let cache = caches[ticker] {
+      return cache.instrument
+    }
+    throw StockPriceError.unknownTicker(ticker)
+  }
+
+  // MARK: - Private helpers
+
+  func cappedDate(_ date: Date) -> Date {
+    cappedToYesterday(date, now: now, timeZone: timeZone)
+  }
+
+  func lookupPrice(ticker: String, dateString: String) -> Decimal? {
+    guard let key = DateKey.from(isoString: dateString) else { return nil }
+    return caches[ticker]?.prices.exact(key)
+  }
+
+  func fallbackPrice(ticker: String, dateString: String) -> Decimal? {
+    guard let key = DateKey.from(isoString: dateString),
+      let cache = caches[ticker]
+    else { return nil }
+    return cache.prices.floor(key)
+  }
+
+  private func generateDateSeries(in range: ClosedRange<Date>) -> [Date] {
+    let calendar = Calendar(identifier: .gregorian)
+    var dates: [Date] = []
+    var current = range.lowerBound
+    while current <= range.upperBound {
+      dates.append(current)
+      guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+      current = next
+    }
+    return dates
+  }
+
+  /// Builds the carry-forward daily price series for `ticker` over `range`
+  /// from the in-memory cache. Weekend/holiday gaps carry the last known close.
+  func buildResultSeries(
+    ticker: String, in range: ClosedRange<Date>
+  ) -> [(date: Date, price: Decimal)] {
     let dates = generateDateSeries(in: range)
     var results: [(date: Date, price: Decimal)] = []
     var lastKnownPrice: Decimal?
@@ -146,100 +187,7 @@ actor StockPriceService {
     return results
   }
 
-  func instrument(for ticker: String) async throws -> Instrument {
-    if let cache = caches[ticker] {
-      return cache.instrument
-    }
-    if !hydratedTickers.contains(ticker) {
-      try await loadCache(ticker: ticker)
-    }
-    if let cache = caches[ticker] {
-      return cache.instrument
-    }
-    throw StockPriceError.unknownTicker(ticker)
-  }
-
-  // MARK: - Private helpers
-
-  /// Fetches the surrounding window needed to cover `date`. Cold cache fetches
-  /// a month-wide window so a request on a weekend / holiday can still resolve
-  /// via `fallbackPrice`. Warm cache extends only the gap between the cache
-  /// edge and the requested date.
-  ///
-  /// Forward extensions overlap the existing latest entry by one day so a
-  /// stale value (an intraday partial bar persisted by an older build) is
-  /// overwritten by the next finalised close. `mergeReturningDelta` is a
-  /// no-op when the re-fetched value matches what's already cached.
-  ///
-  /// Unlike `ExchangeRateService.fetchToCoverDate`, this method propagates
-  /// fetch errors so `price(ticker:on:)` can surface network failures when
-  /// the fallback cache is also empty.
-  ///
-  /// `date` is already capped at yesterday by `price(ticker:on:)`.
-  private func fetchToCoverDate(ticker: String, date: Date, dateString: String) async throws {
-    let gregorian = Calendar(identifier: .gregorian)
-    if let cache = caches[ticker] {
-      if dateString > cache.latestDate,
-        let fetchStart = dateFormatter.date(from: cache.latestDate),
-        fetchStart <= date
-      {
-        try await fetchInChunks(ticker: ticker, from: fetchStart, to: date)
-      } else if dateString < cache.earliestDate,
-        let earliestDate = dateFormatter.date(from: cache.earliestDate),
-        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate)
-      {
-        try await fetchInChunks(ticker: ticker, from: date, to: fetchEnd)
-      }
-    } else if let fetchStart = gregorian.date(byAdding: .day, value: -30, to: date) {
-      try await fetchInChunks(ticker: ticker, from: fetchStart, to: date)
-    } else {
-      try await fetchAndMerge(ticker: ticker, from: date, to: date)
-    }
-  }
-
-  /// See `Shared/PriceCacheCap.swift` for the rationale on capping
-  /// requests at the prior local-calendar day.
-  private func cappedDate(_ date: Date) -> Date {
-    cappedToYesterday(date, now: now, timeZone: timeZone)
-  }
-
-  private func lookupPrice(ticker: String, dateString: String) -> Decimal? {
-    guard let key = DateKey.from(isoString: dateString) else { return nil }
-    return caches[ticker]?.prices.exact(key)
-  }
-
-  private func fallbackPrice(ticker: String, dateString: String) -> Decimal? {
-    guard let key = DateKey.from(isoString: dateString),
-      let cache = caches[ticker]
-    else { return nil }
-    return cache.prices.floor(key)
-  }
-
-  private func generateDateSeries(in range: ClosedRange<Date>) -> [Date] {
-    let calendar = Calendar(identifier: .gregorian)
-    var dates: [Date] = []
-    var current = range.lowerBound
-    while current <= range.upperBound {
-      dates.append(current)
-      guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
-      current = next
-    }
-    return dates
-  }
-
-  private func fetchInChunks(ticker: String, from: Date, to: Date) async throws {
-    let calendar = Calendar(identifier: .gregorian)
-    var chunkStart = from
-    while chunkStart <= to {
-      let nextYear = calendar.date(byAdding: .year, value: 1, to: chunkStart) ?? to
-      let chunkEnd = min(nextYear, to)
-      try await fetchAndMerge(ticker: ticker, from: chunkStart, to: chunkEnd)
-      guard let next = calendar.date(byAdding: .day, value: 1, to: chunkEnd) else { break }
-      chunkStart = next
-    }
-  }
-
-  private func fetchAndMerge(ticker: String, from: Date, to: Date) async throws {
+  func fetchAndMerge(ticker: String, from: Date, to: Date) async throws {
     let response = try await client.fetchDailyPrices(ticker: ticker, from: from, to: to)
     // Yahoo Finance (and the chunked extension call sites) legitimately
     // return an empty payload for weekend / holiday / future probes.
@@ -325,7 +273,7 @@ actor StockPriceService {
   /// the disk converges to the latest in-memory state. A crash between
   /// two writes leaves the disk at an intermediate-but-consistent
   /// snapshot — acceptable for a best-effort persistent cache.
-  private func persistDelta(ticker: String, deltaRecords: [StockPriceRecord]) async throws {
+  func persistDelta(ticker: String, deltaRecords: [StockPriceRecord]) async throws {
     guard let cache = caches[ticker] else { return }
     let meta = StockTickerMetaRecord(
       ticker: ticker,

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -11,17 +11,18 @@ enum StockPriceError: Error, Equatable {
 
 actor StockPriceService {
   private let client: StockPriceClient
-  // `caches` is accessed by the merge extension in
-  // `StockPriceService+Merge.swift` (which defines
-  // `mergeReturningDelta(ticker:instrument:newPrices:)`, called from this
-  // file), so it is `internal` rather than `private`. It remains
-  // actor-isolated; the access modifier is internal only so the
-  // sibling-file extension can see it.
-  var caches: [String: StockPriceCache] = [:]
-  /// Loaded tickers — set on first hydration so we don't re-read SQL when
-  /// the cache is genuinely empty.
   private var hydratedTickers: Set<String> = []
   private let database: any DatabaseWriter
+
+  // MARK: - Cross-extension internals
+  // `caches`, `dateFormatter`, `now`, `timeZone`, and `logger` are accessed
+  // by the merge extension in `StockPriceService+Merge.swift` (which defines
+  // `mergeReturningDelta(ticker:instrument:newPrices:)`, called from this
+  // file) and by the bounded-extension / chunking extension in
+  // `StockPriceService+FetchRange.swift`, so they are `internal` rather than
+  // `private`. They remain actor-isolated; the access modifier is internal
+  // only so the sibling-file extensions can see them.
+  var caches: [String: StockPriceCache] = [:]
   let dateFormatter: ISO8601DateFormatter
   /// Injected clock so tests can pin "today" deterministically.
   let now: @Sendable () -> Date
@@ -29,7 +30,7 @@ actor StockPriceService {
   /// Production defaults to `TimeZone.current`; tests asserting on a
   /// specific `YYYY-MM-DD` label pin to `UTC`.
   let timeZone: TimeZone
-  private let logger = Logger(
+  let logger = Logger(
     subsystem: "com.moolah.app", category: "StockPriceService")
 
   init(

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -108,14 +108,16 @@ actor StockPriceService {
       return buildResultSeries(ticker: ticker, in: range)
     }
 
-    // Fetch uncovered sub-ranges using bounded 30-day windows so a
-    // horizon-restricted provider cannot advance bounds over un-fetched days.
-    let subRanges = uncoveredSubRanges(
-      ticker: ticker,
-      fetchStart: range.lowerBound,
-      fetchEnd: fetchUpperBound)
-    for sub in subRanges {
-      try await fetchAndMerge(ticker: ticker, from: sub.lowerBound, to: sub.upperBound)
+    // Cover the requested range contiguously using bounded 30-day windows
+    // driven by `ContiguousFetchPlanner`. Unlike a precomputed chunk list,
+    // the loop anchors each window at the live cache bounds and stops as
+    // soon as a window yields no progress — preventing a horizon-restricted
+    // provider from jumping `latest` over un-fetched interior days.
+    if let lowerKey = DateKey.from(isoString: dateFormatter.string(from: range.lowerBound)),
+      let upperKey = DateKey.from(isoString: dateFormatter.string(from: fetchUpperBound))
+    {
+      try await coverRangeContiguously(
+        ticker: ticker, lowerKey: lowerKey, upperKey: upperKey)
     }
 
     return buildResultSeries(ticker: ticker, in: range)

--- a/plans/2026-06-17-contiguous-price-cache-extension-design.md
+++ b/plans/2026-06-17-contiguous-price-cache-extension-design.md
@@ -1,0 +1,225 @@
+# Contiguous price-cache extension (crypto / stock / FX)
+
+> Design spec. Fixes a data-correctness bug: the historic price/rate caches
+> can contain interior date gaps that were **never fetched**, which the
+> read path then papers over with a stale prior-day value — silently wrong
+> net-worth and income/expense figures.
+
+## Background
+
+Three services cache historic prices/rates, each in its own table pair in
+the shared profile-index database (`ProfileIndexSchema+SharedInstrumentRegistry`):
+
+| Service | Price table | Meta table |
+|---|---|---|
+| `CryptoPriceService` | `crypto_price` | `crypto_token_meta` |
+| `StockPriceService` | `stock_price` | `stock_ticker_meta` |
+| `ExchangeRateService` | `exchange_rate` | `exchange_rate_meta` |
+
+All three are **near-identical parallel implementations** of the same
+pattern: a `SortedDateSeries` of daily values plus a `[earliest_date,
+latest_date]` bounds pair in the meta row, an `extensionWindow` /
+`fetchToCoverDate` that fetches toward an out-of-range requested date, a
+`mergeReturningDelta` that folds fetched rows in, and an `inRangeFallback`
+read that returns the prior-trading-day value for an in-range miss.
+
+The caches are **local, derived, un-synced, and rebuildable** — only the
+instrument *registry* metadata syncs via CloudKit, never the price rows.
+
+## The bug
+
+The cache tracks coverage as nothing more than the outer `[earliest,
+latest]` bounds. Two code paths let those bounds straddle days that were
+never actually fetched:
+
+1. **Boundary jump on a partial fill.** `mergeReturningDelta` sets
+   `latest = max(existing.latest, returned.max())` (and the symmetric
+   `earliest = min(...)`). The forward `extensionWindow` requests an
+   **unbounded** range `[latest … requestedDate]`, which can span years.
+   When a provider serves only a recent *tail* of that range (e.g.
+   CoinGecko's free tier refuses data older than 365 days — verified HTTP
+   error `10012`), the merge advances `latest` to the tail's max and the
+   un-served middle becomes a permanent hole.
+2. **Disconnected island.** The cold-cache branch fetches a free-floating
+   30-day window around the requested date, not anchored to the existing
+   bounds, stretching `[earliest, latest]` across a span that was never
+   queried.
+
+Once `[earliest, latest]` straddles an un-fetched span, `inRangeFallback`
+short-circuits every read in that span to the nearest prior value and the
+hole is **never re-fetched** — by design, to avoid a network probe per
+weekend. The result is a silently stale price, not a blank.
+
+### Evidence (production Real Profile cache)
+
+- **Crypto (24/7 — any gap is spurious):** LDO 14.6% covered (one
+  contiguous 1,204-day void: 2023-01-27 → 2026-05-15, recent block exactly
+  the 32-day cold window); STRK 5.5%; ZK 6.6%; EIGEN 6.4%.
+- **Stocks (ASX, 5/7 — weekend/holiday gaps legitimate):** mostly healthy
+  (~68% ≈ trading-days-minus-holidays), but a real spurious hole: VGS.AX
+  2026-03-01 → 2026-04-07 (37 days, not a holiday). 6-day gaps are genuine
+  Easter closures.
+- **FX (5/7):** healthy — no gap exceeds a weekend.
+
+Impact tracks how continuously each market trades; the defect is identical
+in all three services.
+
+## The invariant
+
+> A series' cached data is always a single **contiguous** block
+> `[earliest, latest]` in which **every day was actually queried**.
+> Therefore any absent day inside the block is a genuine no-price day
+> (closed market), and the prior-trading-day fallback over it is correct.
+
+The prior-day fallback is **not** the bug and is retained — it is the
+*required* behaviour for closed-market days. The fix is to guarantee the
+fallback only ever operates over genuine gaps.
+
+## The model (how extension works after the fix)
+
+- **`latest` is the last day with actual data; `earliest` the first.**
+- **Forward fill always queries a bounded window anchored at the boundary:**
+  `[latest … latest + W]` (default `W ≈ 30` days — large enough to clear a
+  weekend/holiday run and be sure the window contains real data, small
+  enough that a provider serves it wholesale rather than partially).
+- **The boundary advances only to a day that actually returned data.** The
+  days between the old boundary and the new one were inside the queried
+  window, so their absence is genuine no-price — fallback is correct.
+- **Re-querying the boundary every pass is intended, not waste.** Recent
+  days whose data was not yet published (or a forward-timezone market's
+  not-yet-available day) are picked up on a later pass. We always query
+  forward *from the latest day we have*, even if earlier passes returned
+  nothing for the days just after it; the gap closes itself once a later
+  day returns data, after which the boundary has moved past it and we stop
+  re-querying it.
+- **Backward fill is symmetric:** bounded windows `[earliest − W … earliest]`
+  stepping back toward the requested date.
+- **Deep backfill is incremental.** Reaching a far out-of-range date takes
+  multiple bounded steps (driven by the existing warming loop). A single
+  `price()` call makes bounded forward/backward progress and returns the
+  best available value (or triggers background warming) rather than issuing
+  one unbounded range request.
+
+Because each window is bounded and anchored at the boundary, a provider that
+refuses part of a *huge* range can no longer cause a boundary jump: the
+window is small enough to be served wholesale, and any in-window absence is
+a genuine no-data day.
+
+### Forward cap and timezone safety
+
+**No artificial forward cap.** A UTC-anchored "today" clamp would be wrong:
+end-of-day in Sydney is still "yesterday" in UTC, so a UTC cap would
+withhold an ASX close that is already published for ~10 hours.
+
+The caps that matter are only those a *provider* imposes. All four current
+providers were verified (live future-date probe, 2026-06-17) to **tolerate
+requests past today without erroring** — they clamp to the latest available
+data or return empty:
+
+| Provider | Asset | Future-date request → |
+|---|---|---|
+| Binance | crypto | returns `[]` (empty), no error |
+| CoinGecko (`market_chart/range`) | crypto | clamps to latest available, no error |
+| Frankfurter (`FROM..TO`) | FX | clamps (`end_date` = last real day), no error |
+| Yahoo Finance (`v8/finance/chart`) | stocks | clamps to available; meta confirms `Australia/Sydney` AEST `gmtoffset:36000` |
+
+(CryptoCompare's `histoday` requires an API key and was not probed keyless;
+its `toTs` is documented to clamp to the latest close, but its future-date
+behaviour must be confirmed with a key before relying on it.)
+
+Therefore the forward window requests up to a generous near-future bound
+(e.g. `now` plus a small buffer) with **no global clamp**, so a
+forward-timezone market's already-published close flows immediately. The
+re-query-the-boundary rule covers "not published yet": a day that returns no
+data simply does not advance the boundary and is retried next pass — never a
+permanent gap.
+
+If a future provider is ever added that *does* error on future dates, the
+cap is applied **in that provider's client only** (documented with its
+timezone assumption, tolerance, and any retry-with-reduced-max behaviour),
+never as a global clamp in the shared core. Date math elsewhere uses
+`Calendar.utc` per `guides/DATE_TIME_GUIDE.md`.
+
+## Architecture: extract a shared core
+
+The contiguous-extension logic is extracted into one reusable component
+that the three services delegate to, removing the triplication that let the
+bug exist in three places. Proposed shape:
+
+- A generic **contiguous-series cache** owning, for one keyed series: the
+  `SortedDateSeries<Value>`, the `[earliest, latest]` bounds, the
+  in-range/prior-day **read with fallback**, the **bounded-window extension
+  planner** (forward/backward, boundary-anchored, future-capped), and the
+  **boundary-safe merge** (advance bounds only across the just-queried
+  window).
+- Each service supplies the parts that genuinely differ: the **provider
+  fetch** for a date range (crypto runs its multi-provider fallback chain;
+  stock/FX call their single provider) and the **persistence** of the
+  returned delta to its own table pair.
+- Value type is generic (`Decimal` for all three today) so the core carries
+  no asset-specific logic.
+
+The boundary-safe merge replaces the three `*+Merge.swift` min/max
+advances; the planner replaces the three `extensionWindow` /
+`fetchToCoverDate` implementations and removes the disconnected cold-window
+branch (a genuinely new series still bootstraps with a single anchored
+window, but one that becomes the series' first contiguous block — there is
+no existing boundary to disconnect from).
+
+## Recovery: purge all fetched price/rate data
+
+The existing on-disk caches cannot be trusted — they already contain
+un-fetchable gaps. Because the data is local, derived, un-synced, and cheap
+to refetch (keyless Binance for crypto deep history; the stock/FX
+providers), recovery is a **total purge**, not a targeted repair:
+
+- A one-time migration on the profile-index database deletes all rows from
+  `crypto_price`, `crypto_token_meta`, `stock_price`, `stock_ticker_meta`,
+  `exchange_rate`, and `exchange_rate_meta`. (Mirrors the precedent set by
+  `v7_purge_intraday_cached_prices`; follows the drop/recreate rules in
+  `guides/DATABASE_SCHEMA_GUIDE.md`.)
+- After the purge every series is empty, so the corrected contiguous
+  extension rebuilds it from scratch on demand / via background warming —
+  with the invariant holding from the first fetch.
+
+## Error handling
+
+- A provider error or empty response for a window leaves the boundary
+  unmoved; the window is retried on a later pass (the desired
+  self-healing). No partial state advances the bounds.
+- Transient vs structural classification (`ConversionFailureClassifier`)
+  is unchanged; a date that no configured provider can supply stays
+  out-of-range and surfaces as `noPriceAvailable` (honest unavailable),
+  exactly as today — this design does not change which dates are reachable,
+  only that reachable dates are fetched contiguously.
+
+## Testing (TDD, against TestBackend / in-memory GRDB)
+
+Shared-core unit tests:
+
+- Forward window is bounded and anchored at `latest`; a tail-only provider
+  response does **not** advance the boundary past the un-served span.
+- A genuinely-absent day inside a fully-queried window is left as a gap and
+  read via prior-day fallback (no boundary corruption, no re-fetch storm).
+- Boundary re-query picks up a day that was unavailable on an earlier pass.
+- Backward fill steps in bounded windows toward an old requested date.
+- No disconnected island is ever persisted.
+- Forward window: a forward-timezone market's already-published close
+  (e.g. an ASX day that is still "yesterday" in UTC) is fetched, not
+  withheld; a day with no data yet leaves the boundary unmoved and is
+  retried, never creating a permanent gap. No global UTC cap is applied.
+
+Per-service tests confirm crypto's multi-provider fetch, stock, and FX each
+drive the shared core correctly. Migration test: the purge empties all six
+tables and a subsequent fetch rebuilds contiguously.
+
+## Out of scope
+
+- Pre-shipping provider mappings (Binance/CoinGecko/CryptoCompare) for known
+  tokens — tracked separately as **#1140**. (That fix lets CoinGecko-only
+  tokens like RPL reach a deep-history provider; this fix ensures whatever
+  *is* reachable is cached contiguously. They are complementary.)
+- Reclassifying worthless dust tokens (e.g. HEX, $0 market cap) — noted in
+  #1140.
+- Any change to the prior-trading-day fallback semantics or to the
+  income/expense "unavailable month" rule (#1077).

--- a/plans/2026-06-17-contiguous-price-cache-extension-plan.md
+++ b/plans/2026-06-17-contiguous-price-cache-extension-plan.md
@@ -1,0 +1,770 @@
+# Contiguous price-cache extension — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the crypto/stock/FX historic price caches grow only as a single contiguous date range, so the prior-trading-day fallback only ever covers genuine no-price days — eliminating the silently-stale-value bug from never-fetched interior gaps.
+
+**Architecture:** Extract one pure, unit-tested window planner (`ContiguousFetchPlanner`) that, given a series' current `[earliest, latest]` bounds and a requested date, returns the next **bounded, boundary-anchored** fetch window (or `nil` when covered). The three services (`CryptoPriceService`, `StockPriceService`, `ExchangeRateService`) replace their unbounded `extensionWindow`/`fetchToCoverDate` logic with a loop driven by this planner, and advance their bounds only across data the planner's window actually returned. A one-time GRDB migration purges all existing (untrustworthy) cache rows so they re-warm contiguously.
+
+**Tech Stack:** Swift 6 actors, GRDB, Swift Testing (`@Test`/`@Suite`), `just` build/test targets, `DateKey` (Int32 yyyymmdd), `SortedDateSeries`.
+
+**Spec:** `plans/2026-06-17-contiguous-price-cache-extension-design.md`
+
+---
+
+## Background the engineer needs
+
+- All three price caches live in the **profile-index** database (shared across profiles), tables `crypto_price`/`crypto_token_meta`, `stock_price`/`stock_ticker_meta`, `exchange_rate`/`exchange_rate_meta`. Schema: `Backends/GRDB/ProfileIndexSchema+SharedInstrumentRegistry.swift`. The rate caches are **local, derived, un-synced** — safe to purge and re-warm.
+- Each service is a non-`@MainActor` `actor` with `caches: [Key: …Cache]`, `hydrated…: Set<…>`, an `ISO8601DateFormatter` (`[.withFullDate]`), `now: @Sendable () -> Date`, `timeZone`, and a `database: any DatabaseWriter`.
+- Dates on the wire and in bounds are ISO `"YYYY-MM-DD"` strings; in-memory series are keyed by `DateKey` (`Int32` yyyymmdd). `DateKey.from(isoString:)` / `DateKey.isoString(_:)` convert; integer order equals chronological order.
+- The bug (see spec): `extensionWindow` returns an **unbounded** `[latest … requested]`; a provider serving only a recent tail makes the merge advance `latest` past an un-fetched span. Bounding the window to `W` days makes any in-window gap genuinely "queried, no data," so the boundary can never jump past unqueried days.
+- **Read path is unchanged.** `inRangeFallback` (prior-trading-day `floor`) stays — it is correct once coverage is contiguous.
+- **No global forward cap** (all four providers tolerate future dates — verified). Forward windows extend up to `today + forwardBuffer` so a forward-timezone market (ASX) close is never withheld.
+- Build/test: `just build-mac`, `just test-mac <Filter>`, `just format-check`. Capture output to `.agent-tmp/` per CLAUDE.md. New test files are Swift Testing suites; per memory `reference_insight_chart_test_file_splitting`, keep each new suite in its own file (≤250-line `type_body_length`).
+
+## File structure
+
+**Create:**
+- `Shared/ContiguousFetchPlanner.swift` — pure window planner (the fix's core).
+- `MoolahTests/Shared/ContiguousFetchPlannerTests.swift` — exhaustive unit tests for the planner.
+- `MoolahTests/Shared/ContiguousExtensionCryptoTests.swift` — crypto service contiguity tests.
+- `MoolahTests/Shared/ContiguousExtensionStockTests.swift` — stock service contiguity tests.
+- `MoolahTests/Shared/ContiguousExtensionFXTests.swift` — FX service contiguity tests.
+- `Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift` — purge migration body.
+- `MoolahTests/Backends/PurgeRateCachesMigrationTests.swift` — migration test.
+
+**Modify:**
+- `Shared/CryptoPriceService.swift` — replace `extensionWindow`; loop the planner in `price(...)`; advance bounds within the loop.
+- `Shared/StockPriceService.swift` — replace `fetchToCoverDate`'s window math; loop the planner.
+- `Shared/ExchangeRateService.swift` — replace `fetchToCoverDate`'s window math; loop the planner.
+- `Backends/GRDB/ProfileIndexSchema.swift` (or wherever the profile-index migrator is registered) — register the purge migration.
+
+---
+
+## Phase 1 — The shared window planner (pure, fully tested)
+
+The planner is pure arithmetic on `Int32` DateKeys. No I/O, no actor. This is where the correctness lives, so it gets exhaustive tests first.
+
+### Task 1: Planner type + "already covered returns nil"
+
+**Files:**
+- Create: `Shared/ContiguousFetchPlanner.swift`
+- Test: `MoolahTests/Shared/ContiguousFetchPlannerTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+
+@testable import Moolah
+
+@Suite struct ContiguousFetchPlannerTests {
+  // DateKeys are yyyymmdd ints; use real calendar days so +1 day math is exercised.
+  static let jan01: Int32 = 20240101
+  static let jan15: Int32 = 20240115
+  static let jan31: Int32 = 20240131
+  static let feb15: Int32 = 20240215
+
+  @Test func requestedInsideBoundsReturnsNil() {
+    let window = ContiguousFetchPlanner.nextWindow(
+      earliest: Self.jan01, latest: Self.jan31,
+      requested: Self.jan15, today: Self.feb15,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(window == nil)
+  }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails to compile (type missing)**
+
+Run: `just test-mac ContiguousFetchPlannerTests 2>&1 | tee .agent-tmp/planner.txt`
+Expected: FAIL — `cannot find 'ContiguousFetchPlanner' in scope`.
+
+- [ ] **Step 3: Create the planner with the covered-case branch**
+
+```swift
+// Shared/ContiguousFetchPlanner.swift
+import Foundation
+
+/// Plans the next **bounded, boundary-anchored** fetch window for a
+/// contiguous date-keyed price/rate cache. Pure arithmetic on `DateKey`
+/// (`Int32` yyyymmdd) — no I/O. Bounding the window is what keeps a cache
+/// contiguous: a provider can only ever serve days inside a window the
+/// planner already declared queried, so the cache's `[earliest, latest]`
+/// can never advance past a day that was never fetched.
+///
+/// `nil` means "the requested date is already inside `[earliest, latest]`"
+/// — the caller reads it via the prior-trading-day fallback, no fetch.
+enum ContiguousFetchPlanner {
+  /// - earliest/latest: current contiguous bounds as `DateKey`, or `nil`
+  ///   when the series is empty (cold cache).
+  /// - requested: the `DateKey` the caller needs.
+  /// - today: the `DateKey` for "now" (callers pass `now()`'s day). Forward
+  ///   windows may extend up to `today + forwardBuffer` — providers tolerate
+  ///   slight future dates and clamp, so this never withholds a
+  ///   forward-timezone market's already-published close.
+  /// - windowDays: max span of a single window (≈30). Large enough to clear
+  ///   a weekend/holiday run, small enough that a provider serves it whole.
+  /// - forwardBuffer: days past `today` a forward window may reach (≈2).
+  static func nextWindow(
+    earliest: Int32?, latest: Int32?,
+    requested: Int32, today: Int32,
+    windowDays: Int, forwardBuffer: Int
+  ) -> ClosedRange<Int32>? {
+    guard let earliest, let latest else {
+      return coldWindow(
+        requested: requested, today: today,
+        windowDays: windowDays, forwardBuffer: forwardBuffer)
+    }
+    if requested >= earliest && requested <= latest { return nil }
+    return nil  // filled in by later tasks
+  }
+
+  private static func coldWindow(
+    requested: Int32, today: Int32, windowDays: Int, forwardBuffer: Int
+  ) -> ClosedRange<Int32>? {
+    return nil  // filled in by Task 4
+  }
+}
+```
+
+- [ ] **Step 4: Run it, verify pass**
+
+Run: `just test-mac ContiguousFetchPlannerTests 2>&1 | tee .agent-tmp/planner.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Shared/ContiguousFetchPlanner.swift MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+git commit -m "feat(price-cache): ContiguousFetchPlanner skeleton + covered-case"
+```
+
+> **DateKey arithmetic note for all planner tasks:** `Int32` yyyymmdd is *not* contiguous across month boundaries (20240131 + 1 ≠ 20240201). The planner must convert via `DateKey.isoString` → `Date` (using `Calendar.utc`) → add/subtract days → `DateKey.from(isoString:)`. Add a private helper `addingDays(_:to:)` in Task 2 and use it everywhere; never do raw `Int32` ± arithmetic on DateKeys.
+
+### Task 2: DateKey day-arithmetic helper
+
+**Files:**
+- Modify: `Shared/ContiguousFetchPlanner.swift`
+- Test: `MoolahTests/Shared/ContiguousFetchPlannerTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+  @Test func addingDaysCrossesMonthBoundary() {
+    #expect(ContiguousFetchPlanner.addingDays(1, to: 20240131) == 20240201)
+    #expect(ContiguousFetchPlanner.addingDays(-1, to: 20240301) == 20240229) // leap year
+    #expect(ContiguousFetchPlanner.addingDays(30, to: 20240101) == 20240131)
+  }
+```
+
+- [ ] **Step 2: Run, verify fail** (`addingDays` not found).
+
+Run: `just test-mac ContiguousFetchPlannerTests/addingDaysCrossesMonthBoundary 2>&1 | tee .agent-tmp/planner.txt`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `addingDays` using `Calendar.utc`**
+
+```swift
+// add inside enum ContiguousFetchPlanner
+static func addingDays(_ days: Int, to key: Int32) -> Int32 {
+  let iso = DateKey.isoString(key)
+  let formatter = ISO8601DateFormatter()
+  formatter.formatOptions = [.withFullDate]
+  formatter.timeZone = TimeZone(identifier: "UTC")
+  guard let date = formatter.date(from: iso),
+    let shifted = Calendar.utc.date(byAdding: .day, value: days, to: date),
+    let result = DateKey.from(isoString: formatter.string(from: shifted))
+  else { return key }
+  return result
+}
+```
+
+> If `ISO8601DateFormatter` with `[.withFullDate]` parses midnight-UTC consistently in this codebase's existing services (it does — see `loadCache`), reuse that. `Calendar.utc` is the project's UTC calendar (see `guides/DATE_TIME_GUIDE.md`).
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** (`feat(price-cache): DateKey day arithmetic helper`).
+
+### Task 3: Forward window (bounded, anchored, future-capped)
+
+**Files:** Modify planner + test.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+  @Test func forwardWindowIsBoundedAndAnchoredAtLatest() {
+    // latest=Jan15, requested far ahead → window [Jan15 … Jan15+30], not [Jan15 … requested].
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20240101, latest: 20240115,
+      requested: 20240601, today: 20240601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240115...20240214) // includes latest (re-query to overwrite stale), spans 30 days
+  }
+
+  @Test func forwardWindowStopsAtRequestedWhenNearer() {
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20240101, latest: 20240115,
+      requested: 20240120, today: 20240601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240115...20240120)
+  }
+
+  @Test func forwardWindowCappedAtTodayPlusBuffer() {
+    // requested beyond today → cap at today+buffer, never an arbitrary future date.
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20240101, latest: 20240115,
+      requested: 20240601, today: 20240118,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240115...20240120) // today(18)+buffer(2)=20
+  }
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement the forward branch** (replace the `requested > latest` `return nil` placeholder)
+
+```swift
+// inside nextWindow, after the in-range nil check:
+if requested > latest {
+  let cap = min(requested, addingDays(forwardBuffer, to: today))
+  let upper = min(addingDays(windowDays, to: latest), cap)
+  // Anchor at `latest` itself so a stale latest-day tick is overwritten.
+  guard latest <= upper else { return nil }
+  return latest...upper
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** (`feat(price-cache): bounded forward window`).
+
+### Task 4: Backward window + cold-cache window
+
+**Files:** Modify planner + test.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+  @Test func backwardWindowIsBoundedAndAnchoredAtEarliest() {
+    // requested far before earliest → window [earliest-30 … earliest-1], not [requested … earliest-1].
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20240201, latest: 20240301,
+      requested: 20230101, today: 20240601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240102...20240131) // earliest-1 = Jan31, back 30 days = Jan02
+  }
+
+  @Test func backwardWindowStopsAtRequestedWhenNearer() {
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: 20240201, latest: 20240301,
+      requested: 20240120, today: 20240601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240120...20240131)
+  }
+
+  @Test func coldCacheWindowEndsAtRequestedWithPriorContext() {
+    // empty cache: window ends at min(requested, today+buffer), reaches back windowDays for fallback context.
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: nil, latest: nil,
+      requested: 20240215, today: 20240601,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240116...20240215)
+  }
+
+  @Test func coldCacheWindowCapsFutureRequestAtToday() {
+    let w = ContiguousFetchPlanner.nextWindow(
+      earliest: nil, latest: nil,
+      requested: 20240601, today: 20240215,
+      windowDays: 30, forwardBuffer: 2)
+    #expect(w == 20240118...20240217) // end=today+buffer=Feb17, back 30 = Jan18
+  }
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement the backward branch + coldWindow**
+
+```swift
+// inside nextWindow, after the forward branch (requested < earliest case):
+if requested < earliest {
+  let lower = max(requested, addingDays(-windowDays, to: earliest))
+  let upper = addingDays(-1, to: earliest)
+  guard lower <= upper else { return nil }
+  return lower...upper
+}
+return nil
+```
+
+```swift
+// replace coldWindow body:
+private static func coldWindow(
+  requested: Int32, today: Int32, windowDays: Int, forwardBuffer: Int
+) -> ClosedRange<Int32>? {
+  let end = min(requested, addingDays(forwardBuffer, to: today))
+  let start = addingDays(-windowDays, to: end)
+  guard start <= end else { return nil }
+  return start...end
+}
+```
+
+- [ ] **Step 4: Run, verify pass** (whole suite).
+
+Run: `just test-mac ContiguousFetchPlannerTests 2>&1 | tee .agent-tmp/planner.txt`
+Expected: all PASS.
+
+- [ ] **Step 5: format-check + commit**
+
+```bash
+just format-check 2>&1 | tee .agent-tmp/fmt.txt
+git add Shared/ContiguousFetchPlanner.swift MoolahTests/Shared/ContiguousFetchPlannerTests.swift
+git commit -m "feat(price-cache): backward + cold-cache windows complete planner"
+```
+
+---
+
+## Phase 2 — Migrate CryptoPriceService
+
+The driving loop pattern (used identically in all three services): while the planner returns a window and the requested date is still uncovered, fetch the window, merge it (advancing bounds to the returned data within the window), and re-check. Stop when covered, when a window makes **no progress** (boundary didn't move — genuine no-more-data, leave for a later call to re-query), or when a fetch throws.
+
+### Task 5: Crypto — failing contiguity test (reproduce the bug)
+
+**Files:**
+- Test: `MoolahTests/Shared/ContiguousExtensionCryptoTests.swift`
+
+- [ ] **Step 1: Write the failing test** — a fake `CryptoPriceClient` that, like CoinGecko-free, only serves dates within 365 days of `today`, and otherwise returns `[:]`. Drive a far-back request and assert the cache has **no interior gap** between the served block and the original bounds (today's behaviour leaves a gap; the fix must not).
+
+```swift
+import Testing
+import Foundation
+@testable import Moolah
+
+@Suite struct ContiguousExtensionCryptoTests {
+  /// Serves a daily price for every day in the requested range that is
+  /// within `horizonDays` of `today`; older days return empty (mimics
+  /// CoinGecko free tier's 365-day refusal collapsing to empty).
+  struct HorizonClient: CryptoPriceClient {
+    let today: Date
+    let horizonDays: Int
+    var syncProvider: SyncProvider { .binance }
+    func dailyPrice(for m: CryptoProviderMapping, on d: Date) async throws -> Decimal { 1 }
+    func currentPrices(for m: [CryptoProviderMapping]) async throws -> [String: Decimal] { [:] }
+    func dailyPrices(for m: CryptoProviderMapping, in range: ClosedRange<Date>) async throws -> [String: Decimal] {
+      let cal = Calendar.utc
+      let cutoff = cal.date(byAdding: .day, value: -horizonDays, to: today)!
+      let fmt = ISO8601DateFormatter(); fmt.formatOptions = [.withFullDate]; fmt.timeZone = TimeZone(identifier: "UTC")
+      var out: [String: Decimal] = [:]
+      var day = range.lowerBound
+      while day <= range.upperBound {
+        if day >= cutoff { out[fmt.string(from: day)] = 100 }
+        day = cal.date(byAdding: .day, value: 1, to: day)!
+      }
+      return out
+    }
+  }
+
+  @Test func farBackRequestLeavesNoInteriorGap() async throws {
+    let today = ISO8601DateFormatter.utcDay("2026-06-17")
+    let service = CryptoPriceService(
+      clients: [HorizonClient(today: today, horizonDays: 365)],
+      database: try TestDatabases.rateCache(),  // in-memory profile-index schema
+      now: { today }, timeZone: TimeZone(identifier: "UTC")!)
+    let mapping = CryptoProviderMapping(
+      instrumentId: "1:binance-test", coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: "TESTUSDT")
+    let instrument = Instrument.crypto(chainId: 1, contractAddress: "0xtest", symbol: "TEST", name: "Test", decimals: 8)
+
+    // Warm a recent block (within horizon), then request a date >365 days back.
+    _ = try? await service.price(for: instrument, mapping: mapping, on: today)
+    _ = try? await service.price(
+      for: instrument, mapping: mapping,
+      on: ISO8601DateFormatter.utcDay("2024-07-12"))
+
+    // The cache must not contain an interior hole: every day between its
+    // earliest and latest must be present OR the bounds must not span the
+    // un-served region. Assert no gap larger than the bounded window.
+    let maxGap = try await service.debugMaxInteriorGapDays(tokenId: instrument.id)
+    #expect(maxGap <= 31)  // bounded window; never a multi-month void
+  }
+}
+```
+
+> This test needs two test-only helpers: `TestDatabases.rateCache()` (an in-memory `DatabaseQueue` migrated with the profile-index rate-cache schema — model it on the existing rate-cache test harness; search `MoolahTests` for how `crypto_price` tables are set up in current `CryptoPriceServiceTests`), `ISO8601DateFormatter.utcDay(_:)` (likely already exists in test support — search; if not, add a one-line helper), and `CryptoPriceService.debugMaxInteriorGapDays(tokenId:)` (Step 3).
+
+- [ ] **Step 2: Run, verify fail** — with today's unbounded logic the far-back request either leaves a multi-month gap (maxGap ≫ 31) or the helper doesn't exist.
+
+Run: `just test-mac ContiguousExtensionCryptoTests 2>&1 | tee .agent-tmp/crypto.txt`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the `debugMaxInteriorGapDays` test helper** to `CryptoPriceService` (guard with `#if DEBUG`)
+
+```swift
+#if DEBUG
+  func debugMaxInteriorGapDays(tokenId: String) -> Int {
+    guard let cache = caches[tokenId] else { return 0 }
+    let keys = cache.prices.sortedKeys
+    var maxGap = 0
+    for i in 1..<max(keys.count, 1) where keys.count > 1 {
+      let a = DateKey.isoString(keys[i - 1]); let b = DateKey.isoString(keys[i])
+      let fmt = ISO8601DateFormatter(); fmt.formatOptions = [.withFullDate]; fmt.timeZone = TimeZone(identifier: "UTC")
+      if let da = fmt.date(from: a), let db = fmt.date(from: b) {
+        let days = Calendar.utc.dateComponents([.day], from: da, to: db).day ?? 0
+        maxGap = max(maxGap, days - 1)
+      }
+    }
+    return maxGap
+  }
+#endif
+```
+
+- [ ] **Step 4: Run, verify the test still fails for the right reason** (now compiles, asserts gap too large). Confirm `maxGap` is large (multi-month) under current logic.
+
+- [ ] **Step 5: Commit the failing test** (`test(price-cache): crypto far-back request must not leave interior gap`).
+
+### Task 6: Crypto — drive `price(...)` with the bounded planner loop
+
+**Files:**
+- Modify: `Shared/CryptoPriceService.swift` (replace `extensionWindow` use in `price(...)`, lines ~156-199, and delete/retire the unbounded `extensionWindow`).
+
+- [ ] **Step 1: Replace the single-shot extension with a bounded loop**
+
+Replace the out-of-range section of `price(for:mapping:on:)` (everything from the `extensionWindow(...)` computation through the `withTaskCancellationHandler` return) with a loop that pulls windows from the planner. Keep the existing in-flight coalescing (`extensionTasks`) wrapping the *per-window* fetch.
+
+```swift
+// after inRangeFallback returned nil (out of range):
+let requestedKey = DateKey.from(isoString: dateString) ?? Int32.max
+let todayKey = DateKey.from(isoString: dateFormatter.string(from: now())) ?? requestedKey
+var guardSteps = 0
+while guardSteps < 64 {  // safety bound; ~64×30d windows covers any real history
+  guardSteps += 1
+  let bounds = boundsKeys(tokenId: tokenId)  // (earliest?, latest?) as DateKey from caches[tokenId]
+  guard let window = ContiguousFetchPlanner.nextWindow(
+    earliest: bounds.earliest, latest: bounds.latest,
+    requested: requestedKey, today: todayKey,
+    windowDays: 30, forwardBuffer: 2)
+  else { break }  // requested now in range
+  let before = bounds
+  let interval = DateKey.isoString(window.lowerBound)...DateKey.isoString(window.upperBound)
+  let fetchInterval = parseInterval(interval)  // ClosedRange<Date> via dateFormatter
+  do {
+    try await fetchWindowCoalesced(
+      instrument: instrument, mapping: mapping, fetchInterval: fetchInterval)
+  } catch {
+    // provider chain fully failed for this window: leave bounds, surface below.
+    break
+  }
+  if let cached = lookupPrice(tokenId: tokenId, dateString: dateString) { return cached }
+  if let inRange = try inRangeFallback(tokenId: tokenId, dateString: dateString) { return inRange }
+  // No progress (bounds unchanged) → genuine no-more-data this side; stop and
+  // let a later call re-query the boundary (recent data may publish later).
+  if boundsKeys(tokenId: tokenId) == before { break }
+}
+if let inRange = try inRangeFallback(tokenId: tokenId, dateString: dateString) { return inRange }
+throw CryptoPriceError.noPriceAvailable(tokenId: tokenId, date: dateString)
+```
+
+> `boundsKeys(tokenId:)`, `parseInterval(_:)`, and `fetchWindowCoalesced(...)` are introduced in Steps 2–3. `fetchWindowCoalesced` is the existing `extensionTasks` coalescing wrapper refactored to fetch a *given* interval (not compute its own window) and to **merge without computing a window** — it calls `fetchRange(instrument:mapping:from:to:)` (already bounded-safe given a bounded interval) rather than `fetchAndExtendCache` (which returns a single price). The merge inside `fetchRange` already advances bounds to `min/max` of returned data — correct now that the *window* is bounded.
+
+- [ ] **Step 2: Add `boundsKeys` and `parseInterval` helpers**
+
+```swift
+private func boundsKeys(tokenId: String) -> (earliest: Int32?, latest: Int32?) {
+  guard let cache = caches[tokenId] else { return (nil, nil) }
+  return (DateKey.from(isoString: cache.earliestDate), DateKey.from(isoString: cache.latestDate))
+}
+
+private func parseInterval(_ iso: ClosedRange<String>) -> ClosedRange<Date> {
+  let lower = dateFormatter.date(from: iso.lowerBound) ?? now()
+  let upper = dateFormatter.date(from: iso.upperBound) ?? now()
+  return lower...max(lower, upper)
+}
+```
+
+- [ ] **Step 3: Refactor the coalescing wrapper to fetch a given interval**
+
+Adapt the existing `extensionTasks` coalescing (currently inside `price`) into:
+
+```swift
+private func fetchWindowCoalesced(
+  instrument: Instrument, mapping: CryptoProviderMapping, fetchInterval: ClosedRange<Date>
+) async throws {
+  let tokenId = instrument.id
+  if let inFlight = extensionTasks[tokenId] { _ = try? await inFlight.task.value; return }
+  let requestId = UUID()
+  let task = Task<Decimal, Error> { [self] in
+    try await self.fetchRange(
+      instrument: instrument, mapping: mapping,
+      from: fetchInterval.lowerBound, to: fetchInterval.upperBound)
+    return 0
+  }
+  extensionTasks[tokenId] = (requestId, task)
+  defer { if extensionTasks[tokenId]?.id == requestId { extensionTasks.removeValue(forKey: tokenId) } }
+  _ = try await withTaskCancellationHandler { try await task.value } onCancel: { task.cancel() }
+}
+```
+
+> `extensionTasks` type stays `[String: (id: UUID, task: Task<Decimal, Error>)]`; the `Decimal` payload is now unused (return 0) — acceptable, or retype to `Task<Void, Error>` in a follow-up. Keep `fetchAndExtendCache` only if still referenced elsewhere; otherwise delete it and `extensionWindow` (now dead). Grep before deleting.
+
+- [ ] **Step 4: Run the crypto contiguity test, verify pass**
+
+Run: `just test-mac ContiguousExtensionCryptoTests 2>&1 | tee .agent-tmp/crypto.txt`
+Expected: PASS (`maxGap <= 31`).
+
+- [ ] **Step 5: Run the full existing crypto suite to catch regressions**
+
+Run: `just test-mac CryptoPriceServiceTests CryptoPriceServiceStablecoinTests CryptoRateLookupTests 2>&1 | tee .agent-tmp/crypto-reg.txt`
+Expected: PASS. Fix any fallout (e.g. tests asserting the old unbounded window shape — update them to the bounded behaviour, noting the change).
+
+- [ ] **Step 6: format-check + commit**
+
+```bash
+just format-check 2>&1 | tee .agent-tmp/fmt.txt
+git add Shared/CryptoPriceService.swift MoolahTests/Shared/ContiguousExtensionCryptoTests.swift
+git commit -m "fix(price-cache): bounded contiguous extension in CryptoPriceService"
+```
+
+### Task 7: Crypto — `prices(in:)` and `warmRange` use bounded sub-ranges
+
+**Files:** Modify `Shared/CryptoPriceService.swift`, `Shared/CryptoPriceService+FetchRange.swift` (`uncoveredSubRanges`).
+
+- [ ] **Step 1: Write the failing test** — a range request spanning a huge gap (cold-to-far) must fill in bounded windows without creating an interior hole.
+
+```swift
+  @Test func rangeRequestFillsContiguouslyInWindows() async throws {
+    let today = ISO8601DateFormatter.utcDay("2026-06-17")
+    let service = CryptoPriceService(
+      clients: [HorizonClient(today: today, horizonDays: 100000)],  // serves everything
+      database: try TestDatabases.rateCache(), now: { today }, timeZone: TimeZone(identifier: "UTC")!)
+    let mapping = CryptoProviderMapping(instrumentId: "1:r", coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: "RUSDT")
+    let instrument = Instrument.crypto(chainId: 1, contractAddress: "0xr", symbol: "R", name: "R", decimals: 8)
+    let lo = ISO8601DateFormatter.utcDay("2024-01-01")
+    _ = try await service.prices(for: instrument, mapping: mapping, in: lo...today)
+    #expect(try await service.debugMaxInteriorGapDays(tokenId: instrument.id) <= 31)
+  }
+```
+
+- [ ] **Step 2: Run, verify fail** (unbounded `uncoveredSubRanges` may emit one giant range).
+
+- [ ] **Step 3: Bound the sub-ranges** — in `uncoveredSubRanges`, split each backward/forward sub-range into `windowDays`-sized chunks (reuse `ContiguousFetchPlanner` or a `chunked(by:)` helper) so no single fetch exceeds a window. Drive them through `fetchRange` in order, anchored at the moving boundary.
+
+```swift
+// after computing `result: [ClosedRange<Date>]`, chunk each entry:
+return result.flatMap { Self.chunked($0, days: 30) }
+```
+
+Add a `static func chunked(_ range: ClosedRange<Date>, days: Int) -> [ClosedRange<Date>]` using `Calendar.utc`.
+
+- [ ] **Step 4: Run, verify pass** (range test + existing `warmRange`/`prices` tests).
+
+Run: `just test-mac ContiguousExtensionCryptoTests CryptoPriceServiceTests 2>&1 | tee .agent-tmp/crypto.txt`
+
+- [ ] **Step 5: format-check + commit** (`fix(price-cache): bound crypto range/warm sub-ranges`).
+
+---
+
+## Phase 3 — Migrate StockPriceService
+
+Same pattern. Stock differs only in keying (`ticker`), single-provider client, and `instrument_id` in meta. Markets close weekends/holidays, so genuine gaps exist — the contiguity test must use a fake client that serves only weekdays and assert gaps are **only** weekend-sized.
+
+### Task 8: Stock — failing contiguity test
+
+**Files:** Test `MoolahTests/Shared/ContiguousExtensionStockTests.swift`.
+
+- [ ] **Step 1: Write the failing test** — fake `StockPriceClient` (`fetchDailyPrices(ticker:from:to:)` → `StockPriceResponse`) that serves weekdays only and refuses (empty) dates older than a horizon. Warm recent, request far-back, assert max interior gap ≤ 4 days (a long weekend), never multi-week.
+
+```swift
+@Suite struct ContiguousExtensionStockTests {
+  struct WeekdayHorizonClient: StockPriceClient {
+    let today: Date; let horizonDays: Int
+    func fetchDailyPrices(ticker: String, from: Date, to: Date) async throws -> StockPriceResponse {
+      let cal = Calendar.utc
+      let cutoff = cal.date(byAdding: .day, value: -horizonDays, to: today)!
+      let fmt = ISO8601DateFormatter(); fmt.formatOptions = [.withFullDate]; fmt.timeZone = TimeZone(identifier: "UTC")
+      var out: [String: Decimal] = [:]; var d = from
+      while d <= to {
+        let wd = cal.component(.weekday, from: d)
+        if d >= cutoff && wd != 1 && wd != 7 { out[fmt.string(from: d)] = 50 }
+        d = cal.date(byAdding: .day, value: 1, to: d)!
+      }
+      return StockPriceResponse(instrument: .fiat(code: "AUD"), prices: out)
+    }
+  }
+  @Test func farBackStockRequestLeavesOnlyWeekendGaps() async throws { /* mirror crypto Task 5, assert <= 4 */ }
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** (`just test-mac ContiguousExtensionStockTests`)
+- [ ] **Step 3:** Add `StockPriceService.debugMaxInteriorGapDays(ticker:)` (`#if DEBUG`, mirror crypto helper, keyed by ticker).
+- [ ] **Step 4: Run, confirm fails for the right reason (gap too large).**
+- [ ] **Step 5: Commit** the failing test.
+
+### Task 9: Stock — bounded planner loop in `price(ticker:on:)`
+
+**Files:** Modify `Shared/StockPriceService.swift` (replace `fetchToCoverDate` window math + the call site in `price`).
+
+- [ ] **Step 1:** Replace `fetchToCoverDate`'s internal window computation with the `ContiguousFetchPlanner`-driven bounded loop (mirror Task 6, keyed by `ticker`; the fetch is the single `client.fetchDailyPrices(ticker:from:to:)` → merge via existing `mergeReturningDelta(ticker:instrument:newPrices:)`). Bound each fetch to one window; loop until covered / no-progress / throw. Stock keeps propagating the throw to `price(...)` per its current contract — but only after the bounded loop exhausts, and only when nothing is in range.
+- [ ] **Step 2:** Add `boundsKeys(ticker:)` helper (mirror crypto).
+- [ ] **Step 3: Run the stock contiguity test + existing `StockPriceServiceTests`, verify pass.**
+
+Run: `just test-mac ContiguousExtensionStockTests StockPriceServiceTests 2>&1 | tee .agent-tmp/stock.txt`
+
+- [ ] **Step 4:** Bound `prices(ticker:in:)` sub-ranges (mirror Task 7 if stock has a range method that emits unbounded sub-ranges).
+- [ ] **Step 5: format-check + commit** (`fix(price-cache): bounded contiguous extension in StockPriceService`).
+
+---
+
+## Phase 4 — Migrate ExchangeRateService
+
+FX is the structural outlier: cache value is `SortedDateSeries<[String: Decimal]>` (a per-day quote map), keyed by `base`, fetched via `client.fetchRates(base:from:to:)` → `[String:[String:Decimal]]`. The planner is value-agnostic (operates on DateKeys only), so it drops in unchanged; only the merge/lookup stay FX-specific.
+
+### Task 10: FX — failing contiguity test
+
+**Files:** Test `MoolahTests/Shared/ContiguousExtensionFXTests.swift`.
+
+- [ ] **Step 1: Write the failing test** — fake `ExchangeRateClient` (`fetchRates(base:from:to:)`) serving weekdays only within a horizon, returning `[date: ["AUD": rate]]`. Warm recent, request far-back, assert max interior gap (over the day-map keys) ≤ 4. Add `ExchangeRateService.debugMaxInteriorGapDays(base:)` (`#if DEBUG`).
+- [ ] **Step 2: Run, verify fail.** (`just test-mac ContiguousExtensionFXTests`)
+- [ ] **Step 3:** Add the debug helper.
+- [ ] **Step 4: Confirm fails for the right reason.**
+- [ ] **Step 5: Commit** the failing test.
+
+### Task 11: FX — bounded planner loop in `rate(...)`/`fetchToCoverDate`
+
+**Files:** Modify `Shared/ExchangeRateService.swift`.
+
+- [ ] **Step 1:** Replace `fetchToCoverDate(base:date:dateString:)`'s window math with the `ContiguousFetchPlanner` bounded loop (mirror Task 6, keyed by `base`; fetch via `fetchAndMerge(base:from:to:)` which already merges + persists). `fetchToCoverDate` currently *swallows* errors — preserve that (FX falls back to cached on failure); the loop simply stops on a throwing/no-progress window.
+- [ ] **Step 2:** Add `boundsKeys(base:)` helper.
+- [ ] **Step 3:** Bound `rates(from:to:in:)` sub-ranges and `prefetchLatest(base:)` to windows.
+- [ ] **Step 4: Run the FX contiguity test + existing `ExchangeRateServiceTests`, verify pass.**
+
+Run: `just test-mac ContiguousExtensionFXTests ExchangeRateServiceTests 2>&1 | tee .agent-tmp/fx.txt`
+
+- [ ] **Step 5: format-check + commit** (`fix(price-cache): bounded contiguous extension in ExchangeRateService`).
+
+---
+
+## Phase 5 — Purge the existing untrustworthy caches
+
+A one-time migration on the **profile-index** database deletes every row from all six cache tables so they re-warm contiguously under the fixed logic. Mirrors the precedent `v7_purge_intraday_cached_prices`.
+
+### Task 12: Purge migration
+
+**Files:**
+- Create: `Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift`
+- Modify: the profile-index migrator registration (find it: `grep -rn "registerMigration" Backends/GRDB/ProfileIndexSchema*.swift`)
+- Test: `MoolahTests/Backends/PurgeRateCachesMigrationTests.swift`
+
+- [ ] **Step 1: Write the failing test** — open an in-memory profile-index DB at the pre-purge schema version, insert a crypto_price row + a stock_price row + an exchange_rate row (+ their meta rows), run the migrator to latest, assert all six tables are empty.
+
+```swift
+import Testing
+import GRDB
+@testable import Moolah
+
+@Suite struct PurgeRateCachesMigrationTests {
+  @Test func purgeEmptiesAllSixCacheTables() throws {
+    let dbQueue = try DatabaseQueue()
+    var migrator = ProfileIndexSchema.migrator
+    // migrate to the version *before* the purge, seed rows, then to latest.
+    try migrator.migrate(dbQueue, upTo: "<id-of-migration-before-purge>")
+    try dbQueue.write { db in
+      try db.execute(sql: "INSERT INTO crypto_price VALUES ('t','2024-01-01',1.0)")
+      try db.execute(sql: "INSERT INTO crypto_token_meta VALUES ('t','T','2024-01-01','2024-01-01')")
+      try db.execute(sql: "INSERT INTO stock_price VALUES ('X.AX','2024-01-01',1.0)")
+      try db.execute(sql: "INSERT INTO stock_ticker_meta VALUES ('X.AX','AUD','2024-01-01','2024-01-01')")
+      try db.execute(sql: "INSERT INTO exchange_rate VALUES ('USD','AUD','2024-01-01',1.5)")
+      try db.execute(sql: "INSERT INTO exchange_rate_meta VALUES ('USD','2024-01-01','2024-01-01')")
+    }
+    try migrator.migrate(dbQueue)  // applies the purge
+    try dbQueue.read { db in
+      for t in ["crypto_price","crypto_token_meta","stock_price","stock_ticker_meta","exchange_rate","exchange_rate_meta"] {
+        #expect(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(t)") == 0)
+      }
+    }
+  }
+}
+```
+
+> Replace `<id-of-migration-before-purge>` with the actual current last migration id from the profile-index migrator.
+
+- [ ] **Step 2: Run, verify fail** (migration not registered → tables still populated).
+
+Run: `just test-mac PurgeRateCachesMigrationTests 2>&1 | tee .agent-tmp/purge.txt`
+Expected: FAIL.
+
+- [ ] **Step 3: Write the migration body + register it**
+
+```swift
+// Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift
+import Foundation
+import GRDB
+
+extension ProfileIndexSchema {
+  /// One-time wipe of all historic price/rate caches. They could contain
+  /// never-fetched interior gaps masked by the prior-day fallback (silently
+  /// stale values); the data is local, derived and cheap to refetch, so we
+  /// clear it and let the corrected contiguous extension rebuild it.
+  static func purgeRateCaches(_ db: Database) throws {
+    for table in [
+      "crypto_price", "crypto_token_meta",
+      "stock_price", "stock_ticker_meta",
+      "exchange_rate", "exchange_rate_meta",
+    ] {
+      try db.execute(sql: "DELETE FROM \(table)")
+    }
+  }
+}
+```
+
+Register (append after the current last profile-index migration):
+
+```swift
+migrator.registerMigration("vNN_purge_rate_caches", migrate: purgeRateCaches)
+```
+
+> Use the next sequential `vNN_…` id matching the profile-index migrator's existing naming. Per `guides/DATABASE_SCHEMA_GUIDE.md`, migrations are frozen once shipped — append, never edit.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5:** Update the test's `<id-of-migration-before-purge>` to the real prior id; rerun. format-check + commit.
+
+```bash
+just format-check 2>&1 | tee .agent-tmp/fmt.txt
+git add Backends/GRDB/ProfileIndexSchema+PurgeRateCaches.swift Backends/GRDB/ProfileIndexSchema*.swift MoolahTests/Backends/PurgeRateCachesMigrationTests.swift
+git commit -m "feat(price-cache): purge untrustworthy rate caches for contiguous rebuild"
+```
+
+---
+
+## Phase 6 — Whole-suite verification
+
+### Task 13: Full build, test, format, review
+
+- [ ] **Step 1: Full macOS suite**
+
+Run: `just test-mac 2>&1 | tee .agent-tmp/full-mac.txt`
+Then: `grep -i 'failed\|error:' .agent-tmp/full-mac.txt`
+Expected: no failures. Investigate any (esp. existing price-service tests pinning the old window shape — update them to the bounded behaviour and note the change).
+
+- [ ] **Step 2: iOS suite**
+
+Run: `just test-ios 2>&1 | tee .agent-tmp/full-ios.txt`
+
+- [ ] **Step 3: format-check + warning check**
+
+Run: `just format-check 2>&1 | tee .agent-tmp/fmt.txt` (expect clean — no SwiftLint baseline). Build warning-free (`SWIFT_TREAT_WARNINGS_AS_ERRORS`).
+
+- [ ] **Step 4: Run the review agents** (`code-review`, `concurrency-review`, `database-schema-review`, `database-code-review`) over the diff; apply all findings.
+
+- [ ] **Step 5: Clean up `.agent-tmp/` and commit any review fixes.**
+
+```bash
+rm -f .agent-tmp/planner.txt .agent-tmp/crypto*.txt .agent-tmp/stock.txt .agent-tmp/fx.txt .agent-tmp/purge.txt .agent-tmp/fmt.txt .agent-tmp/full-*.txt
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** invariant → planner (Phase 1) + per-service loops (Phases 2-4); bounded windows → Tasks 3/4/7/9/11; no-disconnected-island → planner always anchors at a boundary; boundary advances only across queried windows → bounded windows + merge (existing min/max merge is safe once windows are bounded); recovery wipe → Phase 5; no global forward cap → Task 3 (`today + forwardBuffer`, providers tolerate future dates); shared core → `ContiguousFetchPlanner`.
+- **Out of scope (per spec):** provider mappings (#1140); fallback semantics; the income/expense unavailable-month rule.
+- **Known follow-up to confirm during execution:** exact current last migration id of the profile-index migrator (Task 12); whether `fetchAndExtendCache`/`extensionWindow` become dead after Task 6 (grep before deleting); whether existing `CryptoPriceServiceTests`/`StockPriceServiceTests`/`ExchangeRateServiceTests` assert the old unbounded window shape (update + note).
+- **Risk:** the bounded loop changes deep-backfill from one request to several windowed fetches — a cold deep range now fills progressively (acceptable per design sign-off). Guard bound (`guardSteps < 64`) prevents runaway loops.


### PR DESCRIPTION
## Problem

The crypto / stock / FX historic price caches track coverage as just outer `[earliest, latest]` bounds. Two paths let those bounds straddle days that were **never fetched**: an unbounded `[latest … requested]` extension that a provider serves only a recent tail of (advancing the bound past the un-served middle), and a disconnected cold-cache 30-day window. Once a gap exists inside `[earliest, latest]`, the read path's prior-trading-day fallback silently serves a **stale** value there and the hole is never re-fetched — so net-worth and income/expense figures are quietly wrong.

Measured on a real profile (24/7 crypto, where any gap is spurious): LDO 14.6% covered (one contiguous 1,204-day void), STRK 5.5%, ZK 6.6%. Stocks/FX are mostly masked by legitimate weekend/holiday gaps but still showed real spurious holes (e.g. VGS.AX a 37-day non-holiday gap).

## Fix

A new pure, exhaustively-tested `ContiguousFetchPlanner` returns the next **bounded, boundary-anchored** fetch window (forward/backward/cold), future-capped at `today + buffer` (no global UTC clamp — all four providers tolerate future dates, verified, so an ASX close isn't withheld ~10h). Every fetch path in all three services — `price`/`prices`/`rate`/`rates`/`warmRange`/`prefetch` — now drives a no-progress-guarded loop over this planner instead of an unbounded range or precomputed chunks. The boundary only advances across days actually inside a queried window, so a gap can only ever be a genuine no-trade day — and the prior-trading-day fallback (retained, unchanged) is then always correct.

The invariant: **a cache series is always a single contiguous block where every interior day was actually queried.**

## Recovery

A one-time migration (`v6_purge_rate_caches`) wipes all six rate-cache tables on the profile-index DB so the now-untrustworthy gappy data rebuilds contiguously under the fixed logic. The caches are local, derived, un-synced and cheap to refetch. Mirrors the precedent `v7_purge_intraday_cached_prices`.

## Scope / non-goals

- This guarantees whatever is **reachable** is cached contiguously. Pre-shipping provider mappings so CoinGecko-only tokens (RPL/ILV/IMX) reach a deep-history provider is **#1140** (complementary, separate).
- The prior-trading-day fallback semantics and the income/expense "unavailable month" rule (#1077) are unchanged. Error/attribution behaviour of `prices(in:)` is preserved (still throws the attributed `WalletSyncError` when a requested endpoint stays uncovered).

## Verification

- TDD throughout: each service has a contiguity test that reproduces the interior-gap bug (maxGap 339 → ≤ 31 crypto / ≤ 4 stock·FX weekend) and fails-without-fix / passes-with-fix.
- Full macOS suite green: **4188 tests, 727 suites passed**. `format-check` clean.
- Reviewed by code-review, concurrency-review, database-schema-review, and database-code-review agents; all findings applied (bounded `prices(in:)`, cancellation propagation, `chunked`/`debugMaxInteriorGapDays` dedup into shared helpers, 250-step guard + warning, etc.).

Design + plan: `plans/2026-06-17-contiguous-price-cache-extension-{design,plan}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)