### PR TITLE
feat(crypto): re-detect provider mappings for registered tokens (#1140 PR2)

### DIFF
--- a/App/ProfileSession+CryptoPresets.swift
+++ b/App/ProfileSession+CryptoPresets.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// Built-in crypto preset seeding (#791) and the startup provider-mapping
+// re-detection pass (#1140). Split out of `ProfileSession.swift` to keep that
+// file within the `file_length` budget.
+extension ProfileSession {
+  /// Fires `registerBuiltInPresetsIfMissing` on the profile's registry
+  /// so chain native gas tokens (ETH on Ethereum / OP / Base; MATIC on
+  /// Polygon) and well-known ERC-20s carry a real provider mapping
+  /// before any conversion path consults the registry. Without this,
+  /// transaction detail / running-balance render fails for crypto legs
+  /// the very first time a profile reads them — issue #791.
+  ///
+  /// Then runs `reconcileProviderMappings` so already-registered tokens
+  /// (e.g. coingecko-only RPL / ILV / IMX) gain newly-cached Binance /
+  /// CryptoCompare mappings on the next launch — deep history resolves
+  /// and months stop rendering "—" (issue #1140).
+  ///
+  /// Both steps share one `Task` tracked in `crossStoreUpdateTasks` so
+  /// `cleanupSync` cancels in-flight work when the session tears down.
+  func seedBuiltInCryptoPresets(
+    registry: (any InstrumentRegistryRepository)?
+  ) {
+    guard let registry else { return }
+    let task = Task {
+      await registry.registerBuiltInPresetsIfMissing()
+      guard !Task.isCancelled else { return }
+      await self.reconcileFromCaches(registry: registry)
+    }
+    crossStoreUpdateTasks.append(task)
+  }
+
+  /// Re-detection pass: upgrade already-registered tokens (e.g.
+  /// coingecko-only RPL / ILV / IMX) with newly-cached Binance /
+  /// CryptoCompare mappings so deep history resolves and months stop
+  /// rendering "—" (issue #1140). Requires both provider caches; skipped
+  /// if either is unavailable (degraded open). CoinGecko ids are already
+  /// resolved at registration time, so the CoinGecko resolver is optional —
+  /// the live `SQLiteCoinGeckoCatalog` also conforms to
+  /// `LocalContractResolver`, so it is passed when the down-cast succeeds.
+  private func reconcileFromCaches(
+    registry: any InstrumentRegistryRepository
+  ) async {
+    guard let cryptoCompareCache, let binanceCache else { return }
+    let lookups = ProviderCatalogLookups(
+      cryptoCompare: cryptoCompareCache,
+      binance: binanceCache,
+      coinGecko: coinGeckoCatalog as? any LocalContractResolver)
+    await registry.reconcileProviderMappings(using: lookups)
+  }
+}

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -309,23 +309,8 @@ final class ProfileSession: Identifiable {
     startPeriodicPragmaOptimize()
   }
 
-  /// Fires `registerBuiltInPresetsIfMissing` on the profile's registry
-  /// so chain native gas tokens (ETH on Ethereum / OP / Base; MATIC on
-  /// Polygon) and well-known ERC-20s carry a real provider mapping
-  /// before any conversion path consults the registry. Without this,
-  /// transaction detail / running-balance render fails for crypto legs
-  /// the very first time a profile reads them — issue #791. Tracked in
-  /// `crossStoreUpdateTasks` so `cleanupSync` cancels in-flight seeds
-  /// when the session tears down.
-  private func seedBuiltInCryptoPresets(
-    registry: (any InstrumentRegistryRepository)?
-  ) {
-    guard let registry else { return }
-    let task = Task {
-      await registry.registerBuiltInPresetsIfMissing()
-    }
-    crossStoreUpdateTasks.append(task)
-  }
+  // `seedBuiltInCryptoPresets(registry:)` and `reconcileFromCaches(registry:)`
+  // live in `ProfileSession+CryptoPresets.swift`.
 
   /// Wires the crypto-token-store -> investment-store hook: when a
   /// registration's `pricingStatus` flips (e.g. user marks a token as

--- a/Domain/Models/CryptoProviderMapping.swift
+++ b/Domain/Models/CryptoProviderMapping.swift
@@ -30,6 +30,18 @@ struct CryptoProviderMapping: Codable, Sendable, Hashable, Identifiable {
     coingeckoId ?? cryptocompareSymbol ?? binanceSymbol ?? instrumentId
   }
 
+  /// Merge-only fill: each nil provider id is taken from `other`; a populated
+  /// column is never overwritten, and `instrumentId` is always kept. Used by
+  /// the startup re-detection pass to upgrade a stored mapping from the
+  /// provider caches without downgrading anything (#1140).
+  func merging(_ other: CryptoProviderMapping) -> CryptoProviderMapping {
+    CryptoProviderMapping(
+      instrumentId: instrumentId,
+      coingeckoId: coingeckoId ?? other.coingeckoId,
+      cryptocompareSymbol: cryptocompareSymbol ?? other.cryptocompareSymbol,
+      binanceSymbol: binanceSymbol ?? other.binanceSymbol)
+  }
+
   /// Built-in presets for common tokens.
   static let builtInPresets: [CryptoProviderMapping] =
     CryptoRegistration.builtInPresets.map(\.mapping)

--- a/Domain/Repositories/InstrumentRegistryRepository+Reconcile.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository+Reconcile.swift
@@ -10,12 +10,15 @@ extension InstrumentRegistryRepository {
   /// provider key was supplied): their mapping gains the now-available
   /// ids without a network round-trip.
   ///
-  /// Each registration returned by `allCryptoRegistrations()` has at least
-  /// one provider field, so its on-chain identity was already
-  /// contract-confirmed at registration time. That makes it safe to
-  /// attribute a Binance `<TICKER>USDT` pair by the row's ticker here —
-  /// the spam-ticker hazard of #790 only applies to *unconfirmed* ERC-20
-  /// identities, which never reach this list.
+  /// Only rows whose identity is already contract-confirmed (at least one
+  /// resolved provider id) and that are not `.spam` are reconciled —
+  /// `allCryptoRegistrations()` also returns `.spam` / `.unpriced` stubs
+  /// with an all-nil mapping (e.g. a spam ERC-20 from discovery carrying a
+  /// copied ticker), and those must NOT have a Binance / CryptoCompare
+  /// symbol attributed from their unverified ticker. The Binance
+  /// `<TICKER>USDT` attribution is safe precisely because the surviving
+  /// rows already carry a contract-resolved provider id, so the ticker is
+  /// confirmed rather than user/spam-supplied — the #790 hazard.
   ///
   /// Merge-only: a populated column is never overwritten (enforced by
   /// `CryptoProviderMapping.merging`), and a row whose merged mapping is
@@ -48,6 +51,21 @@ extension InstrumentRegistryRepository {
     for registration in registrations {
       do {
         try Task.checkCancellation()
+        // #790: only re-detect rows whose identity is already
+        // contract-confirmed (>=1 resolved provider id). An all-nil mapping
+        // (e.g. a .spam/.unpriced stub from discovery carrying a copied
+        // ticker) must NOT get a Binance/CryptoCompare symbol attributed
+        // from its unverified ticker. Also skip .spam outright — there's
+        // nothing to gain reconciling a hidden token.
+        // #790: only re-detect rows whose identity is already
+        // contract-confirmed (>=1 resolved provider id). An all-nil mapping
+        // (e.g. a .spam/.unpriced stub from discovery carrying a copied
+        // ticker) must NOT get a Binance/CryptoCompare symbol attributed
+        // from its unverified ticker. Also skip .spam outright — there's
+        // nothing to gain reconciling a hidden token.
+        guard registration.mapping.hasProviderMapping,
+          registration.pricingStatus != .spam
+        else { continue }
         let merged = try await mergedMapping(for: registration, using: catalogs)
         guard merged != registration.mapping else { continue }
         try await registerCrypto(registration.instrument, mapping: merged)

--- a/Domain/Repositories/InstrumentRegistryRepository+Reconcile.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository+Reconcile.swift
@@ -1,0 +1,152 @@
+import Foundation
+import OSLog
+
+extension InstrumentRegistryRepository {
+  /// Re-runs provider detection over every already-registered crypto
+  /// instrument, filling only the nil provider columns from the cached
+  /// CryptoCompare / Binance / CoinGecko catalogs and merging the result
+  /// back in. This is the startup pass that fixes #1140 for tokens that
+  /// were registered before a provider's catalog had loaded (or before a
+  /// provider key was supplied): their mapping gains the now-available
+  /// ids without a network round-trip.
+  ///
+  /// Each registration returned by `allCryptoRegistrations()` has at least
+  /// one provider field, so its on-chain identity was already
+  /// contract-confirmed at registration time. That makes it safe to
+  /// attribute a Binance `<TICKER>USDT` pair by the row's ticker here —
+  /// the spam-ticker hazard of #790 only applies to *unconfirmed* ERC-20
+  /// identities, which never reach this list.
+  ///
+  /// Merge-only: a populated column is never overwritten (enforced by
+  /// `CryptoProviderMapping.merging`), and a row whose merged mapping is
+  /// unchanged is not rewritten — no sync churn. Per-token failures are
+  /// logged and skipped; cancellation returns immediately. Best-effort
+  /// otherwise (no throws out of the method).
+  func reconcileProviderMappings(using catalogs: ProviderCatalogLookups) async {
+    let logger = Logger(
+      subsystem: "com.moolah.app", category: "InstrumentRegistryReconcile")
+
+    let registrations: [CryptoRegistration]
+    do {
+      registrations = try await allCryptoRegistrations()
+    } catch {
+      logger.warning(
+        """
+        reconcileProviderMappings: load failed: \
+        \(error.localizedDescription, privacy: .public)
+        """
+      )
+      return
+    }
+
+    do {
+      try Task.checkCancellation()
+    } catch {
+      return
+    }
+
+    for registration in registrations {
+      do {
+        try Task.checkCancellation()
+        let merged = try await mergedMapping(for: registration, using: catalogs)
+        guard merged != registration.mapping else { continue }
+        try await registerCrypto(registration.instrument, mapping: merged)
+      } catch is CancellationError {
+        return
+      } catch {
+        logger.warning(
+          """
+          reconcileProviderMappings: \(registration.id, privacy: .public): \
+          \(error.localizedDescription, privacy: .public)
+          """
+        )
+      }
+    }
+  }
+
+  /// Builds an additive candidate mapping by filling only the nil columns
+  /// of `registration.mapping` from the caches, then merges it back. Only
+  /// nil columns trigger a cache call, so a fully-mapped row does no work.
+  /// The three independent cache lookups fan out via `async let`, and
+  /// `CancellationError` propagates out so the loop's cancellation handler
+  /// can exit promptly mid-token.
+  private func mergedMapping(
+    for registration: CryptoRegistration,
+    using catalogs: ProviderCatalogLookups
+  ) async throws -> CryptoProviderMapping {
+    let mapping = registration.mapping
+    let instrument = registration.instrument
+    let ticker = (instrument.ticker ?? "").uppercased()
+    let contractAddress = instrument.contractAddress
+
+    async let newBinance = detectBinance(
+      existing: mapping.binanceSymbol, ticker: ticker, catalogs: catalogs)
+    async let newCryptoCompare = detectCryptoCompare(
+      existing: mapping.cryptocompareSymbol,
+      ticker: ticker,
+      contractAddress: contractAddress,
+      mapping: mapping,
+      catalogs: catalogs)
+    async let newCoinGecko = detectCoinGecko(
+      existing: mapping.coingeckoId, instrument: instrument, catalogs: catalogs)
+
+    let (binance, cryptoCompare, coinGecko) = await (
+      newBinance, newCryptoCompare, newCoinGecko
+    )
+    try Task.checkCancellation()
+
+    let candidate = CryptoProviderMapping(
+      instrumentId: mapping.instrumentId,
+      coingeckoId: coinGecko,
+      cryptocompareSymbol: cryptoCompare,
+      binanceSymbol: binance)
+    return mapping.merging(candidate)
+  }
+
+  private func detectBinance(
+    existing: String?, ticker: String, catalogs: ProviderCatalogLookups
+  ) async -> String? {
+    guard existing == nil, !ticker.isEmpty else { return existing }
+    guard await catalogs.binance.hasUsdtPair(base: ticker) else { return nil }
+    return "\(ticker)USDT"
+  }
+
+  private func detectCryptoCompare(
+    existing: String?,
+    ticker: String,
+    contractAddress: String?,
+    mapping: CryptoProviderMapping,
+    catalogs: ProviderCatalogLookups
+  ) async -> String? {
+    guard existing == nil else { return existing }
+    if let contractAddress {
+      // ERC-20: match on the on-chain contract first.
+      if let bySymbol = await catalogs.cryptoCompare.symbol(forContract: contractAddress) {
+        return bySymbol
+      }
+      // Post-confirm by symbol only when the row already carries a
+      // confirmed contract-based provider id (coingeckoId), mirroring
+      // CompositeTokenResolutionClient.postConfirmCryptoCompareBySymbol —
+      // never a bare ticker for an unconfirmed identity (#790).
+      guard mapping.coingeckoId != nil, !ticker.isEmpty,
+        await catalogs.cryptoCompare.allSymbols().contains(ticker)
+      else { return nil }
+      return ticker
+    }
+    // Native: (chainId, isNative) pins identity, so the ticker is trusted.
+    guard !ticker.isEmpty,
+      await catalogs.cryptoCompare.nativeSymbols().contains(ticker)
+    else { return nil }
+    return ticker
+  }
+
+  private func detectCoinGecko(
+    existing: String?, instrument: Instrument, catalogs: ProviderCatalogLookups
+  ) async -> String? {
+    guard existing == nil, let contractAddress = instrument.contractAddress,
+      let chainId = instrument.chainId, let coinGecko = catalogs.coinGecko
+    else { return existing }
+    return await coinGecko.localContractMatch(
+      chainId: chainId, contractAddress: contractAddress)?.coingeckoId
+  }
+}

--- a/Domain/Repositories/InstrumentRegistryRepository+Reconcile.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository+Reconcile.swift
@@ -57,12 +57,6 @@ extension InstrumentRegistryRepository {
         // ticker) must NOT get a Binance/CryptoCompare symbol attributed
         // from its unverified ticker. Also skip .spam outright — there's
         // nothing to gain reconciling a hidden token.
-        // #790: only re-detect rows whose identity is already
-        // contract-confirmed (>=1 resolved provider id). An all-nil mapping
-        // (e.g. a .spam/.unpriced stub from discovery carrying a copied
-        // ticker) must NOT get a Binance/CryptoCompare symbol attributed
-        // from its unverified ticker. Also skip .spam outright — there's
-        // nothing to gain reconciling a hidden token.
         guard registration.mapping.hasProviderMapping,
           registration.pricingStatus != .spam
         else { continue }

--- a/Domain/Repositories/ProviderCatalogLookups.swift
+++ b/Domain/Repositories/ProviderCatalogLookups.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// The cache-query seams that the re-detection pass reads, bundled so they
+/// can be passed as one value and stubbed in tests. Each field is a
+/// protocol, so the back-end provider caches and the test stubs both
+/// conform without the domain layer depending on any concrete type (#1140).
+struct ProviderCatalogLookups: Sendable {
+  let cryptoCompare: any CryptoCompareSymbolLookup
+  let binance: any BinancePairLookup
+  /// `nil` when no local CoinGecko contract catalog is available (e.g. the
+  /// bundled snapshot has not loaded yet). The reconcile pass skips
+  /// CoinGecko id detection in that case.
+  let coinGecko: (any LocalContractResolver)?
+}

--- a/MoolahTests/Domain/CryptoProviderMappingTests.swift
+++ b/MoolahTests/Domain/CryptoProviderMappingTests.swift
@@ -77,3 +77,47 @@ struct CryptoProviderMappingTests {
     }
   }
 }
+
+@Suite("CryptoProviderMapping.merging")
+struct CryptoProviderMappingMergingTests {
+  @Test("fills nil columns from other, never downgrades populated ones")
+  func mergeFillsNilsOnly() {
+    let stored = CryptoProviderMapping(
+      instrumentId: "1:0xrpl", coingeckoId: "rocket-pool",
+      cryptocompareSymbol: nil, binanceSymbol: nil)
+    let extra = CryptoProviderMapping(
+      instrumentId: "1:0xrpl", coingeckoId: "WRONG",
+      cryptocompareSymbol: "RPL", binanceSymbol: "RPLUSDT")
+    let merged = stored.merging(extra)
+    #expect(merged.coingeckoId == "rocket-pool")
+    #expect(merged.cryptocompareSymbol == "RPL")
+    #expect(merged.binanceSymbol == "RPLUSDT")
+    #expect(merged.instrumentId == "1:0xrpl")
+  }
+
+  @Test("no-op merge equals self")
+  func noOp() {
+    let full = CryptoProviderMapping(
+      instrumentId: "1:0xrpl", coingeckoId: "rocket-pool",
+      cryptocompareSymbol: "RPL", binanceSymbol: "RPLUSDT")
+    #expect(
+      full.merging(
+        .init(
+          instrumentId: "1:0xrpl", coingeckoId: nil,
+          cryptocompareSymbol: nil, binanceSymbol: nil)) == full)
+  }
+
+  @Test("does not mutate instrumentId even if other differs")
+  func keepsOwnInstrumentId() {
+    let stored = CryptoProviderMapping(
+      instrumentId: "1:0xrpl", coingeckoId: nil,
+      cryptocompareSymbol: nil, binanceSymbol: "RPLUSDT")
+    let other = CryptoProviderMapping(
+      instrumentId: "999:0xother", coingeckoId: "rocket-pool",
+      cryptocompareSymbol: "RPL", binanceSymbol: "WRONGUSDT")
+    let merged = stored.merging(other)
+    #expect(merged.instrumentId == "1:0xrpl")
+    #expect(merged.binanceSymbol == "RPLUSDT")  // own populated value kept
+    #expect(merged.coingeckoId == "rocket-pool")  // nil filled from other
+  }
+}

--- a/MoolahTests/Domain/InstrumentRegistryReconcileTests.swift
+++ b/MoolahTests/Domain/InstrumentRegistryReconcileTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("InstrumentRegistryRepository — reconcileProviderMappings")
+@MainActor
+struct InstrumentRegistryReconcileTests {
+  // MARK: - In-memory cache stubs
+
+  struct StubCC: CryptoCompareSymbolLookup {
+    var byContract: [String: String] = [:]
+    var natives: Set<String> = []
+    var all: Set<String> = []
+
+    func symbol(forContract address: String) async -> String? {
+      byContract[address.lowercased()]
+    }
+    func nativeSymbols() async -> Set<String> { natives }
+    func allSymbols() async -> Set<String> { all }
+  }
+
+  struct StubBinance: BinancePairLookup {
+    var pairs: Set<String> = []
+
+    func hasUsdtPair(base symbol: String) async -> Bool {
+      pairs.contains("\(symbol.uppercased())USDT")
+    }
+  }
+
+  struct StubCG: LocalContractResolver {
+    var byContract: [String: LocalContractMatch] = [:]
+
+    func localContractMatch(chainId: Int, contractAddress: String) async -> LocalContractMatch? {
+      byContract[contractAddress.lowercased()]
+    }
+  }
+
+  // MARK: - Registry fixture (mirrors InstrumentRegistryContractTests)
+
+  @MainActor
+  final class HookCapture {
+    var changedIds: [String] = []
+  }
+
+  @MainActor
+  struct Subject {
+    let repo: GRDBInstrumentRegistryRepository
+    let hooks: HookCapture
+  }
+
+  @MainActor
+  func makeSubject() throws -> Subject {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let hooks = HookCapture()
+    let repo = GRDBInstrumentRegistryRepository(
+      database: database,
+      onRecordChanged: { [hooks] id in Task { @MainActor in hooks.changedIds.append(id) } },
+      onRecordDeleted: { _ in }
+    )
+    return Subject(repo: repo, hooks: hooks)
+  }
+
+  // MARK: - Fixtures
+
+  private var rpl: Instrument {
+    .crypto(
+      chainId: 1, contractAddress: "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      symbol: "RPL", name: "Rocket Pool", decimals: 18)
+  }
+
+  private var rplAddress: String { "0xd33526068d116ce69f19a9ee46f0bd304f21a51f" }
+
+  private func reg(byId id: String, in repo: GRDBInstrumentRegistryRepository) async throws
+    -> CryptoRegistration
+  {
+    let regs = try await repo.allCryptoRegistrations()
+    return try #require(regs.first { $0.id == id })
+  }
+
+  // MARK: - Tests
+
+  @Test("fills nil provider columns from the caches")
+  func upgradesPartialMapping() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let rpl = rpl
+    try await repo.registerCrypto(
+      rpl,
+      mapping: CryptoProviderMapping(
+        instrumentId: rpl.id, coingeckoId: "rocket-pool",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(byContract: [rplAddress: "RPL"]),
+      binance: StubBinance(pairs: ["RPLUSDT"]),
+      coinGecko: StubCG())
+    await repo.reconcileProviderMappings(using: catalogs)
+
+    let reg = try await reg(byId: rpl.id, in: repo)
+    #expect(reg.mapping.coingeckoId == "rocket-pool")
+    #expect(reg.mapping.cryptocompareSymbol == "RPL")
+    #expect(reg.mapping.binanceSymbol == "RPLUSDT")
+  }
+
+  @Test("never downgrades a populated column and writes nothing when fully covered")
+  func neverDowngrades() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let hooks = subject.hooks
+    let rpl = rpl
+    try await repo.registerCrypto(
+      rpl,
+      mapping: CryptoProviderMapping(
+        instrumentId: rpl.id, coingeckoId: "rocket-pool",
+        cryptocompareSymbol: "RPL", binanceSymbol: "RPLUSDT"))
+    try await Task.sleep(for: .milliseconds(50))
+    hooks.changedIds.removeAll()
+
+    // Caches offer DIFFERENT values; merge-only fill must ignore them.
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(byContract: [rplAddress: "XXX"]),
+      binance: StubBinance(pairs: ["RPLUSDT"]),
+      coinGecko: StubCG(
+        byContract: [
+          rplAddress: LocalContractMatch(
+            coingeckoId: "other", symbol: "RPL", name: "Rocket Pool")
+        ]))
+    await repo.reconcileProviderMappings(using: catalogs)
+
+    let reg = try await reg(byId: rpl.id, in: repo)
+    #expect(reg.mapping.coingeckoId == "rocket-pool")
+    #expect(reg.mapping.cryptocompareSymbol == "RPL")
+    #expect(reg.mapping.binanceSymbol == "RPLUSDT")
+
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds.isEmpty)
+  }
+
+  @Test("no sync churn when already fully covered")
+  func noChurnWhenCovered() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let hooks = subject.hooks
+    let rpl = rpl
+    try await repo.registerCrypto(
+      rpl,
+      mapping: CryptoProviderMapping(
+        instrumentId: rpl.id, coingeckoId: "rocket-pool",
+        cryptocompareSymbol: "RPL", binanceSymbol: "RPLUSDT"))
+    try await Task.sleep(for: .milliseconds(50))
+    hooks.changedIds.removeAll()
+
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(byContract: [rplAddress: "RPL"]),
+      binance: StubBinance(pairs: ["RPLUSDT"]),
+      coinGecko: StubCG(
+        byContract: [
+          rplAddress: LocalContractMatch(
+            coingeckoId: "rocket-pool", symbol: "RPL", name: "Rocket Pool")
+        ]))
+    await repo.reconcileProviderMappings(using: catalogs)
+
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds.isEmpty)
+  }
+
+  @Test("leaves a token unchanged when no cache knows it")
+  func ignoresUnknownTokens() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let rpl = rpl
+    try await repo.registerCrypto(
+      rpl,
+      mapping: CryptoProviderMapping(
+        instrumentId: rpl.id, coingeckoId: "rocket-pool",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(), binance: StubBinance(), coinGecko: StubCG())
+    await repo.reconcileProviderMappings(using: catalogs)
+
+    let reg = try await reg(byId: rpl.id, in: repo)
+    #expect(reg.mapping.coingeckoId == "rocket-pool")
+    #expect(reg.mapping.cryptocompareSymbol == nil)
+    #expect(reg.mapping.binanceSymbol == nil)
+  }
+
+  @Test("fills native token from native symbols + binance pair")
+  func nativeToken() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await repo.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(natives: ["ETH"]),
+      binance: StubBinance(pairs: ["ETHUSDT"]),
+      coinGecko: StubCG())
+    await repo.reconcileProviderMappings(using: catalogs)
+
+    let reg = try await reg(byId: eth.id, in: repo)
+    #expect(reg.mapping.coingeckoId == "ethereum")
+    #expect(reg.mapping.cryptocompareSymbol == "ETH")
+    #expect(reg.mapping.binanceSymbol == "ETHUSDT")
+  }
+
+  @Test("idempotent — a second reconcile fires no writes")
+  func idempotent() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let hooks = subject.hooks
+    let rpl = rpl
+    try await repo.registerCrypto(
+      rpl,
+      mapping: CryptoProviderMapping(
+        instrumentId: rpl.id, coingeckoId: "rocket-pool",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(byContract: [rplAddress: "RPL"]),
+      binance: StubBinance(pairs: ["RPLUSDT"]),
+      coinGecko: StubCG())
+    await repo.reconcileProviderMappings(using: catalogs)
+    try await Task.sleep(for: .milliseconds(50))
+    hooks.changedIds.removeAll()
+
+    await repo.reconcileProviderMappings(using: catalogs)
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds.isEmpty)
+  }
+}

--- a/MoolahTests/Domain/InstrumentRegistryReconcileTests.swift
+++ b/MoolahTests/Domain/InstrumentRegistryReconcileTests.swift
@@ -235,4 +235,44 @@ struct InstrumentRegistryReconcileTests {
     try await Task.sleep(for: .milliseconds(50))
     #expect(hooks.changedIds.isEmpty)
   }
+
+  @Test("a .spam row with a copied ticker is never given a provider symbol (#790)")
+  func spamRowNotPoisoned() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let hooks = subject.hooks
+    // A spam ERC-20 impersonating Optimism: a different contract, but a
+    // copied "OP" ticker and an all-nil mapping persisted at .spam by the
+    // discovery actor. Reconcile must not attribute OPUSDT / OP from the
+    // unverified ticker — that's the #790 poisoning the contract-confirmed
+    // resolver path is built to prevent.
+    let fakeOp = Instrument.crypto(
+      chainId: 1, contractAddress: "0x000000000000000000000000000000000000dead",
+      symbol: "OP", name: "Optimism", decimals: 18)
+    try await repo.registerCrypto(
+      fakeOp,
+      mapping: CryptoProviderMapping(
+        instrumentId: fakeOp.id, coingeckoId: nil,
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      forcingStatus: .spam)
+    try await Task.sleep(for: .milliseconds(50))
+    hooks.changedIds.removeAll()
+
+    let catalogs = ProviderCatalogLookups(
+      cryptoCompare: StubCC(byContract: ["0x000000000000000000000000000000000000dead": "OP"]),
+      binance: StubBinance(pairs: ["OPUSDT"]),
+      coinGecko: StubCG())
+    await repo.reconcileProviderMappings(using: catalogs)
+
+    // The row is returned by allCryptoRegistrations() (it's .spam, so the
+    // Lookup guard does not drop it), so it must be explicitly skipped.
+    let reg = try await reg(byId: fakeOp.id, in: repo)
+    #expect(reg.mapping.coingeckoId == nil)
+    #expect(reg.mapping.cryptocompareSymbol == nil)
+    #expect(reg.mapping.binanceSymbol == nil)
+    #expect(reg.pricingStatus == .spam)
+
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds.isEmpty)
+  }
 }


### PR DESCRIPTION
**PR2 of 2** for #1140 — **stacked on #1142** (base: `feature/crypto-provider-catalog`). This is the change that closes the issue.

## What's here
- **`CryptoProviderMapping.merging(_:)`** — merge-only fill (never downgrades a populated provider id).
- **`ProviderCatalogLookups`** — a `Sendable` bundle of the cache query seams (CryptoCompare symbol/native/all, Binance USDT-pair, CoinGecko contract lookup).
- **`reconcileProviderMappings(using:)`** — a best-effort startup pass that, for each already-registered crypto token, fills its missing provider columns from the (PR1) caches and merge-only upgrades the stored mapping, writing only on change (no sync churn). Cancellation-aware, mirrors `registerBuiltInPresetsIfMissing`.
- **Startup wiring** — runs after preset seeding in the tracked session task, using the live caches wired in PR1.

## Why this fixes #1140
RPL/ILV/IMX were registered with only a `coingecko_id`; CoinGecko's free tier refuses >365-day history, so months rendered "—". On next launch this pass detects their keyless **Binance** pairs (`RPLUSDT`/`ILVUSDT`/`IMXUSDT`) from the cache and adds `binance_symbol`, restoring deep history. As the caches refresh (PR1), newly-listed providers are picked up automatically — no app update or vendoring step.

## #790 safety
Re-detection only runs on rows that are **already contract-confirmed** (`hasProviderMapping`) and **not `.spam`** — a spam ERC-20 carrying a copied ticker can never get a Binance/CryptoCompare symbol attributed from its unverified ticker. Covered by a regression test (`spamRowNotPoisoned`, verified to fail without the guard).

## Verification
45 tests across 10 suites pass on macOS; `just format-check` clean; build green. Each task had spec + quality review (plus concurrency review on the async/actor paths) with all findings applied.

HEX is intentionally **not** reclassified (kept in scope as a probe-only token per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)