### PR TITLE
fix(crypto): DefiLlama follow-ups — Polygon provider ids + history-floor clamp

### DIFF
--- a/Backends/DefiLlama/DefiLlamaClient.swift
+++ b/Backends/DefiLlama/DefiLlamaClient.swift
@@ -47,14 +47,29 @@ struct DefiLlamaClient: CryptoPriceClient, Sendable {
         tokenId: mapping.instrumentId, provider: "DefiLlama")
     }
 
+    // One support read serves both the unsupported short-circuit and the
+    // history-floor clamp below (and the promote-only update later).
+    let cached = await supportCache?.support(for: mapping.instrumentId)
+
     // Short-circuit a fresh "unsupported" verdict so we don't pay a round-trip
     // for a token DefiLlama is known not to price.
-    if let cached = await supportCache?.support(for: mapping.instrumentId),
-      !cached.supported,
+    if let cached, !cached.supported,
       Date().timeIntervalSince(cached.lastChecked) < Self.supportMaxAge
     {
       throw CryptoPriceError.noProviderMapping(
         tokenId: mapping.instrumentId, provider: "DefiLlama")
+    }
+
+    // History-floor clamp: when the whole requested window ends before the
+    // token's known first-liquidity date, DefiLlama has no data to return, so
+    // skip the round-trip and report an empty window. The contiguous-window
+    // backfill's no-progress guard then stops the backward walk. A token's
+    // first-liquidity date does not move, so this clamp applies regardless of
+    // the row's freshness. ISO `YYYY-MM-DD` strings compare chronologically.
+    if let floor = cached?.earliestDate,
+      DefiLlamaWireFormat.isoDay(from: range.upperBound.timeIntervalSince1970) < floor
+    {
+      return [:]
     }
 
     let url = DefiLlamaWireFormat.chartURL(
@@ -72,8 +87,7 @@ struct DefiLlamaClient: CryptoPriceClient, Sendable {
     // keeps the recorded earliest date monotonically non-increasing.
     if !prices.isEmpty {
       let windowFloor = prices.keys.min()
-      let existingFloor = await supportCache?.support(for: mapping.instrumentId)?.earliestDate
-      let floor = [existingFloor, windowFloor].compactMap { $0 }.min()
+      let floor = [cached?.earliestDate, windowFloor].compactMap { $0 }.min()
       await supportCache?.upsert(
         instrumentId: mapping.instrumentId,
         supported: true,

--- a/Domain/Models/CryptoRegistration.swift
+++ b/Domain/Models/CryptoRegistration.swift
@@ -109,8 +109,8 @@ struct CryptoRegistration: Codable, Sendable, Hashable, Identifiable {
       instrument: .crypto(
         chainId: 137, contractAddress: nil, symbol: "MATIC", name: "Polygon", decimals: 18),
       mapping: CryptoProviderMapping(
-        instrumentId: "137:native", coingeckoId: "matic-network",
-        cryptocompareSymbol: "MATIC", binanceSymbol: "MATICUSDT"
+        instrumentId: "137:native", coingeckoId: "polygon-ecosystem-token",
+        cryptocompareSymbol: "MATIC", binanceSymbol: "POLUSDT"
       )
     ),
     CryptoRegistration(

--- a/MoolahTests/Backends/DefiLlama/DefiLlamaClientTests.swift
+++ b/MoolahTests/Backends/DefiLlama/DefiLlamaClientTests.swift
@@ -160,4 +160,56 @@ final class DefiLlamaClientTests {
     _ = try await client.dailyPrices(for: wethMapping, in: day...day)
     #expect(await cache.support(for: wethMapping.instrumentId)?.supported == true)
   }
+
+  @Test("a window entirely before the cached floor returns empty with no network call")
+  func clampBelowFloor() async throws {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("dl-floor-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let networking = makeNetworking()
+    let cache = try DefiLlamaSupportCache.make(directory: tempDir, networking: networking)
+    // Supported token whose first-liquidity floor is 2021-01-01.
+    await cache.upsert(
+      instrumentId: wethMapping.instrumentId, supported: true, earliestDate: "2021-01-01",
+      lastChecked: Date())
+    let hitFlag = LockedBox(false)
+    let coinId = "ethereum:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    StubURLProtocol.handlers["coins.llama.fi:/chart/\(coinId)"] = { _ in
+      hitFlag.set(true)
+      return (HTTPURLResponse.ok(etag: ""), Data("{\"coins\":{}}".utf8))
+    }
+    let client = DefiLlamaClient(networking: networking, supportCache: cache)
+    // A window wholly in 2019 — entirely before the 2021-01-01 floor.
+    let from = Date(timeIntervalSince1970: 1_546_300_800)  // 2019-01-01
+    let to = Date(timeIntervalSince1970: 1_548_979_200)  // 2019-02-01
+    let prices = try await client.dailyPrices(for: wethMapping, in: from...to)
+    #expect(prices.isEmpty)
+    #expect(hitFlag.get() == false)  // pre-liquidity window clamped; no network call
+  }
+
+  @Test("a window whose upperBound equals the floor still fetches (strict boundary)")
+  func clampExactFloorBoundaryFetches() async throws {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("dl-floor-eq-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let networking = makeNetworking()
+    let cache = try DefiLlamaSupportCache.make(directory: tempDir, networking: networking)
+    await cache.upsert(
+      instrumentId: wethMapping.instrumentId, supported: true, earliestDate: "2021-01-01",
+      lastChecked: Date())
+    let hitFlag = LockedBox(false)
+    let coinId = "ethereum:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    StubURLProtocol.handlers["coins.llama.fi:/chart/\(coinId)"] = { _ in
+      hitFlag.set(true)
+      return (HTTPURLResponse.ok(etag: ""), Data("{\"coins\":{}}".utf8))
+    }
+    let client = DefiLlamaClient(networking: networking, supportCache: cache)
+    // upperBound lands exactly on the floor day — the clamp is strict (`<`),
+    // so this must NOT be clamped; the floor day itself may carry data.
+    let floorDay = Date(timeIntervalSince1970: 1_609_459_200)  // 2021-01-01 UTC
+    _ = try await client.dailyPrices(for: wethMapping, in: floorDay...floorDay)
+    #expect(hitFlag.get() == true)  // boundary day fetches, never clamped
+  }
 }

--- a/MoolahTests/Domain/CryptoRegistrationTests.swift
+++ b/MoolahTests/Domain/CryptoRegistrationTests.swift
@@ -12,6 +12,18 @@ struct CryptoRegistrationTests {
     }
   }
 
+  /// The Polygon native preset must carry the post-rebrand provider ids: the
+  /// MATIC→POL migration retired the `matic-network` CoinGecko id (now dead on
+  /// CoinGecko and DefiLlama) and halted Binance's `MATICUSDT` pair (now
+  /// `POLUSDT`). Pin the live ids so a regression to the stale ones is caught.
+  @Test
+  func polygonPresetUsesPostRebrandProviderIds() throws {
+    let polygon = try #require(
+      CryptoRegistration.builtInPresets.first { $0.instrument.id == "137:native" })
+    #expect(polygon.mapping.coingeckoId == "polygon-ecosystem-token")
+    #expect(polygon.mapping.binanceSymbol == "POLUSDT")
+  }
+
   @Test
   func legacyRegistrationDecodesAsPriced() throws {
     let json = Data(


### PR DESCRIPTION
Two follow-ups from the DefiLlama price-provider review (#1144).

## 1. Polygon preset uses post-rebrand provider ids
The MATIC→POL rebrand staled two ids in the `137:native` built-in preset:
- `coingeckoId: matic-network` → **dead** on CoinGecko's own API and DefiLlama → `polygon-ecosystem-token` (live, ~$0.076).
- `binanceSymbol: MATICUSDT` → **BREAK** (halted) on Binance → `POLUSDT` (TRADING).

`cryptocompareSymbol: "MATIC"` left as-is (CryptoCompare needs a key to verify and is the deprecated last-resort). Regression test pins both fixed ids.

## 2. History-floor clamp in DefiLlamaClient
`dailyPrices` now skips the network round-trip when the requested window ends strictly before the token's cached `earliestDate` (first-liquidity) floor, returning empty — the contiguous-window backfill's no-progress guard then stops the backward walk. This is the consumption of the `earliest_date` floor that #1144 recorded but deferred. Also hoists the single `support(for:)` read to serve the short-circuit, the clamp, and the promote-only update. Clamp is strict (`<`), so a window whose `upperBound` equals the floor still fetches (tested).

## Testing
- New tests: Polygon preset ids; clamp-below-floor (empty, no network); exact-floor-boundary (still fetches).
- Full macOS suite green; `format-check` clean; code-review Approved.

Relates to #1140 / follows up #1144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)