### PR TITLE
fix(crypto): oversample DefiLlama /chart at 12h to fill daily price gaps

### DIFF
--- a/Backends/DefiLlama/DefiLlamaWireFormat.swift
+++ b/Backends/DefiLlama/DefiLlamaWireFormat.swift
@@ -6,17 +6,30 @@ import Foundation
 enum DefiLlamaWireFormat {
   private static let base = URL(string: "https://coins.llama.fi") ?? URL(fileURLWithPath: "/")
 
-  /// `/chart/{coin}?start=&span=&period=1d` — a daily series covering
-  /// `[from, to]`. `span` is the inclusive day count plus a 2-day buffer so the
-  /// final day is always included (DefiLlama returns near-day points).
+  /// Points per UTC day requested from `/chart` (`period=12h`).
+  ///
+  /// We oversample at 12h rather than `period=1d` because DefiLlama snaps each
+  /// requested point to the nearest real observation (~00:00 / ~23:59). At `1d`
+  /// those near-midnight timestamps alias against UTC-day buckets — consecutive
+  /// points collide on one day and skip the next — silently dropping ~1 day in
+  /// 5, even for max-confidence liquid tokens. Two points per day guarantees at
+  /// least one lands in every UTC day, so `parseChart`'s last-per-day bucketing
+  /// is dense. Finer than 12h does not recover more (genuinely sparse history
+  /// stays sparse); 12h is the smallest period that closes the aliasing.
+  private static let chartPointsPerDay = 2
+
+  /// `/chart/{coin}?start=&span=&period=12h` — a 12-hourly series covering
+  /// `[from, to]`, bucketed back to one price per UTC day by `parseChart`.
+  /// `span` is the inclusive day count plus a 2-day buffer (so the final day is
+  /// always included), times `chartPointsPerDay`.
   static func chartURL(coinId: String, from: Date, to: Date) -> URL {
     let pathURL = base.appendingPathComponent("chart").appendingPathComponent(coinId)
     var components = URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
     let days = max(0, Int(to.timeIntervalSince(from) / 86_400)) + 1 + 2
     components.queryItems = [
       URLQueryItem(name: "start", value: String(Int(from.timeIntervalSince1970))),
-      URLQueryItem(name: "span", value: String(days)),
-      URLQueryItem(name: "period", value: "1d"),
+      URLQueryItem(name: "span", value: String(days * chartPointsPerDay)),
+      URLQueryItem(name: "period", value: "12h"),
     ]
     return components.url ?? pathURL
   }

--- a/MoolahTests/Backends/DefiLlama/DefiLlamaWireFormatTests.swift
+++ b/MoolahTests/Backends/DefiLlama/DefiLlamaWireFormatTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("DefiLlamaWireFormat")
+struct DefiLlamaWireFormatTests {
+  private func queryItems(_ url: URL) -> [String: String] {
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    return Dictionary(
+      uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+  }
+
+  @Test("chart URL oversamples at 12h so every UTC day gets a point")
+  func chartURLOversamples() {
+    // DefiLlama's `period=1d` series snaps each point to the nearest real
+    // observation (~00:00 / ~23:59), which aliases against UTC-day buckets and
+    // drops ~1 day in 5. Oversampling at 12h (2 points/day) guarantees ≥1 point
+    // lands in every UTC day, so `parseChart`'s last-per-day bucketing is dense.
+    let from = Date(timeIntervalSince1970: 1_725_148_800)  // 2024-09-01 UTC
+    let to = Date(timeIntervalSince1970: 1_727_654_400)  // 2024-09-30 UTC (29 days later)
+    let items = queryItems(
+      DefiLlamaWireFormat.chartURL(coinId: "coingecko:ethereum", from: from, to: to))
+
+    #expect(items["period"] == "12h")
+    #expect(items["start"] == "1725148800")
+    // Inclusive day count (29 + 1) + 2-day buffer = 32 days, at 2 points/day.
+    #expect(items["span"] == "64")
+  }
+
+  @Test("a single-day window still oversamples at 12h")
+  func chartURLSingleDayOversamples() {
+    let day = Date(timeIntervalSince1970: 1_725_148_800)  // 2024-09-01 UTC
+    let items = queryItems(
+      DefiLlamaWireFormat.chartURL(coinId: "coingecko:ethereum", from: day, to: day))
+
+    #expect(items["period"] == "12h")
+    // (0 + 1) inclusive + 2-day buffer = 3 days, at 2 points/day.
+    #expect(items["span"] == "6")
+  }
+}


### PR DESCRIPTION
## Problem

On the prod "Real Profile" the September-2024 net-worth graph is almost entirely blank. Root cause: DefiLlama's `/chart?period=1d` series snaps each requested point to the nearest real observation (~00:00 / ~23:59). Those near-midnight timestamps **alias against UTC-day buckets** — consecutive points collide on one calendar day and skip the next — so `parseChart`'s last-per-day bucketing silently drops ~1 day in 5, even for max-confidence (0.99) liquid tokens.

The net-worth graph drops a day if **any** held priced token can't be valued, so the per-token holes union together: ~21 of 30 September days were blanked across the profile's eight held priced tokens (UNI, LDO, TIA, ENS, STRK, OP, ZK, RPL).

The 0.2 confidence floor is **not** implicated — confidence is a per-coin gate, not per-point, and every affected token reported 0.99.

## Fix

Request `period=12h` (2 points/day, `span` ×2) instead of `1d`. Two points per day guarantees at least one lands in every UTC day, so the existing last-per-day bucketing becomes dense. No parser change needed.

## Verification

- New `DefiLlamaWireFormatTests` (TDD: red → green) asserts the `period=12h` + oversampled `span`.
- **Live** against `coins.llama.fi`, replicating the exact URL the new code builds — every affected token goes from partial to full September coverage:

  | token | old (1d) | new (12h) |
  |---|---|---|
  | UNI | 21/30 | **30/30** |
  | LDO | 22/30 | **30/30** |
  | TIA | 24/30 | **30/30** |
  | ENS | 25/30 | **30/30** |
  | STRK | 25/30 | **30/30** |
  | OP | 27/30 | **30/30** |
  | ZK | 29/30 | **30/30** |
  | RPL | 29/30 | **30/30** |

  Finer than 12h recovers nothing more (genuinely sparse deep history stays sparse).
- 26 crypto-price regression tests green (`CryptoPriceService`, coalescing, DefiLlama suites); `just format-check` clean.

## Note — existing cache does not self-heal

Coverage is bounds-tracked: `ContiguousFetchPlanner` treats any date inside `[earliest, latest]` as covered, so this fixes **future** fetches and cold-cache rebuilds but does **not** refill already-cached interior gaps. Healing the prod profile's existing September holes requires clearing the affected tokens' `crypto_price` rows (a regenerable rate cache) so the next render re-backfills at 12h — handled separately.

EIGEN's late-September blank is unrelated and out of scope (the token had no market price before 2024-10-01); to be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)