### PR TITLE
fix(crypto): purge crypto price cache so DefiLlama gaps re-backfill (v7)

### DIFF
--- a/Backends/GRDB/ProfileIndexSchema+PurgeCryptoPriceCache.swift
+++ b/Backends/GRDB/ProfileIndexSchema+PurgeCryptoPriceCache.swift
@@ -1,0 +1,47 @@
+// Backends/GRDB/ProfileIndexSchema+PurgeCryptoPriceCache.swift
+
+import Foundation
+import GRDB
+
+// MARK: - v7 migration body
+//
+// Empties the two crypto rate-cache tables in the profile-index database —
+// `crypto_price` and `crypto_token_meta`.
+//
+// Why a one-shot purge: crypto daily prices fetched before the DefiLlama
+// 12h-oversampling fix carry scattered single-day holes. DefiLlama's
+// `period=1d` series snapped each point to the nearest real observation
+// (~00:00 / ~23:59), which aliased against UTC-day buckets and dropped ~1 day
+// in 5. The fixed client requests `period=12h`, but `ContiguousFetchPlanner`
+// only ever extends a cache toward its `[earliest, latest]` bounds — it never
+// re-fetches a date already inside them — so the existing interior gaps would
+// persist forever. Wiping the rows forces a dense cold re-backfill.
+//
+// Both tables must go together: the bounds the planner trusts live in
+// `crypto_token_meta`, so leaving the meta row would keep the planner treating
+// the gappy interior as covered (`CryptoPriceService.loadCache` returns a
+// hydrated cache whenever a meta row exists). The stock and exchange-rate
+// caches use date-anchored providers without this aliasing, so they are left
+// intact.
+//
+// The tables are local, derived, and un-synced — safe to truncate. They
+// re-warm automatically as the price service serves requests.
+// `DATABASE_SCHEMA_GUIDE.md §9`'s "rate caches kept forever" retention rule is
+// unaffected — only the *rows* are purged, not the tables themselves.
+
+extension ProfileIndexSchema {
+  /// Body of the `v7_purge_crypto_price_cache` migration.
+  ///
+  /// Deletes every row from `crypto_price` and `crypto_token_meta` so the
+  /// daily-gap rows cached before the DefiLlama 12h-oversampling fix
+  /// re-backfill densely. Both tables together: the cache bounds that drive
+  /// `ContiguousFetchPlanner` live in `crypto_token_meta`, so dropping only the
+  /// prices would leave the planner believing the gappy interior is covered.
+  static func purgeCryptoPriceCache(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        DELETE FROM crypto_price;
+        DELETE FROM crypto_token_meta;
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileIndexSchema.swift
+++ b/Backends/GRDB/ProfileIndexSchema.swift
@@ -34,6 +34,13 @@ import GRDB
 /// `v6_purge_rate_caches`          — DELETE FROM all six rate-cache tables
 ///   so gappy legacy rows are flushed before the contiguous-fill era. See
 ///   `ProfileIndexSchema+PurgeRateCaches.swift`.
+/// `v7_purge_crypto_price_cache`   — DELETE FROM `crypto_price` +
+///   `crypto_token_meta` so the daily-gap rows cached before the DefiLlama
+///   12h-oversampling fix re-backfill densely. Both tables together: the
+///   cache bounds that drive `ContiguousFetchPlanner` live in
+///   `crypto_token_meta`, so dropping only the prices would leave the planner
+///   believing the gappy interior is covered. See
+///   `ProfileIndexSchema+PurgeCryptoPriceCache.swift`.
 ///
 /// Each migration body is registered here. Once shipped, migration IDs
 /// are frozen forever; splitting later is fine, merging post-ship is
@@ -47,7 +54,7 @@ enum ProfileIndexSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 6
+  static let version = 7
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -65,6 +72,8 @@ enum ProfileIndexSchema {
     migrator.registerMigration("v4_needs_push", migrate: addNeedsPush)
     migrator.registerMigration("v5_deletion_journal", migrate: addDeletionJournal)
     migrator.registerMigration("v6_purge_rate_caches", migrate: purgeRateCaches)
+    migrator.registerMigration(
+      "v7_purge_crypto_price_cache", migrate: purgeCryptoPriceCache)
 
     return migrator
   }

--- a/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
@@ -17,8 +17,8 @@ struct ProfileIndexSchemaV3Tests {
 
   @Test("schema version reflects the latest migration")
   func versionIsLatest() {
-    // Bumped to 6 by `v6_purge_rate_caches` (contiguous-price-cache branch).
-    #expect(ProfileIndexSchema.version == 6)
+    // Bumped to 7 by `v7_purge_crypto_price_cache` (DefiLlama 12h-oversampling branch).
+    #expect(ProfileIndexSchema.version == 7)
   }
 
   @Test("v3 creates the instrument table plus all six rate-cache tables")

--- a/MoolahTests/Backends/PurgeCryptoPriceCacheMigrationTests.swift
+++ b/MoolahTests/Backends/PurgeCryptoPriceCacheMigrationTests.swift
@@ -1,0 +1,89 @@
+// MoolahTests/Backends/PurgeCryptoPriceCacheMigrationTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Confirms that `v7_purge_crypto_price_cache` empties the two crypto rate-cache
+/// tables (`crypto_price` + `crypto_token_meta`) so the DefiLlama daily-gap
+/// rows cached before the 12h-oversampling fix re-backfill densely. Both tables
+/// must be wiped together: the cache bounds that drive `ContiguousFetchPlanner`
+/// live in `crypto_token_meta`, so leaving the meta row would keep the planner
+/// believing the gappy interior is already covered. The stock and exchange-rate
+/// caches are not affected by the aliasing and must be left intact.
+@Suite("v7_purge_crypto_price_cache migration")
+struct PurgeCryptoPriceCacheMigrationTests {
+  @Test("v7 wipes both crypto cache tables but leaves stock/exchange caches intact")
+  func purgesCryptoCachesOnly() throws {
+    let dbQueue = try DatabaseQueue()
+
+    // Migrate to v6 (the state before the new purge migration).
+    try ProfileIndexSchema.migrator.migrate(dbQueue, upTo: "v6_purge_rate_caches")
+
+    // Seed the two crypto cache tables plus one stock and one exchange row.
+    try dbQueue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO crypto_token_meta (token_id, symbol, earliest_date, latest_date)
+          VALUES ('1:native', 'ETH', '2024-01-01', '2024-12-31');
+          INSERT INTO crypto_price (token_id, date, price_usd)
+          VALUES ('1:native', '2024-09-15', 2500.0);
+
+          INSERT INTO stock_ticker_meta (ticker, instrument_id, earliest_date, latest_date)
+          VALUES ('VGS.AX', 'inst-1', '2024-01-01', '2024-12-31');
+          INSERT INTO stock_price (ticker, date, price)
+          VALUES ('VGS.AX', '2024-09-15', 149.82);
+
+          INSERT INTO exchange_rate_meta (base, earliest_date, latest_date)
+          VALUES ('USD', '2024-01-01', '2024-12-31');
+          INSERT INTO exchange_rate (base, quote, date, rate)
+          VALUES ('USD', 'AUD', '2024-09-15', 1.55);
+          """)
+    }
+
+    // Apply v7.
+    try ProfileIndexSchema.migrator.migrate(dbQueue)
+
+    let counts: [String: Int] = try dbQueue.read { database in
+      var result: [String: Int] = [:]
+      for table in [
+        "crypto_price", "crypto_token_meta",
+        "stock_price", "stock_ticker_meta",
+        "exchange_rate", "exchange_rate_meta",
+      ] {
+        result[table] = try Table(table).fetchCount(database)
+      }
+      return result
+    }
+    #expect(counts["crypto_price"] == 0)
+    #expect(counts["crypto_token_meta"] == 0)
+    // The aliasing is crypto-specific — these must survive.
+    #expect(counts["stock_price"] == 1)
+    #expect(counts["stock_ticker_meta"] == 1)
+    #expect(counts["exchange_rate"] == 1)
+    #expect(counts["exchange_rate_meta"] == 1)
+  }
+
+  @Test("schema is intact after v7 — re-inserts succeed")
+  func schemaIntactAfterPurge() throws {
+    let dbQueue = try DatabaseQueue()
+    try ProfileIndexSchema.migrator.migrate(dbQueue)
+
+    try dbQueue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO crypto_token_meta (token_id, symbol, earliest_date, latest_date)
+          VALUES ('1:native', 'ETH', '2026-01-01', '2026-06-01');
+          INSERT INTO crypto_price (token_id, date, price_usd)
+          VALUES ('1:native', '2026-06-01', 3000.0);
+          """)
+    }
+
+    let price: Double? = try dbQueue.read { database in
+      try Double.fetchOne(
+        database, sql: "SELECT price_usd FROM crypto_price WHERE token_id = '1:native'")
+    }
+    #expect(price == 3000.0)
+  }
+}


### PR DESCRIPTION
Follow-up to #1146 (DefiLlama 12h oversampling).

## Why this is needed

#1146 fixes *future* DefiLlama fetches, but `ContiguousFetchPlanner` only ever extends a cache toward its `[earliest, latest]` bounds — it treats any date already inside them as covered and never re-fetches it. So the scattered single-day holes already cached under the old `period=1d` logic would persist forever; the prod net-worth graph would stay gappy for historic months even on the new RC.

This mirrors the precedent set by `v6_purge_rate_caches` (which flushed gappy pre-contiguous-era rows).

## What it does

Adds migration `v7_purge_crypto_price_cache` that empties **both** crypto cache tables:

```sql
DELETE FROM crypto_price;
DELETE FROM crypto_token_meta;
```

Both together, deliberately: the cache bounds the planner trusts live in `crypto_token_meta`, and `CryptoPriceService.loadCache` hydrates a cache whenever a meta row exists. Dropping only the prices would leave the planner believing the gappy interior is still covered — so the wipe must clear the bounds too, making every crypto token look cold and forcing a dense cold re-backfill at 12h.

**Scope is crypto-only.** The stock (`stock_price`/`stock_ticker_meta`) and exchange-rate (`exchange_rate`/`exchange_rate_meta`) caches use date-anchored providers without the UTC-day aliasing, so they're left intact (unlike v6, which purged all six).

The tables are local, derived, and un-synced — safe to truncate; they re-warm automatically as the price service serves requests.

## Tests

New `PurgeCryptoPriceCacheMigrationTests` (TDD red→green): seeds all six caches at v6, applies v7, asserts the two crypto tables are emptied **and** the four stock/exchange rows survive; plus a schema-intact re-insert check. v6 and v7 migration suites green; `just format-check` clean.

## Ordering

Independent of #1146 (touches different files). Both land in the same RC; the runtime re-backfill happens in a build that contains both, so merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)