### PR TITLE
fix(accounts): live-refresh account groups after an in-app import

### DIFF
--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -262,7 +262,14 @@ final class ProfileSession: Identifiable {
     // `init` body) so the init stays within the
     // `function_body_length` budget — same pattern as `cryptoSyncStore`
     // / `cryptoTokenDiscovery` below.
-    self.accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+    // `instrumentChanges` wires the shared registry's change stream as a
+    // cross-connection refresh backstop: an in-app profile import writes
+    // the `account_group` rows through its own `DatabaseQueue`, which the
+    // open session's `observeAll()` never sees — without this the sidebar's
+    // groups stay missing until a restart (same pattern as `AccountStore`).
+    self.accountGroupStore = AccountGroupStore(
+      repository: backend.accountGroups,
+      instrumentChanges: backend.instrumentChangeObserver)
     self.groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
     // InsightStore is wired here (not in `makeDomainStores`) because it reads
     // `accountGroupStore`, which is itself constructed in `finishInit` — by

--- a/Features/Accounts/AccountGroupStore.swift
+++ b/Features/Accounts/AccountGroupStore.swift
@@ -31,6 +31,32 @@ final class AccountGroupStore {
   /// `ProfileSession.cleanupSync`) or `deinit` as a safety net.
   private var observationTask: Task<Void, Never>?
 
+  /// Shared instrument-registry change seam + the child task draining it.
+  /// `observeAll()` tracks only the `account_group` table, so a write that
+  /// lands through a *different* GRDB connection — an in-app profile import
+  /// holds its own `DatabaseQueue` over the same file — never fires it, and
+  /// the sidebar's groups stay stale until a restart re-reads the file. An
+  /// import always pings this registry stream (it registers every non-fiat
+  /// denomination before the per-profile write), so re-fetching on each
+  /// tick live-refreshes the open list across the DB boundary — mirroring
+  /// `AccountStore` / `EarmarkStore` / `TransactionStore`. Nil in
+  /// previews / legacy tests.
+  private let instrumentChanges: (any InstrumentChangeObserving)?
+  private var instrumentChangeObservationTask: Task<Void, Never>?
+
+  /// Monotonic counter over authoritative `observeAll()` snapshots. The
+  /// instrument-registry refresh path captures it before its `fetchAll()`
+  /// and drops a stale refetch that raced a fresher snapshot — see
+  /// `applyInstrumentRegistryRefresh`. `private(set)` (only
+  /// `bumpSnapshotGeneration()` writes it) + `@ObservationIgnored` (a pure
+  /// guard counter no view reads). Mirrors `AccountStore`.
+  @ObservationIgnored private(set) var snapshotGeneration: UInt64 = 0
+
+  /// The single increment path for `snapshotGeneration`.
+  private func bumpSnapshotGeneration() {
+    snapshotGeneration &+= 1
+  }
+
   /// Test-only emission tick stream. Yields `()` after every state
   /// assignment in `apply(groups:)`. Tests use the
   /// `TestableStoreObservation` helpers in
@@ -40,8 +66,12 @@ final class AccountGroupStore {
   let testObservationTickStream: AsyncStream<Void>
   private let testObservationTickContinuation: AsyncStream<Void>.Continuation
 
-  init(repository: any AccountGroupRepository) {
+  init(
+    repository: any AccountGroupRepository,
+    instrumentChanges: (any InstrumentChangeObserving)? = nil
+  ) {
     self.repository = repository
+    self.instrumentChanges = instrumentChanges
     let pair = AsyncStream<Void>.makeStream()
     self.testObservationTickStream = pair.stream
     self.testObservationTickContinuation = pair.continuation
@@ -51,6 +81,12 @@ final class AccountGroupStore {
     // `stopObserving()` is the sole lifetime gate. A weak capture would
     // just add a nil-check hazard without preventing the retain.
     observationTask = Task { await self.observe() }
+    if let instrumentChanges {
+      let changes = instrumentChanges.observeChanges()
+      instrumentChangeObservationTask = Task { [self] in
+        await self.observeInstrumentRegistryChanges(changes)
+      }
+    }
   }
 
   deinit {
@@ -60,6 +96,7 @@ final class AccountGroupStore {
     // `@MainActor`-isolated state requires `MainActor.assumeIsolated`.
     MainActor.assumeIsolated {
       observationTask?.cancel()
+      instrumentChangeObservationTask?.cancel()
       testObservationTickContinuation.finish()
     }
   }
@@ -75,7 +112,7 @@ final class AccountGroupStore {
     await withTaskGroup(of: Void.self) { group in
       group.addTask { [self] in
         for await fresh in groupsStream {
-          await self.apply(groups: fresh)
+          await self.applyGroupsSnapshot(fresh)
         }
       }
       group.addTask { [self] in
@@ -86,13 +123,63 @@ final class AccountGroupStore {
     }
   }
 
-  /// Applies a fresh snapshot from `observeAll()`. Yields the test tick
-  /// so deterministic emission-aware tests can await observed state.
-  /// Internal (not private) so a hypothetical future `+Observation`
-  /// split mirrors `AccountStore` / `EarmarkStore`.
-  func apply(groups fresh: [AccountGroup]) async {
+  /// The **authoritative** per-emission entry point for the `observeAll()`
+  /// subscription. Bumps `snapshotGeneration` so a concurrent
+  /// instrument-registry refetch can detect that it raced a fresher
+  /// snapshot, then applies it. Mirrors `AccountStore.applyAccountsSnapshot`.
+  private func applyGroupsSnapshot(_ fresh: [AccountGroup]) async {
+    bumpSnapshotGeneration()
+    await apply(groups: fresh)
+  }
+
+  /// Assigns a fresh snapshot and yields the test tick so deterministic
+  /// emission-aware tests can await observed state. Does NOT bump the
+  /// generation — only authoritative `observeAll()` snapshots do, so the
+  /// registry-refresh guard stays meaningful.
+  private func apply(groups fresh: [AccountGroup]) async {
     self.groups = fresh
     testObservationTickContinuation.yield(())
+  }
+
+  /// Consumes the shared instrument registry's change stream. Each tick
+  /// re-fetches the groups and re-applies them so a write that landed
+  /// through a connection `observeAll()` doesn't track (an in-app import's
+  /// own `DatabaseQueue`) still reaches the open sidebar. `Task.isCancelled`
+  /// is re-checked after the stream suspension so a teardown that races a
+  /// tick exits before issuing a fetch. `snapshotGeneration` is captured
+  /// *before* the `fetchAll()` so a stale refetch can be dropped — see
+  /// `applyInstrumentRegistryRefresh`. Mirrors
+  /// `AccountStore.observeInstrumentRegistryChanges`.
+  private func observeInstrumentRegistryChanges(_ changes: AsyncStream<Void>) async {
+    for await _ in changes {
+      guard !Task.isCancelled else { return }
+      let observedGeneration = snapshotGeneration
+      do {
+        let fresh = try await repository.fetchAll()
+        guard !Task.isCancelled else { return }
+        await applyInstrumentRegistryRefresh(fresh, observedGeneration: observedGeneration)
+      } catch {
+        surface(error: error)
+      }
+    }
+  }
+
+  /// Applies an instrument-registry-triggered refetch, but only if no
+  /// authoritative `observeAll()` snapshot has landed since the fetch was
+  /// issued. The `fetchAll()` runs unordered with respect to `observeAll()`;
+  /// a fetch that read the database before a concurrent write committed
+  /// returns a stale row set, and applying it after a fresher authoritative
+  /// snapshot would clobber `groups` back to the pre-write state. The
+  /// generation check and the assignment inside `apply(groups:)` run with no
+  /// intervening suspension on the main actor, so the only harmful ordering
+  /// (a stale refresh applied *after* a fresh snapshot) is exactly what the
+  /// guard drops. Internal so the store's refresh tests can drive the guard
+  /// path directly with a captured generation. Mirrors `AccountStore`.
+  func applyInstrumentRegistryRefresh(
+    _ fresh: [AccountGroup], observedGeneration: UInt64
+  ) async {
+    guard snapshotGeneration == observedGeneration else { return }
+    await apply(groups: fresh)
   }
 
   /// Surfaces an observation error onto `self.error`. Internal so the
@@ -108,16 +195,19 @@ final class AccountGroupStore {
     self.error = error
   }
 
-  /// Tears down the observation task. Idempotent.
+  /// Tears down the observation tasks. Idempotent.
   func stopObserving() {
     observationTask?.cancel()
+    instrumentChangeObservationTask?.cancel()
   }
 
   /// Test-only. Awaits the observation task chain to fully terminate
-  /// after `stopObserving()`, then nils the reference.
+  /// after `stopObserving()`, then nils the references.
   func awaitObservationTermination() async {
     await observationTask?.value
     observationTask = nil
+    await instrumentChangeObservationTask?.value
+    instrumentChangeObservationTask = nil
   }
 
   // MARK: - Lookups

--- a/MoolahTests/Features/Accounts/AccountGroupStoreRegistryRefreshTests.swift
+++ b/MoolahTests/Features/Accounts/AccountGroupStoreRegistryRefreshTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Cross-database refresh coverage for the reactive `AccountGroupStore`.
+///
+/// An in-app profile import writes the `account_group` rows through a
+/// GRDB connection that the already-open session's `observeAll()` does
+/// not observe (the import path and the live session can hold separate
+/// `DatabaseQueue`s over the same file). The per-profile data observation
+/// therefore never fires, so the sidebar's group headers stay missing
+/// until an app restart re-reads the file — the bug these tests pin.
+///
+/// `AccountStore` / `EarmarkStore` / `TransactionStore` already dodge this
+/// by additionally consuming the shared instrument registry's
+/// `observeChanges()` stream and re-running `fetchAll()` on each tick —
+/// and an import always fires that stream (it registers every non-fiat
+/// denomination before the per-profile write). These tests pin that
+/// `AccountGroupStore` consumes the same stream so an open sidebar
+/// live-refreshes its groups across the DB boundary.
+@Suite("AccountGroupStore registry refresh", .serialized)
+@MainActor
+struct AccountGroupStoreRegistryRefreshTests {
+
+  /// Registers an arbitrary crypto instrument on the shared registry,
+  /// which fires its `observeChanges()` stream — the signal an import
+  /// emits via `registerInstruments` before writing the per-profile rows.
+  private func fireRegistryChange(
+    on registry: GRDBInstrumentRegistryRepository
+  ) async throws {
+    let crypto = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      symbol: "WBTC", name: "Wrapped Bitcoin", decimals: 8)
+    try await registry.registerCrypto(
+      crypto,
+      mapping: CryptoProviderMapping(
+        instrumentId: crypto.id, coingeckoId: "wrapped-bitcoin",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+  }
+
+  @Test("registry tick refreshes groups written via a separate connection")
+  func registryTickRefreshesGroupsAcrossConnections() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("AccountGroupStoreRegistryRefreshTests-\(UUID().uuidString)")
+    // Run the scenario in a helper so the two `DatabaseQueue`s and the store
+    // are released (closing their SQLite connections) before the directory
+    // is deleted — otherwise unlinking the open `data.sqlite` trips libsqlite3's
+    // "vnode unlinked while in use" integrity check.
+    try await runCrossConnectionRefresh(in: directory)
+    try? FileManager.default.removeItem(at: directory)
+  }
+
+  /// Drives the cross-connection refresh and tears down every DB handle
+  /// before returning. The "live session" connection the store observes and
+  /// the "import" connection the new row is written through are two queues
+  /// over one WAL file, so the store's `observeAll()` is blind to the import
+  /// write — only the registry backstop can surface it.
+  private func runCrossConnectionRefresh(in directory: URL) async throws {
+    let url = directory.appendingPathComponent("data.sqlite")
+    let sessionQueue = try ProfileDatabase.open(at: url)
+    let importQueue = try ProfileDatabase.open(at: url)
+
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let store = AccountGroupStore(
+      repository: GRDBAccountGroupRepository(database: sessionQueue),
+      instrumentChanges: registry)
+    try await store.waitForFirstEmission()
+    #expect(store.groups.isEmpty)
+
+    // The import writes the group through its own connection. The session's
+    // `observeAll()` is blind to this (separate `DatabaseQueue`), so without
+    // the registry backstop the store stays empty until a restart.
+    _ = try await GRDBAccountGroupRepository(database: importQueue).create(
+      AccountGroup(
+        name: "Imported Crypto", bucket: .investments,
+        instrument: .defaultTestInstrument))
+
+    // The import fires the shared registry's change stream; the store must
+    // re-fetch and surface the group it never observed.
+    try await fireRegistryChange(on: registry)
+
+    await expectEventually("registry tick live-refreshes the imported group") {
+      store.groups.count == 1 && store.groups.first?.name == "Imported Crypto"
+    }
+
+    // Stop observation and await termination so no task retains the store
+    // past this scope; the store and both queues then deinit on return,
+    // closing the file before the caller deletes it.
+    store.stopObserving()
+    await store.awaitObservationTermination()
+  }
+
+  @Test("registry change after stopObserving does not refresh the store")
+  func registryChangeAfterStopDoesNotRefresh() async throws {
+    let (backend, _) = try TestBackend.create()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let store = AccountGroupStore(
+      repository: backend.accountGroups, instrumentChanges: registry)
+    try await store.waitForFirstEmission()
+    await store.drainPendingEmissions()
+    store.stopObserving()
+    await store.awaitObservationTermination()
+
+    try await fireRegistryChange(on: registry)
+
+    let didEmit = await store.didEmitWithin(timeout: .milliseconds(200))
+    #expect(didEmit == false)
+  }
+
+  @Test("stale instrument-registry refresh does not clobber a fresher groups snapshot")
+  func staleRegistryRefreshIsDropped() async throws {
+    // The registry refresh path captures the generation BEFORE its
+    // `fetchAll()`. A fetch that read the database before a concurrent write
+    // committed returns a stale row set; without the generation guard,
+    // applying it after a fresher authoritative snapshot would clobber
+    // `groups` back to the pre-write state. The guard must drop it.
+    let (backend, _) = try TestBackend.create()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let store = AccountGroupStore(
+      repository: backend.accountGroups, instrumentChanges: registry)
+    let first = try await backend.accountGroups.create(
+      AccountGroup(name: "First", bucket: .investments, instrument: .defaultTestInstrument))
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: first.id) != nil }, description: "first group visible")
+
+    // The registry path would capture the generation here, before its fetch.
+    let observedGeneration = store.snapshotGeneration
+
+    // An authoritative `observeAll()` snapshot lands while the (simulated)
+    // stale fetch is still in flight, bumping the generation.
+    let second = try await backend.accountGroups.create(
+      AccountGroup(name: "Second", bucket: .investments, instrument: .defaultTestInstrument))
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: second.id) != nil }, description: "second group visible")
+
+    // The stale, empty refetch resolves last. It must be dropped, not applied.
+    await store.applyInstrumentRegistryRefresh([], observedGeneration: observedGeneration)
+    #expect(store.by(id: first.id) != nil)
+    #expect(store.by(id: second.id) != nil)
+
+    store.stopObserving()
+  }
+
+  @Test("up-to-date instrument-registry refresh applies")
+  func currentRegistryRefreshApplies() async throws {
+    // Companion to `staleRegistryRefreshIsDropped`: when no authoritative
+    // snapshot has landed since the fetch was issued, the refresh applies —
+    // this is the cross-connection re-read the path exists for.
+    let (backend, _) = try TestBackend.create()
+    let registry = try SharedRegistryTestSupport.makeSharedRegistry()
+    let store = AccountGroupStore(
+      repository: backend.accountGroups, instrumentChanges: registry)
+    let group = try await backend.accountGroups.create(
+      AccountGroup(name: "Original", bucket: .investments, instrument: .defaultTestInstrument))
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id) != nil }, description: "group visible")
+
+    // Capture the current generation and apply a refresh tagged with it —
+    // simulating a fetch that observed the latest snapshot. A renamed copy
+    // proves the refresh was applied rather than dropped.
+    let observedGeneration = store.snapshotGeneration
+    var renamed = group
+    renamed.name = "Renamed"
+    await store.applyInstrumentRegistryRefresh([renamed], observedGeneration: observedGeneration)
+    #expect(store.by(id: group.id)?.name == "Renamed")
+
+    store.stopObserving()
+  }
+}

--- a/MoolahTests/Features/Accounts/AccountGroupStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Accounts/AccountGroupStoreSyncRefreshTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Symptom-A regression coverage for the reactive `AccountGroupStore`,
+/// mirroring `AccountStoreSyncRefreshTests`. The store subscribes to
+/// `repository.observeAll()` from `init`, so any GRDB write — local OR
+/// sync-driven — propagates to the sidebar without a manual reload, and
+/// `stopObserving()` cleanly severs that propagation.
+@Suite("AccountGroupStore sync refresh", .serialized)
+@MainActor
+struct AccountGroupStoreSyncRefreshTests {
+
+  @Test("remote group insert refreshes the store without manual refresh")
+  func remoteGroupInsertRefreshesStore() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+    #expect(store.groups.isEmpty)
+
+    _ = try await backend.accountGroups.create(
+      AccountGroup(name: "Synced", bucket: .investments, instrument: .defaultTestInstrument))
+
+    await expectEventually("inserted group reaches the store") {
+      store.groups.first?.name == "Synced"
+    }
+
+    store.stopObserving()
+  }
+
+  @Test("stopObserving cancels the observation task")
+  func stopObservingCancelsObservationTask() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+    // Drain any ticks buffered between init and the first
+    // `waitForFirstEmission` so the post-cancel assertion only sees ticks
+    // that arrive AFTER the backend write.
+    await store.drainPendingEmissions()
+    store.stopObserving()
+    // `stopObserving()` returns the moment `Task.cancel()` is issued; the
+    // observation loops only notice cancellation on the next stream check.
+    // Await termination so an in-flight emission can't race the cancel.
+    await store.awaitObservationTermination()
+
+    _ = try await backend.accountGroups.create(
+      AccountGroup(name: "After cancel", bucket: .investments, instrument: .defaultTestInstrument))
+    let didEmit = await store.didEmitWithin(timeout: .milliseconds(200))
+    #expect(didEmit == false)
+  }
+
+  @Test("GRDB wipes during sign-out reach the store before stopObserving cancels it")
+  func signOutTeardownOrdering() async throws {
+    let (backend, database) = try TestBackend.create()
+    _ = try await backend.accountGroups.create(
+      AccountGroup(name: "WillBeWiped", bucket: .investments, instrument: .defaultTestInstrument))
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForNextEmission(
+      matching: { $0.groups.count == 1 }, description: "store sees seeded group")
+
+    // Simulate the sign-out path: GRDB wipes happen first, then
+    // `stopObserving()` cancels the observation. The wipe-emission must
+    // reach the store BEFORE cancellation, otherwise the user would see the
+    // last-known-populated state frozen on screen until relaunch.
+    try await database.write { connection in
+      try connection.execute(sql: "DELETE FROM account_group")
+    }
+    try await store.waitForNextEmission(
+      matching: { $0.groups.isEmpty },
+      description: "wipe propagated to store before cancellation")
+    store.stopObserving()
+    #expect(store.groups.isEmpty)
+  }
+}


### PR DESCRIPTION
## Problem

Importing a profile JSON **through the running app** left the sidebar's account **groups** missing until an app restart — even though the imported data was written correctly (`account_group` rows present, `Account.groupId` membership intact). Accounts and earmarks refreshed live; only the group headers/nesting stayed stale until relaunch.

Discovered while importing production "Real Profile" into a dev "Test Profile". Verified the on-disk DB had both groups and all 17 memberships exactly matching the export — so the data was never lost, only the live view.

## Root cause

`AccountGroupStore` relied **solely** on `repository.observeAll()`. GRDB `ValueObservation` only fires for writes made through the *same* `DatabaseQueue` connection, and the in-app import path holds its own connection over the profile's `data.sqlite`, so the already-open session's group observation never ticks.

`AccountStore` / `EarmarkStore` / `TransactionStore` already dodge this: they additionally consume the shared instrument-registry `observeChanges()` stream and re-run `fetchAll()` on each tick. An import always pings that stream — `CloudKitDataImporter.registerInstruments` registers every non-fiat denomination before the per-profile write. `AccountGroupStore` was simply never wired to that backstop (neither was `CategoryStore`, tracked separately).

## Fix

Wire the same registry-change backstop into `AccountGroupStore`, mirroring `AccountStore` exactly:

- A second observation task drains `observeChanges()` and re-fetches on each tick.
- A `snapshotGeneration` counter drops a stale refetch that raced a fresher authoritative `observeAll()` snapshot.
- Both observation tasks are cancelled on `stopObserving()` / `deinit`.
- `ProfileSession` passes `backend.instrumentChangeObserver` into the store.

## Tests

- **Cross-connection regression** — two `DatabaseQueue`s over one WAL file, proving the backstop surfaces a group that `observeAll()` on the session's connection never saw (the exact bug shape).
- **Generation guard** — stale refetch dropped / current refetch applied.
- **Sync-refresh parity** — base observation contract: remote insert, `stopObserving` teardown, sign-out wipe ordering.

Full macOS suite green. `code-review` and `concurrency-review` agents run; their findings (access-control tightening, test parity) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)