### PR TITLE
Show value/P&L history chart for crypto, groups, standard & exchange accounts

### DIFF
--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -104,19 +104,25 @@ struct PositionsViewInput: Sendable, Hashable {
     return positions.contains(where: { $0.hasCostBasis })
   }
 
-  /// `true` iff the chart container is rendered at all. The aggregate
-  /// historical series must be non-empty. Beyond that, either:
-  /// - `shouldHide` is `true` (every remaining position is in
-  ///   `hostCurrency` or no positions remain — the historical series
-  ///   alone justifies the chart for a closed-out account), or
-  /// - at least one current position carries cost basis.
+  /// `true` iff the chart container is rendered at all. A non-empty
+  /// aggregate historical series is sufficient — the chart shows at minimum
+  /// a value line (cost/gain-loss overlay is separately gated on
+  /// `showsCostBaseline`).
   ///
   /// This is intentionally more permissive than `showsPLPill`, which
-  /// additionally requires `totalValue` to be non-nil.
+  /// additionally requires `totalValue` to be non-nil and at least one
+  /// cost-bearing position.
   var showsChart: Bool {
-    guard let series = historicalValue, !series.total.isEmpty else { return false }
-    return shouldHide || positions.contains(where: { $0.hasCostBasis })
+    guard let series = historicalValue else { return false }
+    return !series.total.isEmpty
   }
+
+  /// `true` iff at least one current position carries a cost basis. Drives
+  /// whether the chart renders the cost/contributions baseline and gain/loss
+  /// shading. When `false` (e.g. a wallet of transfer-in or airdrop tokens),
+  /// the chart shows the value line only — a zero-cost baseline would
+  /// misleadingly render the entire holding as gain.
+  var showsCostBaseline: Bool { positions.contains(where: { $0.hasCostBasis }) }
 
   /// `true` iff the all-positions chart line should render. False when any
   /// row's current value is unavailable — partial historical totals would be

--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -106,8 +106,8 @@ struct PositionsViewInput: Sendable, Hashable {
 
   /// `true` iff the chart container is rendered at all. A non-empty
   /// aggregate historical series is sufficient — the chart shows at minimum
-  /// a value line (cost/gain-loss overlay is separately gated on
-  /// `showsCostBaseline`).
+  /// a value line (the cost/gain-loss overlay is separately gated by the
+  /// data-driven `PositionsChartBaselineResolver.showsBaseline(points:mode:)`).
   ///
   /// This is intentionally more permissive than `showsPLPill`, which
   /// additionally requires `totalValue` to be non-nil and at least one
@@ -116,13 +116,6 @@ struct PositionsViewInput: Sendable, Hashable {
     guard let series = historicalValue else { return false }
     return !series.total.isEmpty
   }
-
-  /// `true` iff at least one current position carries a cost basis. Drives
-  /// whether the chart renders the cost/contributions baseline and gain/loss
-  /// shading. When `false` (e.g. a wallet of transfer-in or airdrop tokens),
-  /// the chart shows the value line only — a zero-cost baseline would
-  /// misleadingly render the entire holding as gain.
-  var showsCostBaseline: Bool { positions.contains(where: { $0.hasCostBasis }) }
 
   /// `true` iff the all-positions chart line should render. False when any
   /// row's current value is unavailable — partial historical totals would be

--- a/Features/Accounts/Views/GroupDetailView.swift
+++ b/Features/Accounts/Views/GroupDetailView.swift
@@ -62,7 +62,8 @@ struct GroupDetailView: View {
       positions: aggregatedPositions,
       hostCurrency: context.displayInstrument,
       title: context.displayName,
-      conversionService: conversionService
+      conversionService: conversionService,
+      accountIds: context.accountIds
     )
   }
 }

--- a/Features/Accounts/Views/StandardAccountView.swift
+++ b/Features/Accounts/Views/StandardAccountView.swift
@@ -45,7 +45,8 @@ struct StandardAccountView: View {
       positions: positions,
       hostCurrency: account.instrument,
       title: account.name,
-      conversionService: conversionService)
+      conversionService: conversionService,
+      accountIds: [account.id])
   }
 }
 

--- a/Features/Crypto/CryptoWalletAccountView.swift
+++ b/Features/Crypto/CryptoWalletAccountView.swift
@@ -49,7 +49,8 @@ struct CryptoWalletAccountView: View {
         conversionService: conversionService,
         // Drives a re-fire of the per-row valuator when the user marks
         // a token as `.spam` from preferences — issue #790.
-        registrationsVersion: session.cryptoTokenStore?.registrationsVersion ?? 0)
+        registrationsVersion: session.cryptoTokenStore?.registrationsVersion ?? 0,
+        accountIds: [account.id])
     }
   }
 

--- a/Features/Exchange/ExchangeAccountView.swift
+++ b/Features/Exchange/ExchangeAccountView.swift
@@ -39,7 +39,8 @@ struct ExchangeAccountView: View {
         hostCurrency: account.instrument,
         title: account.name,
         conversionService: conversionService,
-        registrationsVersion: session.cryptoTokenStore?.registrationsVersion ?? 0)
+        registrationsVersion: session.cryptoTokenStore?.registrationsVersion ?? 0,
+        accountIds: [account.id])
     }
   }
 

--- a/Features/Investments/InvestmentStore+PositionsInput.swift
+++ b/Features/Investments/InvestmentStore+PositionsInput.swift
@@ -76,12 +76,12 @@ extension InvestmentStore {
       range: range)
   }
 
-  // MARK: - Forwarding wrappers
+  // MARK: - Convenience fetch
 
-  /// Single-account forwarding wrapper for `MultiInstrumentPositionsAssembler
-  /// .fetchTransactions(repository:accountIds:)`. Retained because
-  /// `refreshPositionTrackedPerformance` in `InvestmentStore+Positions.swift`
-  /// calls this method with a single `UUID`.
+  /// Single-account convenience that delegates to
+  /// `MultiInstrumentPositionsAssembler.fetchTransactions(repository:accountIds:)`.
+  /// Used by `refreshPositionTrackedPerformance` in
+  /// `InvestmentStore+Positions.swift`, which supplies a single `UUID`.
   func fetchAllTransactions(
     repository: TransactionRepository,
     accountId: UUID

--- a/Features/Investments/InvestmentStore+PositionsInput.swift
+++ b/Features/Investments/InvestmentStore+PositionsInput.swift
@@ -1,9 +1,3 @@
-// swiftlint:disable multiline_arguments
-//
-// positionsViewInput and costBasisSnapshot construct multi-argument
-// types across multiple lines for readability; the rule fires on every
-// such call site in this file.
-
 import Foundation
 
 // `PositionsViewInput` assembly + trade-based cost-basis snapshotting
@@ -50,144 +44,51 @@ extension InvestmentStore {
         alwaysShowsFullSurface: true)
     }
 
+    let accountId = loadedAccountId ?? UUID()
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+
     let txns: [Transaction]
     do {
-      txns = try await fetchAllTransactions(
+      txns = try await assembler.fetchTransactions(
         repository: transactionRepository,
-        accountId: loadedAccountId ?? UUID())
+        accountIds: [accountId])
     } catch is CancellationError {
       throw CancellationError()
     } catch {
       logger.warning(
-        "fetchAllTransactions failed, cost basis will be empty: \(error.localizedDescription, privacy: .public)"
+        "fetchTransactions failed, cost basis will be empty: \(error.localizedDescription, privacy: .public)"
       )
       txns = []
     }
+
     let hostCurrency = loadedHostCurrency ?? valuedPositions.first?.value?.instrument ?? .AUD
-    let costSnapshot = await costBasisSnapshot(
-      transactions: txns, hostCurrency: hostCurrency)
-    let rowsWithCost = applyingCostBasis(costSnapshot, hostCurrency: hostCurrency)
-
-    let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
-      transactions: txns,
-      accountId: loadedAccountId ?? UUID(),
-      hostCurrency: hostCurrency,
-      range: range
-    )
-
-    return PositionsViewInput(
+    let context = PositionsAssemblyContext(
       title: title,
       hostCurrency: hostCurrency,
-      positions: rowsWithCost,
-      historicalValue: series,
+      accountIds: [accountId],
       assetKeysByInstrumentId: assetKeysByInstrumentId,
       performance: accountPerformance,
-      hasAnyHistoricalActivity: Self.hasAnyTradeLeg(
-        in: txns, accountId: loadedAccountId, hostCurrency: hostCurrency),
       alwaysShowsFullSurface: true)
+    return await assembler.assemble(
+      context: context,
+      valuedRows: valuedPositions,
+      transactions: txns,
+      range: range)
   }
 
-  /// Overlays a per-instrument cost-basis snapshot onto the already-loaded
-  /// `valuedPositions`, leaving quantity / unit price / value untouched.
-  /// An instrument absent from `costSnapshot` keeps a `nil` cost basis
-  /// (cost unavailable, not zero — see `costBasisSnapshot`).
-  func applyingCostBasis(
-    _ costSnapshot: [String: Decimal], hostCurrency: Instrument
-  ) -> [ValuedPosition] {
-    valuedPositions.map { row in
-      ValuedPosition(
-        instrument: row.instrument,
-        quantity: row.quantity,
-        unitPrice: row.unitPrice,
-        costBasis: costSnapshot[row.instrument.id].map {
-          InstrumentAmount(quantity: $0, instrument: hostCurrency)
-        },
-        value: row.value
-      )
-    }
-  }
+  // MARK: - Forwarding wrappers
 
-  /// Range-independent "did this account ever hold a non-host-currency
-  /// position" check used to keep the chart populated on accounts whose
-  /// last trade pre-dates the active range.
-  static func hasAnyTradeLeg(
-    in transactions: [Transaction], accountId: UUID?, hostCurrency: Instrument
-  ) -> Bool {
-    transactions.contains { txn in
-      txn.legs.contains { leg in
-        leg.accountId == accountId
-          && leg.type == .trade
-          && leg.instrument != hostCurrency
-      }
-    }
-  }
-
+  /// Single-account forwarding wrapper for `MultiInstrumentPositionsAssembler
+  /// .fetchTransactions(repository:accountIds:)`. Retained because
+  /// `refreshPositionTrackedPerformance` in `InvestmentStore+Positions.swift`
+  /// calls this method with a single `UUID`.
   func fetchAllTransactions(
     repository: TransactionRepository,
     accountId: UUID
   ) async throws -> [Transaction] {
-    var all: [Transaction] = []
-    var page = 0
-    while true {
-      let result = try await repository.fetch(
-        filter: TransactionFilter(accountId: accountId),
-        page: page, pageSize: 200
-      )
-      try Task.checkCancellation()
-      all.append(contentsOf: result.transactions)
-      if result.transactions.count < 200 { break }
-      page += 1
-    }
-    return all
-  }
-
-  func costBasisSnapshot(
-    transactions: [Transaction], hostCurrency: Instrument
-  ) async -> [String: Decimal] {
-    var engine = CostBasisEngine()
-    // Track instruments whose cost basis has been corrupted by a failing
-    // classification (e.g., a historical exchange rate gap on a swap). Per
-    // Rule 11 we must NOT return a silently-wrong number for these — omit
-    // them from the result so the caller treats the cost basis as
-    // unavailable rather than wrong.
-    var instrumentsWithFailedClassification: Set<String> = []
-    let sorted = transactions.sorted { $0.date < $1.date }
-    for txn in sorted {
-      guard !Task.isCancelled else { break }
-      do {
-        let classification = try await TradeEventClassifier.classify(
-          legs: txn.legs, on: txn.date,
-          hostCurrency: hostCurrency, conversionService: conversionService
-        )
-        for buy in classification.buys {
-          engine.processBuy(
-            instrument: buy.instrument, quantity: buy.quantity,
-            costPerUnit: buy.costPerUnit, date: txn.date)
-        }
-        for sell in classification.sells {
-          _ = engine.processSell(
-            instrument: sell.instrument, quantity: sell.quantity,
-            proceedsPerUnit: sell.proceedsPerUnit, date: txn.date)
-        }
-      } catch {
-        logger.warning(
-          "Failed to classify txn \(txn.id, privacy: .public) for cost basis: \(error.localizedDescription, privacy: .public)"
-        )
-        // Mark every non-fiat instrument in this txn's legs as having
-        // uncertain cost basis going forward.
-        for leg in txn.legs where leg.instrument.kind != .fiatCurrency {
-          instrumentsWithFailedClassification.insert(leg.instrument.id)
-        }
-      }
-    }
-    var result: [String: Decimal] = [:]
-    for lot in engine.allOpenLots() {
-      result[lot.instrument.id, default: 0] += lot.remainingCost
-    }
-    // Drop any instrument whose cost basis is no longer reliable.
-    for id in instrumentsWithFailedClassification {
-      result.removeValue(forKey: id)
-    }
-    return result
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    return try await assembler.fetchTransactions(
+      repository: repository,
+      accountIds: [accountId])
   }
 }

--- a/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
+++ b/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
@@ -126,7 +126,8 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
         conversionService: conversionService,
         rows: rows,
         assetKeys: assetKeys,
-        repository: repository)
+        repository: repository
+      )
       return
     }
     positionsInput = PositionsViewInput(
@@ -139,16 +140,17 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
   }
 
   private func buildHistoryInput(
-    conversionService: any InstrumentConversionService,
+    conversionService service: any InstrumentConversionService,
     rows: [ValuedPosition],
     assetKeys: [String: String],
     repository: any TransactionRepository
   ) async {
-    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    let accountIdSet = Set(accountIds)
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: service)
     let txns: [Transaction]
     do {
       txns = try await assembler.fetchTransactions(
-        repository: repository, accountIds: Set(accountIds))
+        repository: repository, accountIds: accountIdSet)
     } catch is CancellationError {
       return
     } catch {
@@ -160,7 +162,7 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
     let context = PositionsAssemblyContext(
       title: title,
       hostCurrency: hostCurrency,
-      accountIds: Set(accountIds),
+      accountIds: accountIdSet,
       assetKeysByInstrumentId: assetKeys,
       performance: nil,
       alwaysShowsFullSurface: false)

--- a/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
+++ b/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
@@ -26,6 +26,7 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
   let title: String
   let conversionService: (any InstrumentConversionService)?
   let registrationsVersion: Int
+  let accountIds: [UUID]
 
   @Environment(ProfileSession.self) private var session: ProfileSession?
 
@@ -81,8 +82,10 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
       } transactions: {
         content
       }
-      .task(id: PositionsTaskKey(positions: positions, registrationsVersion: registrationsVersion))
-      {
+      .task(
+        id: PositionsTaskKey(
+          positions: positions, registrationsVersion: registrationsVersion, range: positionsRange)
+      ) {
         await valuatePositions()
       }
     } else {
@@ -118,6 +121,14 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
       )
     }
     guard !Task.isCancelled else { return }
+    if !accountIds.isEmpty, let repository = session?.backend.transactions {
+      await buildHistoryInput(
+        conversionService: conversionService,
+        rows: rows,
+        assetKeys: assetKeys,
+        repository: repository)
+      return
+    }
     positionsInput = PositionsViewInput(
       title: title,
       hostCurrency: hostCurrency,
@@ -126,14 +137,49 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
       assetKeysByInstrumentId: assetKeys
     )
   }
+
+  private func buildHistoryInput(
+    conversionService: any InstrumentConversionService,
+    rows: [ValuedPosition],
+    assetKeys: [String: String],
+    repository: any TransactionRepository
+  ) async {
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    let txns: [Transaction]
+    do {
+      txns = try await assembler.fetchTransactions(
+        repository: repository, accountIds: Set(accountIds))
+    } catch is CancellationError {
+      return
+    } catch {
+      Self.logger.warning(
+        "history txn fetch failed: \(error.localizedDescription, privacy: .public)")
+      txns = []
+    }
+    guard !Task.isCancelled else { return }
+    let context = PositionsAssemblyContext(
+      title: title,
+      hostCurrency: hostCurrency,
+      accountIds: Set(accountIds),
+      assetKeysByInstrumentId: assetKeys,
+      performance: nil,
+      alwaysShowsFullSurface: false)
+    positionsInput = await assembler.assemble(
+      context: context,
+      valuedRows: rows,
+      transactions: txns,
+      range: positionsRange)
+  }
 }
 
 /// Composite id for the positions-valuation `.task(id:)`. Re-fires when
-/// the positions list changes OR when the crypto-registry version bumps
-/// (spam flip in preferences). Issue #790.
+/// the positions list changes, the crypto-registry version bumps
+/// (spam flip in preferences), or the selected time range changes.
+/// Issue #790.
 private struct PositionsTaskKey: Hashable {
   let positions: [Position]
   let registrationsVersion: Int
+  let range: PositionsTimeRange
 }
 
 extension View {
@@ -145,7 +191,8 @@ extension View {
     hostCurrency: Instrument,
     title: String,
     conversionService: (any InstrumentConversionService)?,
-    registrationsVersion: Int = 0
+    registrationsVersion: Int = 0,
+    accountIds: [UUID] = []
   ) -> some View {
     modifier(
       MultiInstrumentPositionsSplitModifier(
@@ -153,7 +200,8 @@ extension View {
         hostCurrency: hostCurrency,
         title: title,
         conversionService: conversionService,
-        registrationsVersion: registrationsVersion))
+        registrationsVersion: registrationsVersion,
+        accountIds: accountIds))
   }
 }
 

--- a/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
+++ b/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
@@ -164,11 +164,13 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
       assetKeysByInstrumentId: assetKeys,
       performance: nil,
       alwaysShowsFullSurface: false)
-    positionsInput = await assembler.assemble(
+    let input = await assembler.assemble(
       context: context,
       valuedRows: rows,
       transactions: txns,
       range: positionsRange)
+    guard !Task.isCancelled else { return }
+    positionsInput = input
   }
 }
 

--- a/MoolahTests/Domain/PositionsViewInputChartTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputChartTests.swift
@@ -29,10 +29,15 @@ struct PositionsViewInputChartTests {
     #expect(!input.showsChart)
   }
 
-  @Test("showsChart is false when non-host positions have no cost basis and shouldHide is false")
-  func chartHiddenWithoutAnyCostBasis() {
+  // Previously "chartHiddenWithoutAnyCostBasis" — the product decision in Task 7
+  // relaxed this: a non-empty series is now sufficient to show the chart even
+  // when no position carries a cost basis (e.g. transfer-in / airdrop wallets).
+  // The chart renders value-only; `showsCostBaseline` separately gates the
+  // cost/gain-loss overlay, and `showsPLPill` remains gated on cost basis.
+  @Test("showsChart is true for held non-host positions with a series but no cost basis")
+  func chartVisibleWithoutAnyCostBasis() {
     let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
+      date: fixedTestDate, value: 60, cost: 0, contributions: nil)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud,
       positions: [
@@ -43,7 +48,12 @@ struct PositionsViewInputChartTests {
       historicalValue: HistoricalValueSeries(
         hostCurrency: aud, total: [point], perInstrument: [:])
     )
-    #expect(!input.showsChart)
+    #expect(input.showsChart, "non-empty series justifies chart even without cost basis")
+    #expect(!input.showsPLPill, "P&L pill still requires at least one cost-bearing position")
+    #expect(
+      !input.showsCostBaseline,
+      "cost baseline suppressed — a zero-cost baseline would misleadingly render the whole holding as gain"
+    )
   }
 
   @Test("showsAggregateChart is false when any row's value is nil")
@@ -163,5 +173,51 @@ struct PositionsViewInputChartTests {
       historicalValue: HistoricalValueSeries(
         hostCurrency: aud, total: [], perInstrument: [:]))
     #expect(!input.showsChart)
+  }
+
+  @Test("showsCostBaseline is true when at least one position carries a cost basis")
+  func costBaselineVisibleWhenCostBasisPresent() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(input.showsCostBaseline)
+  }
+
+  @Test("showsCostBaseline is false when no position carries a cost basis")
+  func costBaselineHiddenWhenNoCostBasis() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 100, cost: 0, contributions: nil)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: nil, value: amount(100))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(!input.showsCostBaseline)
+  }
+
+  @Test("showsCostBaseline is false when positions is empty")
+  func costBaselineHiddenWhenPositionsEmpty() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 100, cost: 0, contributions: nil)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(!input.showsCostBaseline)
   }
 }

--- a/MoolahTests/Domain/PositionsViewInputChartTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputChartTests.swift
@@ -32,8 +32,10 @@ struct PositionsViewInputChartTests {
   // Previously "chartHiddenWithoutAnyCostBasis" — the product decision in Task 7
   // relaxed this: a non-empty series is now sufficient to show the chart even
   // when no position carries a cost basis (e.g. transfer-in / airdrop wallets).
-  // The chart renders value-only; `showsCostBaseline` separately gates the
-  // cost/gain-loss overlay, and `showsPLPill` remains gated on cost basis.
+  // The chart renders value-only; the baseline is now data-driven via
+  // `PositionsChartBaselineResolver.showsBaseline(points:mode:)` — `showsCostBaseline`
+  // has been removed from `PositionsViewInput`. `showsPLPill` remains gated on
+  // cost basis.
   @Test("showsChart is true for held non-host positions with a series but no cost basis")
   func chartVisibleWithoutAnyCostBasis() {
     let point = HistoricalValueSeries.Point(
@@ -50,10 +52,6 @@ struct PositionsViewInputChartTests {
     )
     #expect(input.showsChart, "non-empty series justifies chart even without cost basis")
     #expect(!input.showsPLPill, "P&L pill still requires at least one cost-bearing position")
-    #expect(
-      !input.showsCostBaseline,
-      "cost baseline suppressed — a zero-cost baseline would misleadingly render the whole holding as gain"
-    )
   }
 
   @Test("showsAggregateChart is false when any row's value is nil")
@@ -175,49 +173,4 @@ struct PositionsViewInputChartTests {
     #expect(!input.showsChart)
   }
 
-  @Test("showsCostBaseline is true when at least one position carries a cost basis")
-  func costBaselineVisibleWhenCostBasisPresent() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: amount(50), value: amount(60))
-      ],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:])
-    )
-    #expect(input.showsCostBaseline)
-  }
-
-  @Test("showsCostBaseline is false when no position carries a cost basis")
-  func costBaselineHiddenWhenNoCostBasis() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 100, cost: 0, contributions: nil)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: nil, value: amount(100))
-      ],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:])
-    )
-    #expect(!input.showsCostBaseline)
-  }
-
-  @Test("showsCostBaseline is false when positions is empty")
-  func costBaselineHiddenWhenPositionsEmpty() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 100, cost: 0, contributions: nil)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud, positions: [],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:])
-    )
-    #expect(!input.showsCostBaseline)
-  }
 }

--- a/MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
+++ b/MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
@@ -10,16 +10,18 @@ struct MultiInstrumentPositionsAssemblerTests {
     chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
   let eth = Instrument.crypto(
     chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  let ltc = Instrument.crypto(
+    chainId: 2, contractAddress: nil, symbol: "LTC", name: "Litecoin", decimals: 8)
   let accountA = UUID()
   let accountB = UUID()
 
-  /// Day 0 = 2026-01-01.
+  /// Day 0 = 2026-01-01. Uses `Calendar.utc` so the result is zone-invariant.
   private func date(daysAfterEpoch days: Int) -> Date {
     var components = DateComponents()
     components.year = 2026
     components.month = 1
     components.day = 1 + days
-    guard let result = Calendar(identifier: .gregorian).date(from: components) else {
+    guard let result = Calendar.utc.date(from: components) else {
       fatalError("Could not construct date \(days) days after 2026-01-01")
     }
     return result
@@ -75,6 +77,9 @@ struct MultiInstrumentPositionsAssemblerTests {
     #expect(input.historicalValue != nil)
     #expect(input.showsChart == true)
     #expect(input.showsPLPill == true)
+    // The seeded buy was 1 BTC for 50_000 AUD, so the applied cost basis
+    // quantity must equal exactly 50_000.
+    #expect(input.positions.first?.costBasis?.quantity == 50_000)
   }
 
   // hasAnyTradeLeg is true when any account in the set has a non-host trade leg,
@@ -124,33 +129,43 @@ struct MultiInstrumentPositionsAssemblerTests {
     )
   }
 
-  // costBasisSnapshot omits an instrument whose classification fails
-  // (unavailable, not zero — Rule 11).
+  // costBasisSnapshot omits an instrument whose classification fails while
+  // keeping cleanly-classifiable instruments (Rule 11 — unavailable, not zero).
   //
-  // Setup: BTC buys fiat-paired (classifiable). ETH buys fiat-paired but
-  // with a BTC-denominated fee whose conversion fails — the classifier throws,
-  // so ETH is added to the failed-classification set and dropped from the
-  // snapshot.
+  // Setup: LTC buy is fiat-paired (classifiable, no failing legs). ETH buy has
+  // a BTC-denominated fee whose conversion fails — the classifier throws, so
+  // ETH is added to the failed-classification set and dropped from the snapshot.
+  // The test asserts BOTH properties: bad instrument absent AND good instrument
+  // present with the correct exact host-currency cost.
   @Test
   func costBasisOmitsUnclassifiableInstrument() async {
-    // BTC→AUD conversion fails; AUD→AUD identity is always free.
+    // BTC→AUD conversion fails; LTC→AUD and AUD→AUD always succeed.
     let service = FailingConversionService(
-      rates: [:],
+      rates: [ltc.id: Decimal(100)],
       failingInstrumentIds: [btc.id])
     let assembler = MultiInstrumentPositionsAssembler(conversionService: service)
 
     let txns = [
+      // LTC fiat buy — cleanly classifiable (no BTC legs).
+      // 5 LTC × 100 AUD/LTC = 500 AUD cost basis.
+      Transaction(
+        date: date(daysAfterEpoch: 1),
+        legs: [
+          TransactionLeg(accountId: accountA, instrument: ltc, quantity: 5, type: .trade),
+          TransactionLeg(accountId: accountA, instrument: aud, quantity: -500, type: .trade),
+        ]
+      ),
       // ETH fiat buy with a BTC fee. The fee conversion (BTC→AUD) fails,
       // so `classify` throws and ETH is marked as unclassifiable.
       Transaction(
-        date: date(daysAfterEpoch: 1),
+        date: date(daysAfterEpoch: 2),
         legs: [
           TransactionLeg(accountId: accountA, instrument: eth, quantity: 10, type: .trade),
           TransactionLeg(accountId: accountA, instrument: aud, quantity: -20_000, type: .trade),
           // BTC-denominated exchange fee — convert(BTC→AUD) will throw.
           TransactionLeg(accountId: accountA, instrument: btc, quantity: -1, type: .expense),
         ]
-      )
+      ),
     ]
 
     let snapshot = await assembler.costBasisSnapshot(
@@ -159,5 +174,8 @@ struct MultiInstrumentPositionsAssemblerTests {
     // ETH classification failed (because the BTC fee conversion throws) →
     // omitted per Rule 11.
     #expect(snapshot[eth.id] == nil, "ETH should be omitted when its classification fails")
+    // LTC classification succeeded → present with the exact cost.
+    #expect(snapshot[ltc.id] != nil, "LTC should be present: its classification succeeded")
+    #expect(snapshot[ltc.id] == 500, "LTC cost basis should equal 500 AUD (5 × 100)")
   }
 }

--- a/MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
+++ b/MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
@@ -138,7 +138,7 @@ struct MultiInstrumentPositionsAssemblerTests {
   // The test asserts BOTH properties: bad instrument absent AND good instrument
   // present with the correct exact host-currency cost.
   @Test
-  func costBasisOmitsUnclassifiableInstrument() async {
+  func costBasisOmitsUnclassifiableInstrument() async throws {
     // BTC→AUD conversion fails; LTC→AUD and AUD→AUD always succeed.
     let service = FailingConversionService(
       rates: [ltc.id: Decimal(100)],
@@ -168,7 +168,7 @@ struct MultiInstrumentPositionsAssemblerTests {
       ),
     ]
 
-    let snapshot = await assembler.costBasisSnapshot(
+    let snapshot = try await assembler.costBasisSnapshot(
       transactions: txns, accountIds: [accountA], hostCurrency: aud)
 
     // ETH classification failed (because the BTC fee conversion throws) →

--- a/MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
+++ b/MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("MultiInstrumentPositionsAssembler")
+struct MultiInstrumentPositionsAssemblerTests {
+  let aud = Instrument.AUD
+  let btc = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+  let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  let accountA = UUID()
+  let accountB = UUID()
+
+  /// Day 0 = 2026-01-01.
+  private func date(daysAfterEpoch days: Int) -> Date {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 1
+    components.day = 1 + days
+    guard let result = Calendar(identifier: .gregorian).date(from: components) else {
+      fatalError("Could not construct date \(days) days after 2026-01-01")
+    }
+    return result
+  }
+
+  private func buyTransaction(
+    instrument: Instrument,
+    qty: Decimal,
+    fiat: Decimal,
+    accountId: UUID,
+    daysAfterEpoch days: Int
+  ) -> Transaction {
+    Transaction(
+      date: date(daysAfterEpoch: days),
+      legs: [
+        TransactionLeg(accountId: accountId, instrument: instrument, quantity: qty, type: .trade),
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -fiat, type: .trade),
+      ]
+    )
+  }
+
+  // A crypto account holding a non-host token with a buy history produces an
+  // input whose showsChart == true (non-empty series + a cost-bearing row).
+  @Test
+  func cryptoAccountInputShowsChart() async throws {
+    let txns = [
+      buyTransaction(
+        instrument: btc, qty: 1, fiat: 50_000, accountId: accountA, daysAfterEpoch: 1)
+    ]
+    let service = FixedConversionService(rates: [btc.id: Decimal(60_000)])
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: service)
+
+    let valuedRows = [
+      ValuedPosition(
+        instrument: btc, quantity: 1,
+        unitPrice: InstrumentAmount(quantity: 60_000, instrument: aud),
+        costBasis: nil,
+        value: InstrumentAmount(quantity: 60_000, instrument: aud))
+    ]
+
+    let context = PositionsAssemblyContext(
+      title: "BTC Account",
+      hostCurrency: aud,
+      accountIds: [accountA])
+    let input = await assembler.assemble(
+      context: context,
+      valuedRows: valuedRows,
+      transactions: txns,
+      range: .all
+    )
+
+    #expect(input.historicalValue != nil)
+    #expect(input.showsChart == true)
+    #expect(input.showsPLPill == true)
+  }
+
+  // hasAnyTradeLeg is true when any account in the set has a non-host trade leg,
+  // and false when there are none.
+  @Test
+  func hasAnyTradeLegAcrossAccounts() {
+    let btcBuyA = Transaction(
+      date: date(daysAfterEpoch: 1),
+      legs: [
+        TransactionLeg(accountId: accountA, instrument: btc, quantity: 1, type: .trade),
+        TransactionLeg(accountId: accountA, instrument: aud, quantity: -50_000, type: .trade),
+      ]
+    )
+    let fiatOnlyB = Transaction(
+      date: date(daysAfterEpoch: 2),
+      legs: [
+        TransactionLeg(accountId: accountB, instrument: aud, quantity: -100, type: .expense)
+      ]
+    )
+
+    // A set containing only accountB (fiat-only) — false.
+    #expect(
+      MultiInstrumentPositionsAssembler.hasAnyTradeLeg(
+        in: [btcBuyA, fiatOnlyB], accountIds: [accountB], hostCurrency: aud) == false,
+      "accountB only has a fiat leg, so hasAnyTradeLeg should be false"
+    )
+
+    // A set containing accountA (which has a non-host trade leg) — true.
+    #expect(
+      MultiInstrumentPositionsAssembler.hasAnyTradeLeg(
+        in: [btcBuyA, fiatOnlyB], accountIds: [accountA], hostCurrency: aud) == true,
+      "accountA has a BTC trade leg, so hasAnyTradeLeg should be true"
+    )
+
+    // Both accounts in the set — still true (accountA has the trade leg).
+    #expect(
+      MultiInstrumentPositionsAssembler.hasAnyTradeLeg(
+        in: [btcBuyA, fiatOnlyB], accountIds: [accountA, accountB], hostCurrency: aud) == true,
+      "the set includes accountA which has a BTC trade leg"
+    )
+
+    // Empty transaction list — false.
+    #expect(
+      MultiInstrumentPositionsAssembler.hasAnyTradeLeg(
+        in: [], accountIds: [accountA, accountB], hostCurrency: aud) == false,
+      "no transactions means no trade legs"
+    )
+  }
+
+  // costBasisSnapshot omits an instrument whose classification fails
+  // (unavailable, not zero — Rule 11).
+  //
+  // Setup: BTC buys fiat-paired (classifiable). ETH buys fiat-paired but
+  // with a BTC-denominated fee whose conversion fails — the classifier throws,
+  // so ETH is added to the failed-classification set and dropped from the
+  // snapshot.
+  @Test
+  func costBasisOmitsUnclassifiableInstrument() async {
+    // BTC→AUD conversion fails; AUD→AUD identity is always free.
+    let service = FailingConversionService(
+      rates: [:],
+      failingInstrumentIds: [btc.id])
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: service)
+
+    let txns = [
+      // ETH fiat buy with a BTC fee. The fee conversion (BTC→AUD) fails,
+      // so `classify` throws and ETH is marked as unclassifiable.
+      Transaction(
+        date: date(daysAfterEpoch: 1),
+        legs: [
+          TransactionLeg(accountId: accountA, instrument: eth, quantity: 10, type: .trade),
+          TransactionLeg(accountId: accountA, instrument: aud, quantity: -20_000, type: .trade),
+          // BTC-denominated exchange fee — convert(BTC→AUD) will throw.
+          TransactionLeg(accountId: accountA, instrument: btc, quantity: -1, type: .expense),
+        ]
+      )
+    ]
+
+    let snapshot = await assembler.costBasisSnapshot(
+      transactions: txns, accountIds: [accountA], hostCurrency: aud)
+
+    // ETH classification failed (because the BTC fee conversion throws) →
+    // omitted per Rule 11.
+    #expect(snapshot[eth.id] == nil, "ETH should be omitted when its classification fails")
+  }
+}

--- a/MoolahTests/Shared/PositionsAssemblerE2ETests.swift
+++ b/MoolahTests/Shared/PositionsAssemblerE2ETests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// End-to-end tests for `MultiInstrumentPositionsAssembler` that flow through
+/// a real `TestBackend` (CloudKitBackend + in-memory GRDB). These tests pin the
+/// full pipeline: `fetchTransactions` from the repository → `ValuedPosition`
+/// construction → `assemble` → `PositionsViewInput` assertions.
+///
+/// All dates use noon-UTC construction so the results are zone-invariant
+/// regardless of the CI runner's local timezone.
+@Suite("MultiInstrumentPositionsAssembler end-to-end")
+struct PositionsAssemblerE2ETests {
+  /// Host (reporting) currency.
+  let aud = Instrument.AUD
+  /// Crypto token — chainId 1, id "1:native".
+  let btc = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+
+  /// Returns a Date at noon UTC, N days before today.
+  ///
+  /// Noon UTC matches the canonical day-token used throughout the codebase
+  /// (`FinancialMonth.date(forKey:)` anchors at noon UTC) and ensures
+  /// `Calendar.startOfDay` groups the transaction under the expected day
+  /// regardless of the host machine's local timezone.
+  private func noonUTCDaysAgo(_ n: Int) -> Date {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC") ?? .current
+    let today = cal.startOfDay(for: Date())
+    guard let offset = cal.date(byAdding: .day, value: -n, to: today) else {
+      fatalError("Could not offset date by \(-n) days")
+    }
+    return offset.addingTimeInterval(12 * 3600)
+  }
+
+  /// A fiat-paired buy transaction for one account.
+  private func buy(
+    instrument: Instrument,
+    qty: Decimal,
+    fiat: Decimal,
+    accountId: UUID,
+    daysAgo: Int
+  ) -> Transaction {
+    Transaction(
+      date: noonUTCDaysAgo(daysAgo),
+      legs: [
+        TransactionLeg(accountId: accountId, instrument: instrument, quantity: qty, type: .trade),
+        TransactionLeg(accountId: accountId, instrument: aud, quantity: -fiat, type: .trade),
+      ]
+    )
+  }
+
+  /// Create an investment account and seed it into the backend.
+  private func createAccount(
+    name: String,
+    in backend: CloudKitBackend
+  ) async throws -> UUID {
+    let id = UUID()
+    let account = Account(id: id, name: name, type: .investment, instrument: aud)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+    return id
+  }
+
+  /// Build `[ValuedPosition]` for a single crypto holding at a fixed unit rate.
+  private func singlePosition(
+    instrument: Instrument,
+    qty: Decimal,
+    rate: Decimal
+  ) -> [ValuedPosition] {
+    [
+      ValuedPosition(
+        instrument: instrument,
+        quantity: qty,
+        unitPrice: InstrumentAmount(quantity: rate, instrument: aud),
+        costBasis: nil,
+        value: InstrumentAmount(quantity: qty * rate, instrument: aud)
+      )
+    ]
+  }
+
+  // MARK: - Test 1: single account via backend round-trip
+
+  /// A single crypto account holding BTC. Transactions are created via
+  /// `backend.transactions.create`, then fetched through
+  /// `assembler.fetchTransactions` — exercising the full repository round-trip.
+  /// Asserts: the last point's value equals qty × rate (exact), showsChart == true.
+  @Test("single crypto account: fetchTransactions + assemble yields non-empty chart")
+  func singleCryptoAccountEndToEnd() async throws {
+    let (backend, _) = try TestBackend.create(instrument: aud)
+    try await TestBackend.register(btc, in: backend)
+    let accountId = try await createAccount(name: "BTC Wallet", in: backend)
+
+    let qty: Decimal = 2
+    let rate: Decimal = 50_000
+    _ = try await backend.transactions.create(
+      buy(instrument: btc, qty: qty, fiat: 80_000, accountId: accountId, daysAgo: 5))
+
+    let conversionService = FixedConversionService(rates: [btc.id: rate])
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    let transactions = try await assembler.fetchTransactions(
+      repository: backend.transactions, accountIds: [accountId])
+    #expect(transactions.count == 1)
+
+    let context = PositionsAssemblyContext(
+      title: "BTC Wallet", hostCurrency: aud, accountIds: [accountId])
+    let input = await assembler.assemble(
+      context: context,
+      valuedRows: singlePosition(instrument: btc, qty: qty, rate: rate),
+      transactions: transactions,
+      range: .threeMonths
+    )
+
+    let series = try #require(input.historicalValue, "historicalValue must be non-nil")
+    #expect(!series.total.isEmpty, "total series must not be empty")
+    let lastPoint = try #require(series.total.last)
+    // FixedConversionService returns the same rate on every date.
+    #expect(lastPoint.value == qty * rate)
+    #expect(input.showsChart)
+  }
+
+  // MARK: - Test 2: group of two accounts holding the same token
+
+  /// Two accounts each hold BTC. The group's last-day aggregate value
+  /// must equal the summed holdings converted at the fixed rate.
+  @Test("group of two accounts: aggregate last-day value equals summed holdings")
+  func groupTwoAccountsAggregatesValue() async throws {
+    let (backend, _) = try TestBackend.create(instrument: aud)
+    try await TestBackend.register(btc, in: backend)
+    let accountAId = try await createAccount(name: "Wallet A", in: backend)
+    let accountBId = try await createAccount(name: "Wallet B", in: backend)
+
+    let qtyA: Decimal = 1
+    let qtyB: Decimal = 3
+    let rate: Decimal = 60_000
+    _ = try await backend.transactions.create(
+      buy(instrument: btc, qty: qtyA, fiat: 40_000, accountId: accountAId, daysAgo: 5))
+    _ = try await backend.transactions.create(
+      buy(instrument: btc, qty: qtyB, fiat: 120_000, accountId: accountBId, daysAgo: 5))
+
+    let conversionService = FixedConversionService(rates: [btc.id: rate])
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    let accountIds: Set<UUID> = [accountAId, accountBId]
+    let transactions = try await assembler.fetchTransactions(
+      repository: backend.transactions, accountIds: accountIds)
+    #expect(transactions.count == 2)
+
+    let totalQty = qtyA + qtyB
+    let context = PositionsAssemblyContext(
+      title: "BTC Group", hostCurrency: aud, accountIds: accountIds)
+    let input = await assembler.assemble(
+      context: context,
+      valuedRows: singlePosition(instrument: btc, qty: totalQty, rate: rate),
+      transactions: transactions,
+      range: .threeMonths
+    )
+
+    let series = try #require(input.historicalValue, "historicalValue must be non-nil")
+    #expect(!series.total.isEmpty)
+    let lastPoint = try #require(series.total.last)
+    #expect(lastPoint.value == (qtyA + qtyB) * rate)
+    #expect(input.showsChart)
+  }
+
+  // MARK: - Test 3: internal transfer between group members does not change aggregate
+
+  /// Account A buys 2 BTC, then transfers 1 BTC to Account B (both in group).
+  /// The group's last-day aggregate value stays equal to 2 BTC × rate — the
+  /// internal transfer nets out on every point in the series.
+  @Test("internal transfer between group members: group value unchanged after transfer")
+  func internalTransferNetsOut() async throws {
+    let (backend, _) = try TestBackend.create(instrument: aud)
+    try await TestBackend.register(btc, in: backend)
+    let accountAId = try await createAccount(name: "Sender", in: backend)
+    let accountBId = try await createAccount(name: "Receiver", in: backend)
+
+    let totalQty: Decimal = 2
+    let transferQty: Decimal = 1
+    let rate: Decimal = 55_000
+    _ = try await backend.transactions.create(
+      buy(instrument: btc, qty: totalQty, fiat: 90_000, accountId: accountAId, daysAgo: 7))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: noonUTCDaysAgo(3),
+        legs: [
+          TransactionLeg(
+            accountId: accountAId, instrument: btc, quantity: -transferQty, type: .expense),
+          TransactionLeg(
+            accountId: accountBId, instrument: btc, quantity: transferQty, type: .income),
+        ]
+      )
+    )
+
+    let conversionService = FixedConversionService(rates: [btc.id: rate])
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    let accountIds: Set<UUID> = [accountAId, accountBId]
+    let transactions = try await assembler.fetchTransactions(
+      repository: backend.transactions, accountIds: accountIds)
+    #expect(transactions.count == 2)
+
+    let context = PositionsAssemblyContext(
+      title: "BTC Transfer Group", hostCurrency: aud, accountIds: accountIds)
+    let input = await assembler.assemble(
+      context: context,
+      valuedRows: singlePosition(instrument: btc, qty: totalQty, rate: rate),
+      transactions: transactions,
+      range: .threeMonths
+    )
+
+    let series = try #require(input.historicalValue, "historicalValue must be non-nil")
+    #expect(!series.total.isEmpty)
+    let lastPoint = try #require(series.total.last)
+    // Internal transfer nets out — group holds 2 BTC externally on every day.
+    #expect(lastPoint.value == totalQty * rate)
+    // FixedConversionService is date-independent: every emitted point equals
+    // totalQty × rate (the transfer causes no dip or phantom buy/sell).
+    for point in series.total {
+      #expect(point.value == totalQty * rate)
+    }
+    #expect(input.showsChart)
+  }
+}

--- a/MoolahTests/Shared/PositionsAssemblerE2ETests.swift
+++ b/MoolahTests/Shared/PositionsAssemblerE2ETests.swift
@@ -18,17 +18,32 @@ struct PositionsAssemblerE2ETests {
   let btc = Instrument.crypto(
     chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
 
-  /// Returns a Date at noon UTC, N days before today.
+  /// A fixed "now" anchored at noon UTC on 2026-06-01. All date helpers and
+  /// `assemble(…, now:)` calls use this value so the tests are deterministic
+  /// regardless of the CI runner's local timezone or wall-clock date.
+  private let fixedNow: Date = {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 6
+    components.day = 1
+    components.hour = 12
+    components.minute = 0
+    components.second = 0
+    guard let date = Calendar.utc.date(from: components) else {
+      fatalError("Could not construct fixedNow")
+    }
+    return date
+  }()
+
+  /// Returns a Date at noon UTC, N days before `fixedNow`.
   ///
   /// Noon UTC matches the canonical day-token used throughout the codebase
   /// (`FinancialMonth.date(forKey:)` anchors at noon UTC) and ensures
   /// `Calendar.startOfDay` groups the transaction under the expected day
   /// regardless of the host machine's local timezone.
   private func noonUTCDaysAgo(_ n: Int) -> Date {
-    var cal = Calendar(identifier: .gregorian)
-    cal.timeZone = TimeZone(identifier: "UTC") ?? .current
-    let today = cal.startOfDay(for: Date())
-    guard let offset = cal.date(byAdding: .day, value: -n, to: today) else {
+    let startOfFixedNow = Calendar.utc.startOfDay(for: fixedNow)
+    guard let offset = Calendar.utc.date(byAdding: .day, value: -n, to: startOfFixedNow) else {
       fatalError("Could not offset date by \(-n) days")
     }
     return offset.addingTimeInterval(12 * 3600)
@@ -109,7 +124,8 @@ struct PositionsAssemblerE2ETests {
       context: context,
       valuedRows: singlePosition(instrument: btc, qty: qty, rate: rate),
       transactions: transactions,
-      range: .threeMonths
+      range: .threeMonths,
+      now: fixedNow
     )
 
     let series = try #require(input.historicalValue, "historicalValue must be non-nil")
@@ -153,7 +169,8 @@ struct PositionsAssemblerE2ETests {
       context: context,
       valuedRows: singlePosition(instrument: btc, qty: totalQty, rate: rate),
       transactions: transactions,
-      range: .threeMonths
+      range: .threeMonths,
+      now: fixedNow
     )
 
     let series = try #require(input.historicalValue, "historicalValue must be non-nil")
@@ -205,7 +222,8 @@ struct PositionsAssemblerE2ETests {
       context: context,
       valuedRows: singlePosition(instrument: btc, qty: totalQty, rate: rate),
       transactions: transactions,
-      range: .threeMonths
+      range: .threeMonths,
+      now: fixedNow
     )
 
     let series = try #require(input.historicalValue, "historicalValue must be non-nil")

--- a/MoolahTests/Shared/PositionsChartDataTests.swift
+++ b/MoolahTests/Shared/PositionsChartDataTests.swift
@@ -29,7 +29,7 @@ struct PositionsChartDataTests {
       point(day: 1, value: 1_150, cost: 800, contributions: 1_000),
     ]
     let resolved = PositionsChartBaselineResolver.resolve(
-      points: points, mode: .aggregate
+      points: points, mode: .aggregate, showBaseline: true
     )
     #expect(resolved.map(\.baseline) == [1_000, 1_000])
     #expect(resolved.map(\.gainSegment) == [100, 150])
@@ -44,7 +44,7 @@ struct PositionsChartDataTests {
       point(day: 1, value: 900, cost: 800, contributions: nil),
     ]
     let resolved = PositionsChartBaselineResolver.resolve(
-      points: points, mode: .perInstrument
+      points: points, mode: .perInstrument, showBaseline: true
     )
     #expect(resolved.map(\.baseline) == [800, 800])
     #expect(resolved.map(\.gainSegment) == [50, 100])
@@ -54,7 +54,7 @@ struct PositionsChartDataTests {
   func lossSegments() throws {
     let points = try [point(day: 0, value: 950, cost: 1_000, contributions: nil)]
     let resolved = PositionsChartBaselineResolver.resolve(
-      points: points, mode: .perInstrument
+      points: points, mode: .perInstrument, showBaseline: true
     )
     #expect(resolved[0].gainSegment == 0)
     #expect(resolved[0].lossSegment == 50)
@@ -67,7 +67,7 @@ struct PositionsChartDataTests {
       point(day: 1, value: 1_150, cost: 800, contributions: nil),
     ]
     let resolved = PositionsChartBaselineResolver.resolve(
-      points: points, mode: .aggregate
+      points: points, mode: .aggregate, showBaseline: true
     )
     #expect(resolved[0].baseline != nil)
     #expect(resolved[1].baseline == nil)
@@ -82,8 +82,41 @@ struct PositionsChartDataTests {
       point(day: 1, value: 1_150, cost: 800, contributions: nil),
     ]
     let resolved = PositionsChartBaselineResolver.resolve(
-      points: points, mode: .aggregate
+      points: points, mode: .aggregate, showBaseline: true
     )
     #expect(resolved.last?.legendUnavailable == true)
+  }
+
+  @Test("showBaseline:false suppresses baseline for all rows regardless of mode")
+  func showBaselineFalseSuppressesAllBaselines() throws {
+    let points = try [
+      point(day: 0, value: 1_100, cost: 800, contributions: 1_000),
+      point(day: 1, value: 1_200, cost: 850, contributions: 1_050),
+    ]
+    // Both aggregate and perInstrument modes should yield nil baseline when showBaseline is false.
+    for mode in [PositionsChartMode.aggregate, PositionsChartMode.perInstrument] {
+      let resolved = PositionsChartBaselineResolver.resolve(
+        points: points, mode: mode, showBaseline: false
+      )
+      #expect(resolved.map(\.baseline) == [nil, nil], "baseline should be nil for mode \(mode)")
+      #expect(resolved.map(\.gainSegment) == [0, 0], "gain should be zero for mode \(mode)")
+      #expect(resolved.map(\.lossSegment) == [0, 0], "loss should be zero for mode \(mode)")
+      #expect(
+        resolved.last?.legendUnavailable == true,
+        "last row legendUnavailable when baseline suppressed for mode \(mode)")
+    }
+  }
+
+  @Test("showBaseline:false renders value line even when cost data is present")
+  func showBaselineFalsePreservesValueLine() throws {
+    let points = try [
+      point(day: 0, value: 500, cost: 400, contributions: 450),
+      point(day: 1, value: 600, cost: 400, contributions: 450),
+    ]
+    let resolved = PositionsChartBaselineResolver.resolve(
+      points: points, mode: .aggregate, showBaseline: false
+    )
+    #expect(resolved.map(\.value) == [500, 600], "value series is preserved")
+    #expect(resolved.map(\.baseline) == [nil, nil], "baseline remains suppressed")
   }
 }

--- a/MoolahTests/Shared/PositionsChartDataTests.swift
+++ b/MoolahTests/Shared/PositionsChartDataTests.swift
@@ -119,4 +119,54 @@ struct PositionsChartDataTests {
     #expect(resolved.map(\.value) == [500, 600], "value series is preserved")
     #expect(resolved.map(\.baseline) == [nil, nil], "baseline remains suppressed")
   }
+
+  // MARK: - showsBaseline(points:mode:)
+
+  @Test("showsBaseline aggregate: true when contributions has a non-zero value")
+  func showsBaselineAggregateTrueWhenContributionsNonZero() throws {
+    let points = try [
+      point(day: 0, value: 1_100, cost: 800, contributions: nil),
+      point(day: 1, value: 1_200, cost: 900, contributions: 1_000),
+    ]
+    #expect(
+      PositionsChartBaselineResolver.showsBaseline(points: points, mode: .aggregate),
+      "aggregate mode returns true when at least one point has non-zero contributions"
+    )
+  }
+
+  @Test("showsBaseline aggregate: false when all contributions are nil or zero")
+  func showsBaselineAggregateFalseWhenContributionsAllNilOrZero() throws {
+    let points = try [
+      point(day: 0, value: 500, cost: 0, contributions: nil),
+      point(day: 1, value: 600, cost: 0, contributions: 0),
+    ]
+    #expect(
+      !PositionsChartBaselineResolver.showsBaseline(points: points, mode: .aggregate),
+      "aggregate mode returns false when all contributions are nil or zero"
+    )
+  }
+
+  @Test("showsBaseline perInstrument: true when cost has a non-zero value")
+  func showsBaselinePerInstrumentTrueWhenCostNonZero() throws {
+    let points = try [
+      point(day: 0, value: 850, cost: 800, contributions: nil),
+      point(day: 1, value: 900, cost: 800, contributions: nil),
+    ]
+    #expect(
+      PositionsChartBaselineResolver.showsBaseline(points: points, mode: .perInstrument),
+      "perInstrument mode returns true when at least one point has non-zero cost"
+    )
+  }
+
+  @Test("showsBaseline perInstrument: false when all cost values are zero")
+  func showsBaselinePerInstrumentFalseWhenCostAllZero() throws {
+    let points = try [
+      point(day: 0, value: 500, cost: 0, contributions: nil),
+      point(day: 1, value: 600, cost: 0, contributions: nil),
+    ]
+    #expect(
+      !PositionsChartBaselineResolver.showsBaseline(points: points, mode: .perInstrument),
+      "perInstrument mode returns false when all cost values are zero"
+    )
+  }
 }

--- a/MoolahTests/Shared/PositionsContributionsTests.swift
+++ b/MoolahTests/Shared/PositionsContributionsTests.swift
@@ -13,20 +13,24 @@ struct PositionsContributionsTests {
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
   let accountId = UUID()
 
-  /// Day 0 = 2026-01-01. `days` may exceed month length; calendar
-  /// arithmetic rolls over correctly. Optional `hour` lets callers
+  /// Day 0 = 2026-01-01 UTC midnight. `days` may exceed month length;
+  /// calendar arithmetic rolls over correctly. Optional `hour` lets callers
   /// produce non-midnight timestamps for Rule 5 / Rule 8 / Rule 10
   /// tests that need the conversion service to receive the original
   /// `transaction.date` (not a `startOfDay`-truncated copy).
+  ///
+  /// Uses `Calendar.utc` so that dates produced here align with the
+  /// builder's UTC-midnight day boundaries (Point.date is anchored at
+  /// noon UTC; `startOfDay(for:)` on a noon-UTC point yields the same
+  /// UTC-midnight value as this helper).
   private func date(daysAfterEpoch days: Int, hour: Int = 0) throws -> Date {
-    let calendar = Calendar(identifier: .gregorian)
     var epoch = DateComponents()
     epoch.year = 2026
     epoch.month = 1
     epoch.day = 1
     epoch.hour = hour
-    let base = try #require(calendar.date(from: epoch))
-    return try #require(calendar.date(byAdding: .day, value: days, to: base))
+    let base = try #require(Calendar.utc.date(from: epoch))
+    return try #require(Calendar.utc.date(byAdding: .day, value: days, to: base))
   }
 
   private func buy(
@@ -117,8 +121,10 @@ struct PositionsContributionsTests {
       hostCurrency: aud, range: .threeMonths,
       now: try date(daysAfterEpoch: 5)
     )
-    let day1 = try #require(series.totalSeries.first { $0.date == day1Date })
-    let day3 = try #require(series.totalSeries.first { $0.date == day3Date })
+    let day1 = try #require(
+      series.totalSeries.first { Calendar.utc.startOfDay(for: $0.date) == day1Date })
+    let day3 = try #require(
+      series.totalSeries.first { Calendar.utc.startOfDay(for: $0.date) == day3Date })
     #expect(day1.contributions == 1_000)
     #expect(day3.contributions == 1_500)
   }
@@ -138,7 +144,8 @@ struct PositionsContributionsTests {
       hostCurrency: aud, range: .threeMonths,
       now: try date(daysAfterEpoch: 5)
     )
-    let day3 = try #require(series.totalSeries.first { $0.date == day3Date })
+    let day3 = try #require(
+      series.totalSeries.first { Calendar.utc.startOfDay(for: $0.date) == day3Date })
     #expect(day3.contributions == 1_200)
   }
 
@@ -184,7 +191,8 @@ struct PositionsContributionsTests {
       hostCurrency: aud, range: .threeMonths,
       now: try date(daysAfterEpoch: 12)
     )
-    let day1 = try #require(series.totalSeries.first { $0.date == day1Date })
+    let day1 = try #require(
+      series.totalSeries.first { Calendar.utc.startOfDay(for: $0.date) == day1Date })
     #expect(day1.contributions == Decimal(1_500))
   }
 
@@ -248,13 +256,14 @@ struct PositionsContributionsTests {
       now: try date(daysAfterEpoch: 5)
     )
     let day1Date = try date(daysAfterEpoch: 1)
-    let day1 = try #require(series.totalSeries.first { $0.date == day1Date })
+    let day1 = try #require(
+      series.totalSeries.first { Calendar.utc.startOfDay(for: $0.date) == day1Date })
     #expect(day1.contributions == 1_000)
     // Sticky-latch invariant: no aggregate point on or after day 3
     // carries a populated `contributions`, regardless of whether the
     // point actually emits (USD position blocks emission via the
     // value-conversion path).
-    for point in series.totalSeries where point.date >= day3 {
+    for point in series.totalSeries where Calendar.utc.startOfDay(for: point.date) >= day3 {
       #expect(point.contributions == nil)
     }
   }

--- a/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("PositionsHistoryBuilder multi-account")
+struct PositionsHistoryBuilderMultiAccountTests {
+  let aud = Instrument.AUD
+  let btc = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+  let accountA = UUID()
+  let accountB = UUID()
+
+  /// Day 0 = 2026-01-01.
+  private func date(daysAfterEpoch days: Int) -> Date {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 1
+    components.day = 1 + days
+    guard let result = Calendar(identifier: .gregorian).date(from: components) else {
+      fatalError("Could not construct date \(days) days after 2026-01-01")
+    }
+    return result
+  }
+
+  private func buy(
+    instrument: Instrument,
+    qty: Decimal,
+    fiat: Decimal,
+    accountId: UUID,
+    daysAfterEpoch days: Int
+  ) -> Transaction {
+    Transaction(
+      date: date(daysAfterEpoch: days),
+      legs: [
+        TransactionLeg(accountId: accountId, instrument: instrument, quantity: qty, type: .trade),
+        TransactionLeg(accountId: accountId, instrument: aud, quantity: -fiat, type: .trade),
+      ]
+    )
+  }
+
+  /// Two accounts each holding the same instrument: the aggregate value
+  /// line equals the sum of both holdings converted on each day.
+  @Test("aggregate value equals sum of holdings across two accounts")
+  func aggregatesHoldingsAcrossTwoAccounts() async throws {
+    // Account A buys 1 BTC on day 1, account B buys 2 BTC on day 1.
+    let txns = [
+      buy(instrument: btc, qty: 1, fiat: 10_000, accountId: accountA, daysAfterEpoch: 1),
+      buy(instrument: btc, qty: 2, fiat: 20_000, accountId: accountB, daysAfterEpoch: 1),
+    ]
+    let service = FixedConversionService(rates: [btc.id: Decimal(15_000)])
+    let builder = PositionsHistoryBuilder(conversionService: service)
+    let now = date(daysAfterEpoch: 3)
+    let series = await builder.build(
+      transactions: txns,
+      accountIds: Set([accountA, accountB]),
+      hostCurrency: aud,
+      range: .threeMonths,
+      now: now
+    )
+
+    // 3 days in range (days 1, 2, 3).
+    #expect(series.totalSeries.count == 3)
+
+    // Aggregate on any day = convert(3 BTC) = 3 × 15_000 = 45_000.
+    let last = try #require(series.totalSeries.last)
+    #expect(last.value == 3 * Decimal(15_000))
+  }
+
+  /// An internal transfer of the same instrument between two members nets
+  /// to zero quantity change for the group — the group's value line is flat
+  /// across the transfer date (no phantom buy/sell).
+  @Test("internal transfer between members nets out: group quantity stays flat")
+  func internalTransferBetweenMembersNetsOut() async throws {
+    // Account A buys 1 BTC on day 0.
+    // On day 1, A sends 1 BTC to B (one transaction, two legs — both in the group).
+    let buyTxn = Transaction(
+      date: date(daysAfterEpoch: 0),
+      legs: [
+        TransactionLeg(accountId: accountA, instrument: btc, quantity: 1, type: .trade),
+        TransactionLeg(accountId: accountA, instrument: aud, quantity: -10_000, type: .trade),
+      ]
+    )
+    let transferTxn = Transaction(
+      date: date(daysAfterEpoch: 1),
+      legs: [
+        TransactionLeg(accountId: accountA, instrument: btc, quantity: -1, type: .expense),
+        TransactionLeg(accountId: accountB, instrument: btc, quantity: 1, type: .income),
+      ]
+    )
+    let service = FixedConversionService(rates: [btc.id: Decimal(12_000)])
+    let builder = PositionsHistoryBuilder(conversionService: service)
+    let now = date(daysAfterEpoch: 2)
+    let series = await builder.build(
+      transactions: [buyTxn, transferTxn],
+      accountIds: Set([accountA, accountB]),
+      hostCurrency: aud,
+      range: .threeMonths,
+      now: now
+    )
+
+    // All points should show 1 BTC (the group's total is unchanged by
+    // the internal transfer).
+    let expected = 1 * Decimal(12_000)
+    #expect(series.totalSeries.count == 3)
+    for point in series.totalSeries {
+      #expect(point.value == expected)
+    }
+  }
+
+  /// The single-account convenience overload still produces the same series
+  /// as calling the set-based API with a single-element set.
+  @Test("single-account convenience overload matches set-based API with singleton set")
+  func singleAccountConvenienceMatches() async throws {
+    let txns = [
+      buy(instrument: btc, qty: 5, fiat: 50_000, accountId: accountA, daysAfterEpoch: 1)
+    ]
+    let service = FixedConversionService(rates: [btc.id: Decimal(11_000)])
+    let builder = PositionsHistoryBuilder(conversionService: service)
+    let now = date(daysAfterEpoch: 3)
+
+    let viaSingleId = await builder.build(
+      transactions: txns, accountId: accountA,
+      hostCurrency: aud, range: .threeMonths, now: now
+    )
+    let viaSet = await builder.build(
+      transactions: txns, accountIds: Set([accountA]),
+      hostCurrency: aud, range: .threeMonths, now: now
+    )
+
+    // Both should produce identical total-series counts and values.
+    #expect(viaSingleId.totalSeries.count == viaSet.totalSeries.count)
+    for (single, unified) in zip(viaSingleId.totalSeries, viaSet.totalSeries) {
+      #expect(single.value == unified.value)
+      #expect(single.cost == unified.cost)
+    }
+  }
+}

--- a/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
@@ -108,6 +108,78 @@ struct PositionsHistoryBuilderMultiAccountTests {
     }
   }
 
+  /// Locks in that the multi-account builder uses each day's own rate, not
+  /// today's rate (Rule 5 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`).
+  ///
+  /// Uses `DateBasedFixedConversionService` with DIFFERENT per-day rates so a
+  /// regression that swapped `on: day` for `on: Date()` would produce three
+  /// equal values (all at the "today" rate) instead of the three distinct
+  /// values this test asserts.
+  ///
+  /// Rate keys use the same local-timezone `Calendar(identifier: .gregorian)`
+  /// the builder uses for its `startOfDay` computation — following the
+  /// precedent of `PositionsHistoryBuilderTests.valueSeriesUsesPerDayRate` —
+  /// so the `rateDate <= queryDate` comparison in
+  /// `DateBasedFixedConversionService` always aligns regardless of the CI
+  /// runner's local timezone.
+  @Test("each day's value uses that day's rate across multiple accounts")
+  func dateDependentConversionProducesCorrectValues() async {
+    // Construct rate keys using the same local calendar the builder uses for
+    // its day-start queries so keys align precisely in every timezone.
+    let localCalendar = Calendar(identifier: .gregorian)
+    func localDate(daysAfterEpoch days: Int) -> Date {
+      var components = DateComponents()
+      components.year = 2026
+      components.month = 1
+      components.day = 1 + days
+      guard let result = localCalendar.date(from: components) else {
+        fatalError("Could not construct local date \(days) days after 2026-01-01")
+      }
+      return result
+    }
+
+    // Account A buys 1 BTC on day 1; account B buys 1 BTC on day 1.
+    // Group total = 2 BTC; each day has its own rate.
+    let txns = [
+      Transaction(
+        date: localDate(daysAfterEpoch: 1),
+        legs: [
+          TransactionLeg(accountId: accountA, instrument: btc, quantity: 1, type: .trade),
+          TransactionLeg(accountId: accountA, instrument: aud, quantity: -10_000, type: .trade),
+        ]
+      ),
+      Transaction(
+        date: localDate(daysAfterEpoch: 1),
+        legs: [
+          TransactionLeg(accountId: accountB, instrument: btc, quantity: 1, type: .trade),
+          TransactionLeg(accountId: accountB, instrument: aud, quantity: -10_000, type: .trade),
+        ]
+      ),
+    ]
+    let service = DateBasedFixedConversionService(rates: [
+      localDate(daysAfterEpoch: 1): [btc.id: Decimal(10_000)],
+      localDate(daysAfterEpoch: 2): [btc.id: Decimal(20_000)],
+      localDate(daysAfterEpoch: 3): [btc.id: Decimal(30_000)],
+    ])
+    let builder = PositionsHistoryBuilder(conversionService: service)
+    let now = localDate(daysAfterEpoch: 3)
+    let series = await builder.build(
+      transactions: txns,
+      accountIds: Set([accountA, accountB]),
+      hostCurrency: aud,
+      range: .threeMonths,
+      now: now
+    )
+
+    // Three points (days 1, 2, 3). Group holds 2 BTC on each day, but
+    // the value steps up with each day's rate. A regression to "always use
+    // today's rate" would produce three identical values of 2 × 30_000 = 60_000.
+    #expect(series.totalSeries.count == 3)
+    #expect(series.totalSeries[0].value == 2 * Decimal(10_000))
+    #expect(series.totalSeries[1].value == 2 * Decimal(20_000))
+    #expect(series.totalSeries[2].value == 2 * Decimal(30_000))
+  }
+
   /// The single-account convenience overload still produces the same series
   /// as calling the set-based API with a single-element set.
   @Test("single-account convenience overload matches set-based API with singleton set")

--- a/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
@@ -116,40 +116,24 @@ struct PositionsHistoryBuilderMultiAccountTests {
   /// equal values (all at the "today" rate) instead of the three distinct
   /// values this test asserts.
   ///
-  /// Rate keys use the same local-timezone `Calendar(identifier: .gregorian)`
-  /// the builder uses for its `startOfDay` computation — following the
-  /// precedent of `PositionsHistoryBuilderTests.valueSeriesUsesPerDayRate` —
-  /// so the `rateDate <= queryDate` comparison in
+  /// Rate keys use `Calendar.utc` — the same basis the builder uses for its
+  /// `startOfDay` computation — so the `rateDate <= queryDate` comparison in
   /// `DateBasedFixedConversionService` always aligns regardless of the CI
   /// runner's local timezone.
   @Test("each day's value uses that day's rate across multiple accounts")
   func dateDependentConversionProducesCorrectValues() async {
-    // Construct rate keys using the same local calendar the builder uses for
-    // its day-start queries so keys align precisely in every timezone.
-    let localCalendar = Calendar(identifier: .gregorian)
-    func localDate(daysAfterEpoch days: Int) -> Date {
-      var components = DateComponents()
-      components.year = 2026
-      components.month = 1
-      components.day = 1 + days
-      guard let result = localCalendar.date(from: components) else {
-        fatalError("Could not construct local date \(days) days after 2026-01-01")
-      }
-      return result
-    }
-
     // Account A buys 1 BTC on day 1; account B buys 1 BTC on day 1.
     // Group total = 2 BTC; each day has its own rate.
     let txns = [
       Transaction(
-        date: localDate(daysAfterEpoch: 1),
+        date: date(daysAfterEpoch: 1),
         legs: [
           TransactionLeg(accountId: accountA, instrument: btc, quantity: 1, type: .trade),
           TransactionLeg(accountId: accountA, instrument: aud, quantity: -10_000, type: .trade),
         ]
       ),
       Transaction(
-        date: localDate(daysAfterEpoch: 1),
+        date: date(daysAfterEpoch: 1),
         legs: [
           TransactionLeg(accountId: accountB, instrument: btc, quantity: 1, type: .trade),
           TransactionLeg(accountId: accountB, instrument: aud, quantity: -10_000, type: .trade),
@@ -157,12 +141,12 @@ struct PositionsHistoryBuilderMultiAccountTests {
       ),
     ]
     let service = DateBasedFixedConversionService(rates: [
-      localDate(daysAfterEpoch: 1): [btc.id: Decimal(10_000)],
-      localDate(daysAfterEpoch: 2): [btc.id: Decimal(20_000)],
-      localDate(daysAfterEpoch: 3): [btc.id: Decimal(30_000)],
+      date(daysAfterEpoch: 1): [btc.id: Decimal(10_000)],
+      date(daysAfterEpoch: 2): [btc.id: Decimal(20_000)],
+      date(daysAfterEpoch: 3): [btc.id: Decimal(30_000)],
     ])
     let builder = PositionsHistoryBuilder(conversionService: service)
-    let now = localDate(daysAfterEpoch: 3)
+    let now = date(daysAfterEpoch: 3)
     let series = await builder.build(
       transactions: txns,
       accountIds: Set([accountA, accountB]),

--- a/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
@@ -11,13 +11,13 @@ struct PositionsHistoryBuilderMultiAccountTests {
   let accountA = UUID()
   let accountB = UUID()
 
-  /// Day 0 = 2026-01-01.
+  /// Day 0 = 2026-01-01. Uses `Calendar.utc` so the result is zone-invariant.
   private func date(daysAfterEpoch days: Int) -> Date {
     var components = DateComponents()
     components.year = 2026
     components.month = 1
     components.day = 1 + days
-    guard let result = Calendar(identifier: .gregorian).date(from: components) else {
+    guard let result = Calendar.utc.date(from: components) else {
       fatalError("Could not construct date \(days) days after 2026-01-01")
     }
     return result

--- a/MoolahTests/Shared/PositionsHistoryBuilderTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderTests.swift
@@ -10,13 +10,13 @@ struct PositionsHistoryBuilderTests {
   let cba = Instrument.stock(ticker: "CBA.AX", exchange: "ASX", name: "CBA")
   let accountId = UUID()
 
-  /// Day 0 = 2026-01-01.
+  /// Day 0 = 2026-01-01. Uses `Calendar.utc` so the result is zone-invariant.
   private func date(daysAfterEpoch days: Int) -> Date {
     var components = DateComponents()
     components.year = 2026
     components.month = 1
     components.day = 1 + days
-    guard let result = Calendar(identifier: .gregorian).date(from: components) else {
+    guard let result = Calendar.utc.date(from: components) else {
       fatalError("Could not construct date \(days) days after 2026-01-01")
     }
     return result
@@ -86,11 +86,14 @@ struct PositionsHistoryBuilderTests {
     // point reflects the cumulative cost basis at that date — exact step
     // function: 4_000 from day 1, 6_500 from day 10 onwards.
     let bhpSeries = series.series(forInstrumentIds: [bhp.id])
-    let calendar = Calendar(identifier: .gregorian)
     let day5 = try #require(
-      bhpSeries.first { calendar.isDate($0.date, inSameDayAs: date(daysAfterEpoch: 5)) })
+      bhpSeries.first {
+        Calendar.utc.isDate($0.date, inSameDayAs: date(daysAfterEpoch: 5))
+      })
     let day20 = try #require(
-      bhpSeries.first { calendar.isDate($0.date, inSameDayAs: date(daysAfterEpoch: 20)) })
+      bhpSeries.first {
+        Calendar.utc.isDate($0.date, inSameDayAs: date(daysAfterEpoch: 20))
+      })
     #expect(day5.cost == 4_000)
     #expect(day20.cost == 6_500)
   }
@@ -185,8 +188,13 @@ struct PositionsHistoryBuilderTests {
       hostCurrency: aud, range: .oneMonth, now: now
     )
     let cutoff = try #require(PositionsTimeRange.oneMonth.cutoff(from: now))
-    let cutoffDay = Calendar(identifier: .gregorian).startOfDay(for: cutoff)
-    #expect(oneMonth.totalSeries.allSatisfy { $0.date >= cutoffDay })
+    let cutoffDay = Calendar.utc.startOfDay(for: cutoff)
+    // Points are anchored at noon UTC; compare by start-of-day so the noon
+    // offset does not falsely fail the >= check against a midnight cutoff.
+    #expect(
+      oneMonth.totalSeries.allSatisfy {
+        Calendar.utc.startOfDay(for: $0.date) >= cutoffDay
+      })
   }
 
   /// Locks in Rule 5 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`: every

--- a/MoolahTests/Shared/PositionsHistoryBuilderZoneTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderZoneTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Zone-invariance test for `PositionsHistoryBuilder` chart-point dates.
+///
+/// The builder emits each day's point anchored at noon UTC so that a downstream
+/// read — even one that uses a non-UTC calendar — still reports the correct
+/// calendar month. This suite verifies that invariant across the full spread of
+/// real-world zones. See `guides/DATE_TIME_GUIDE.md` §4 and §6.
+@Suite("PositionsHistoryBuilder zone invariance")
+struct PositionsHistoryBuilderZoneTests {
+  let aud = Instrument.AUD
+  let btc = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+  let accountId = UUID()
+
+  /// A spread of zones either side of UTC: one strongly negative (the case that
+  /// drifts a midnight-UTC instant into the prior day), UTC itself, and two
+  /// strongly positive. Mirrors `TimezonelessDateTests`.
+  private static let zones: [String] = [
+    "America/Los_Angeles",  // UTC-8 / -7
+    "UTC",
+    "Australia/Brisbane",  // UTC+10, no DST
+    "Pacific/Kiritimati",  // UTC+14, the extreme positive case
+  ]
+
+  private func calendar(_ identifier: String) throws -> Calendar {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = try #require(TimeZone(identifier: identifier))
+    return cal
+  }
+
+  @Test("emitted point dates report April 2026 in every timezone")
+  func pointDatesAreZoneInvariant() async throws {
+    // Transaction on 2026-04-15 — mid-month to avoid any ±1-day zone drift
+    // crossing a month boundary. The chart axis labels months, so month
+    // stability is the invariant that matters.
+    var txnComponents = DateComponents()
+    txnComponents.year = 2026
+    txnComponents.month = 4
+    txnComponents.day = 15
+    let txnDate = try #require(Calendar.utc.date(from: txnComponents))
+
+    let txn = Transaction(
+      date: txnDate,
+      legs: [
+        TransactionLeg(accountId: accountId, instrument: btc, quantity: 1, type: .trade),
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -50_000, type: .trade),
+      ]
+    )
+
+    // Fixed `now` at noon UTC on 2026-04-20 so the series spans a few days in April.
+    var nowComponents = DateComponents()
+    nowComponents.year = 2026
+    nowComponents.month = 4
+    nowComponents.day = 20
+    nowComponents.hour = 12
+    let now = try #require(Calendar.utc.date(from: nowComponents))
+
+    let service = FixedConversionService(rates: [btc.id: Decimal(50_000)])
+    let builder = PositionsHistoryBuilder(conversionService: service)
+    let series = await builder.build(
+      transactions: [txn],
+      accountId: accountId,
+      hostCurrency: aud,
+      range: .all,
+      now: now
+    )
+
+    // Pick the first emitted point (2026-04-15). It must report month 4 in
+    // every zone. Midnight UTC would drift to March 31 in America/Los_Angeles;
+    // the noon-UTC anchor keeps it safely in April for all real-world zones.
+    let firstPoint = try #require(series.totalSeries.first)
+    for zone in Self.zones {
+      let components = try calendar(zone).dateComponents([.year, .month], from: firstPoint.date)
+      #expect(components.year == 2026, "year drifted in \(zone)")
+      #expect(components.month == 4, "month drifted in \(zone)")
+    }
+  }
+}

--- a/Shared/MultiInstrumentPositionsAssembler.swift
+++ b/Shared/MultiInstrumentPositionsAssembler.swift
@@ -1,0 +1,201 @@
+// swiftlint:disable multiline_arguments
+//
+// `costBasisSnapshot` passes enough labelled parameters to trigger
+// multiline_arguments; scoped to this file rather than reformatting
+// every call site.
+
+import Foundation
+import OSLog
+
+/// The fixed "who / where / how" inputs to `MultiInstrumentPositionsAssembler
+/// .assemble(context:valuedRows:transactions:range:)`. Grouping them lets the
+/// call site stay below SwiftLint's five-parameter limit while keeping
+/// every field named and documented.
+struct PositionsAssemblyContext: Sendable {
+  /// Display label passed through to `PositionsViewInput.title`.
+  let title: String
+  /// The host (reporting) currency for all monetary outputs.
+  let hostCurrency: Instrument
+  /// The account UUIDs whose legs drive cost-basis classification and
+  /// history-builder netting.
+  let accountIds: Set<UUID>
+  /// Maps instrument id → canonical asset key for cross-chain rollup.
+  /// Empty (the default) means no rollup — each position stands alone.
+  let assetKeysByInstrumentId: [String: String]
+  /// Account-level performance numbers, if available. Non-nil triggers the
+  /// three-tile performance strip in `PositionsView`.
+  let performance: AccountPerformance?
+  /// `true` for investment-account hosts, where the full surface renders
+  /// even with no open positions. Other callers pass `false` (the default).
+  let alwaysShowsFullSurface: Bool
+
+  init(
+    title: String,
+    hostCurrency: Instrument,
+    accountIds: Set<UUID>,
+    assetKeysByInstrumentId: [String: String] = [:],
+    performance: AccountPerformance? = nil,
+    alwaysShowsFullSurface: Bool = false
+  ) {
+    self.title = title
+    self.hostCurrency = hostCurrency
+    self.accountIds = accountIds
+    self.assetKeysByInstrumentId = assetKeysByInstrumentId
+    self.performance = performance
+    self.alwaysShowsFullSurface = alwaysShowsFullSurface
+  }
+}
+
+/// Store-independent helper that owns the cost-basis-snapshot and history-
+/// assembly logic for multi-instrument positions views.
+///
+/// Call `fetchTransactions(repository:accountIds:)` to load all relevant
+/// transactions, then `assemble(context:valuedRows:transactions:range:)` to
+/// produce the `PositionsViewInput` the view layer needs. Separating fetch
+/// from assembly lets callers supply a pre-fetched slice (e.g. a group-level
+/// merge) without duplicating the cost-basis engine or history builder.
+///
+/// Sendable: `conversionService` is an existential protocol; the concrete
+/// implementations shipped with the app are all `Sendable`.
+struct MultiInstrumentPositionsAssembler: Sendable {
+  let conversionService: any InstrumentConversionService
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "MultiInstrumentPositionsAssembler")
+
+  // MARK: - Transaction fetch
+
+  /// Pages through all transactions touching any of `accountIds`.
+  func fetchTransactions(
+    repository: any TransactionRepository,
+    accountIds: Set<UUID>
+  ) async throws -> [Transaction] {
+    var all: [Transaction] = []
+    var page = 0
+    while true {
+      let result = try await repository.fetch(
+        filter: TransactionFilter(accountIds: accountIds),
+        page: page, pageSize: 200
+      )
+      try Task.checkCancellation()
+      all.append(contentsOf: result.transactions)
+      if result.transactions.count < 200 { break }
+      page += 1
+    }
+    return all
+  }
+
+  // MARK: - Cost-basis snapshot
+
+  /// Open-lot remaining cost per instrument id, in `hostCurrency` `Decimal`s.
+  ///
+  /// Classifies only the legs that belong to `accountIds` so internal
+  /// transfers between group members net out — consistent with how
+  /// `PositionsHistoryBuilder` handles the same set. Instruments whose
+  /// classification fails are **omitted** (cost unavailable, not zero) per
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
+  func costBasisSnapshot(
+    transactions: [Transaction],
+    accountIds: Set<UUID>,
+    hostCurrency: Instrument
+  ) async -> [String: Decimal] {
+    var engine = CostBasisEngine()
+    var instrumentsWithFailedClassification: Set<String> = []
+    let sorted = transactions.sorted { $0.date < $1.date }
+    for txn in sorted {
+      guard !Task.isCancelled else { break }
+      let scopedLegs = txn.legs.filter {
+        $0.accountId.map { accountIds.contains($0) } ?? false
+      }
+      guard !scopedLegs.isEmpty else { continue }
+      do {
+        let classification = try await TradeEventClassifier.classify(
+          legs: scopedLegs, on: txn.date,
+          hostCurrency: hostCurrency, conversionService: conversionService
+        )
+        for buy in classification.buys {
+          engine.processBuy(
+            instrument: buy.instrument, quantity: buy.quantity,
+            costPerUnit: buy.costPerUnit, date: txn.date)
+        }
+        for sell in classification.sells {
+          _ = engine.processSell(
+            instrument: sell.instrument, quantity: sell.quantity,
+            proceedsPerUnit: sell.proceedsPerUnit, date: txn.date)
+        }
+      } catch {
+        logger.warning(
+          "Failed to classify txn \(txn.id, privacy: .public) for cost basis: \(error.localizedDescription, privacy: .public)"
+        )
+        for leg in scopedLegs where leg.instrument.kind != .fiatCurrency {
+          instrumentsWithFailedClassification.insert(leg.instrument.id)
+        }
+      }
+    }
+    var result: [String: Decimal] = [:]
+    for lot in engine.allOpenLots() {
+      result[lot.instrument.id, default: 0] += lot.remainingCost
+    }
+    for id in instrumentsWithFailedClassification {
+      result.removeValue(forKey: id)
+    }
+    return result
+  }
+
+  // MARK: - Full input assembly
+
+  /// Builds the full `PositionsViewInput`: overlays cost basis on `valuedRows`,
+  /// builds the history series, and sets `hasAnyHistoricalActivity`.
+  func assemble(
+    context: PositionsAssemblyContext,
+    valuedRows: [ValuedPosition],
+    transactions: [Transaction],
+    range: PositionsTimeRange
+  ) async -> PositionsViewInput {
+    let costSnapshot = await costBasisSnapshot(
+      transactions: transactions,
+      accountIds: context.accountIds,
+      hostCurrency: context.hostCurrency)
+    let rowsWithCost = valuedRows.map { row in
+      ValuedPosition(
+        instrument: row.instrument, quantity: row.quantity, unitPrice: row.unitPrice,
+        costBasis: costSnapshot[row.instrument.id].map {
+          InstrumentAmount(quantity: $0, instrument: context.hostCurrency)
+        },
+        value: row.value)
+    }
+    let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
+      transactions: transactions, accountIds: context.accountIds,
+      hostCurrency: context.hostCurrency, range: range)
+    return PositionsViewInput(
+      title: context.title,
+      hostCurrency: context.hostCurrency,
+      positions: rowsWithCost,
+      historicalValue: series,
+      assetKeysByInstrumentId: context.assetKeysByInstrumentId,
+      performance: context.performance,
+      hasAnyHistoricalActivity: Self.hasAnyTradeLeg(
+        in: transactions,
+        accountIds: context.accountIds,
+        hostCurrency: context.hostCurrency),
+      alwaysShowsFullSurface: context.alwaysShowsFullSurface)
+  }
+
+  // MARK: - Trade-leg check
+
+  /// Range-independent check: `true` iff any transaction in `transactions`
+  /// contains a `.trade` leg in a non-`hostCurrency` instrument belonging to
+  /// one of the given `accountIds`.
+  static func hasAnyTradeLeg(
+    in transactions: [Transaction],
+    accountIds: Set<UUID>,
+    hostCurrency: Instrument
+  ) -> Bool {
+    transactions.contains { txn in
+      txn.legs.contains { leg in
+        (leg.accountId.map { accountIds.contains($0) } ?? false)
+          && leg.type == .trade
+          && leg.instrument != hostCurrency
+      }
+    }
+  }
+}

--- a/Shared/MultiInstrumentPositionsAssembler.swift
+++ b/Shared/MultiInstrumentPositionsAssembler.swift
@@ -1,56 +1,16 @@
-// swiftlint:disable multiline_arguments
-//
 // `costBasisSnapshot` passes enough labelled parameters to trigger
 // multiline_arguments; scoped to this file rather than reformatting
 // every call site.
+// swiftlint:disable multiline_arguments
 
 import Foundation
 import OSLog
-
-/// The fixed "who / where / how" inputs to `MultiInstrumentPositionsAssembler
-/// .assemble(context:valuedRows:transactions:range:)`. Grouping them lets the
-/// call site stay below SwiftLint's five-parameter limit while keeping
-/// every field named and documented.
-struct PositionsAssemblyContext: Sendable {
-  /// Display label passed through to `PositionsViewInput.title`.
-  let title: String
-  /// The host (reporting) currency for all monetary outputs.
-  let hostCurrency: Instrument
-  /// The account UUIDs whose legs drive cost-basis classification and
-  /// history-builder netting.
-  let accountIds: Set<UUID>
-  /// Maps instrument id → canonical asset key for cross-chain rollup.
-  /// Empty (the default) means no rollup — each position stands alone.
-  let assetKeysByInstrumentId: [String: String]
-  /// Account-level performance numbers, if available. Non-nil triggers the
-  /// three-tile performance strip in `PositionsView`.
-  let performance: AccountPerformance?
-  /// `true` for investment-account hosts, where the full surface renders
-  /// even with no open positions. Other callers pass `false` (the default).
-  let alwaysShowsFullSurface: Bool
-
-  init(
-    title: String,
-    hostCurrency: Instrument,
-    accountIds: Set<UUID>,
-    assetKeysByInstrumentId: [String: String] = [:],
-    performance: AccountPerformance? = nil,
-    alwaysShowsFullSurface: Bool = false
-  ) {
-    self.title = title
-    self.hostCurrency = hostCurrency
-    self.accountIds = accountIds
-    self.assetKeysByInstrumentId = assetKeysByInstrumentId
-    self.performance = performance
-    self.alwaysShowsFullSurface = alwaysShowsFullSurface
-  }
-}
 
 /// Store-independent helper that owns the cost-basis-snapshot and history-
 /// assembly logic for multi-instrument positions views.
 ///
 /// Call `fetchTransactions(repository:accountIds:)` to load all relevant
-/// transactions, then `assemble(context:valuedRows:transactions:range:)` to
+/// transactions, then `assemble(context:valuedRows:transactions:range:now:)` to
 /// produce the `PositionsViewInput` the view layer needs. Separating fetch
 /// from assembly lets callers supply a pre-fetched slice (e.g. a group-level
 /// merge) without duplicating the cost-basis engine or history builder.
@@ -93,16 +53,19 @@ struct MultiInstrumentPositionsAssembler: Sendable {
   /// `PositionsHistoryBuilder` handles the same set. Instruments whose
   /// classification fails are **omitted** (cost unavailable, not zero) per
   /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
+  ///
+  /// Throws `CancellationError` via `Task.checkCancellation()` so a cancelled
+  /// task never produces a partial cost-basis snapshot.
   func costBasisSnapshot(
     transactions: [Transaction],
     accountIds: Set<UUID>,
     hostCurrency: Instrument
-  ) async -> [String: Decimal] {
+  ) async throws -> [String: Decimal] {
     var engine = CostBasisEngine()
     var instrumentsWithFailedClassification: Set<String> = []
     let sorted = transactions.sorted { $0.date < $1.date }
     for txn in sorted {
-      guard !Task.isCancelled else { break }
+      try Task.checkCancellation()
       let scopedLegs = txn.legs.filter {
         $0.accountId.map { accountIds.contains($0) } ?? false
       }
@@ -122,6 +85,8 @@ struct MultiInstrumentPositionsAssembler: Sendable {
             instrument: sell.instrument, quantity: sell.quantity,
             proceedsPerUnit: sell.proceedsPerUnit, date: txn.date)
         }
+      } catch is CancellationError {
+        throw CancellationError()
       } catch {
         logger.warning(
           "Failed to classify txn \(txn.id, privacy: .public) for cost basis: \(error.localizedDescription, privacy: .public)"
@@ -145,16 +110,44 @@ struct MultiInstrumentPositionsAssembler: Sendable {
 
   /// Builds the full `PositionsViewInput`: overlays cost basis on `valuedRows`,
   /// builds the history series, and sets `hasAnyHistoricalActivity`.
+  ///
+  /// **Invariant (caller's responsibility):** every non-nil
+  /// `valuedRows[i].value.instrument` must equal `context.hostCurrency`. The
+  /// four production call sites guarantee this via `PositionsValuator`; no
+  /// runtime assertion is added here to avoid trapping in production on
+  /// unexpected data.
+  ///
+  /// The cost-basis snapshot and the history series are computed concurrently
+  /// (they are independent of each other). If the snapshot is cancelled, the
+  /// method returns a minimal input with `historicalValue: nil` rather than
+  /// propagating the cancellation — the history series result is still valid.
   func assemble(
     context: PositionsAssemblyContext,
     valuedRows: [ValuedPosition],
     transactions: [Transaction],
-    range: PositionsTimeRange
+    range: PositionsTimeRange,
+    now: Date = Date()
   ) async -> PositionsViewInput {
-    let costSnapshot = await costBasisSnapshot(
+    async let snapshotTask = costBasisSnapshot(
       transactions: transactions,
       accountIds: context.accountIds,
       hostCurrency: context.hostCurrency)
+    let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
+      transactions: transactions, accountIds: context.accountIds,
+      hostCurrency: context.hostCurrency, range: range, now: now)
+    let costSnapshot: [String: Decimal]
+    do {
+      costSnapshot = try await snapshotTask
+    } catch {
+      return PositionsViewInput(
+        title: context.title,
+        hostCurrency: context.hostCurrency,
+        positions: valuedRows,
+        historicalValue: nil,
+        assetKeysByInstrumentId: context.assetKeysByInstrumentId,
+        performance: context.performance,
+        alwaysShowsFullSurface: context.alwaysShowsFullSurface)
+    }
     let rowsWithCost = valuedRows.map { row in
       ValuedPosition(
         instrument: row.instrument, quantity: row.quantity, unitPrice: row.unitPrice,
@@ -163,9 +156,6 @@ struct MultiInstrumentPositionsAssembler: Sendable {
         },
         value: row.value)
     }
-    let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
-      transactions: transactions, accountIds: context.accountIds,
-      hostCurrency: context.hostCurrency, range: range)
     return PositionsViewInput(
       title: context.title,
       hostCurrency: context.hostCurrency,

--- a/Shared/PositionsAssemblyContext.swift
+++ b/Shared/PositionsAssemblyContext.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The fixed "who / where / how" inputs to `MultiInstrumentPositionsAssembler
+/// .assemble(context:valuedRows:transactions:range:now:)`. Grouping them lets the
+/// call site stay below SwiftLint's five-parameter limit while keeping
+/// every field named and documented.
+struct PositionsAssemblyContext: Sendable {
+  /// Display label passed through to `PositionsViewInput.title`.
+  let title: String
+  /// The host (reporting) currency for all monetary outputs.
+  let hostCurrency: Instrument
+  /// The account UUIDs whose legs drive cost-basis classification and
+  /// history-builder netting.
+  let accountIds: Set<UUID>
+  /// Maps instrument id → canonical asset key for cross-chain rollup.
+  /// Empty (the default) means no rollup — each position stands alone.
+  let assetKeysByInstrumentId: [String: String]
+  /// Account-level performance numbers, if available. Non-nil triggers the
+  /// three-tile performance strip in `PositionsView`.
+  let performance: AccountPerformance?
+  /// `true` for investment-account hosts, where the full surface renders
+  /// even with no open positions. Other callers pass `false` (the default).
+  let alwaysShowsFullSurface: Bool
+
+  /// Custom init retained so callers can omit optional fields via default
+  /// arguments — the synthesised memberwise init cannot supply defaults.
+  init(
+    title: String,
+    hostCurrency: Instrument,
+    accountIds: Set<UUID>,
+    assetKeysByInstrumentId: [String: String] = [:],
+    performance: AccountPerformance? = nil,
+    alwaysShowsFullSurface: Bool = false
+  ) {
+    self.title = title
+    self.hostCurrency = hostCurrency
+    self.accountIds = accountIds
+    self.assetKeysByInstrumentId = assetKeysByInstrumentId
+    self.performance = performance
+    self.alwaysShowsFullSurface = alwaysShowsFullSurface
+  }
+}

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -99,7 +99,6 @@ struct PositionsHistoryBuilder: Sendable {
   }
 
   /// Single-account convenience overload. Forwards to the `Set<UUID>` version.
-  @concurrent
   func build(
     transactions: [Transaction],
     accountId: UUID,

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -41,7 +41,7 @@ struct PositionsHistoryBuilder: Sendable {
   @concurrent
   func build(
     transactions: [Transaction],
-    accountId: UUID,
+    accountIds: Set<UUID>,
     hostCurrency: Instrument,
     range: PositionsTimeRange,
     now: Date = Date()
@@ -49,7 +49,7 @@ struct PositionsHistoryBuilder: Sendable {
     let calendar = Calendar(identifier: .gregorian)
     let sortedTxns =
       transactions
-      .filter { $0.legs.contains(where: { $0.accountId == accountId }) }
+      .filter { $0.legs.contains(where: { $0.accountId.map { accountIds.contains($0) } ?? false }) }
       .sorted { $0.date < $1.date }
 
     guard let firstTxnDate = sortedTxns.first?.date else {
@@ -66,7 +66,7 @@ struct PositionsHistoryBuilder: Sendable {
     }
 
     let context = BuildContext(
-      sortedTxns: sortedTxns, accountId: accountId,
+      sortedTxns: sortedTxns, accountIds: accountIds,
       hostCurrency: hostCurrency, calendar: calendar)
     var state = BuildState()
     do {
@@ -98,6 +98,20 @@ struct PositionsHistoryBuilder: Sendable {
     return state.series(hostCurrency: hostCurrency)
   }
 
+  /// Single-account convenience overload. Forwards to the `Set<UUID>` version.
+  @concurrent
+  func build(
+    transactions: [Transaction],
+    accountId: UUID,
+    hostCurrency: Instrument,
+    range: PositionsTimeRange,
+    now: Date = Date()
+  ) async -> HistoricalValueSeries {
+    await build(
+      transactions: transactions, accountIds: [accountId],
+      hostCurrency: hostCurrency, range: range, now: now)
+  }
+
   /// Pre-fold any transactions strictly before `start` so the snapshot at
   /// `start` already reflects historical buys.
   private func preFoldHistory(
@@ -110,7 +124,7 @@ struct PositionsHistoryBuilder: Sendable {
     {
       try await apply(
         transaction: context.sortedTxns[state.txnIndex],
-        accountId: context.accountId,
+        accountIds: context.accountIds,
         hostCurrency: context.hostCurrency,
         state: &state
       )
@@ -129,7 +143,7 @@ struct PositionsHistoryBuilder: Sendable {
     {
       try await apply(
         transaction: context.sortedTxns[state.txnIndex],
-        accountId: context.accountId,
+        accountIds: context.accountIds,
         hostCurrency: context.hostCurrency,
         state: &state
       )
@@ -140,7 +154,7 @@ struct PositionsHistoryBuilder: Sendable {
   /// Immutable inputs threaded through `build`'s per-day loop.
   private struct BuildContext {
     let sortedTxns: [Transaction]
-    let accountId: UUID
+    let accountIds: Set<UUID>
     let hostCurrency: Instrument
     let calendar: Calendar
   }
@@ -252,11 +266,13 @@ struct PositionsHistoryBuilder: Sendable {
   /// conversion errors set the sticky latch and stay swallowed.
   private func apply(
     transaction: Transaction,
-    accountId: UUID,
+    accountIds: Set<UUID>,
     hostCurrency: Instrument,
     state: inout BuildState
   ) async throws {
-    let accountLegs = transaction.legs.filter { $0.accountId == accountId }
+    let accountLegs = transaction.legs.filter {
+      $0.accountId.map { accountIds.contains($0) } ?? false
+    }
     for leg in accountLegs where leg.instrument != hostCurrency {
       state.quantities[leg.instrument, default: 0] += leg.quantity
     }
@@ -290,10 +306,17 @@ struct PositionsHistoryBuilder: Sendable {
     }
 
     // Contributions fold (sticky latch — see BuildState docs).
+    // A flow counts for the group only if the transaction touches exactly
+    // one member of `accountIds` (single member → external counterpart).
+    // Touching ≥2 members means an internal transfer → excluded.
     guard let running = state.contributions else { return }
+    let membersTouched = Set(transaction.legs.compactMap(\.accountId)).intersection(accountIds)
+    guard membersTouched.count == 1, let member = membersTouched.first else {
+      return
+    }
     do {
       let amounts = try await AccountCashFlows.flowAmounts(
-        for: transaction, accountId: accountId,
+        for: transaction, accountId: member,
         hostCurrency: hostCurrency, service: conversionService
       )
       if !amounts.isEmpty {

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -46,7 +46,6 @@ struct PositionsHistoryBuilder: Sendable {
     range: PositionsTimeRange,
     now: Date = Date()
   ) async -> HistoricalValueSeries {
-    let calendar = Calendar(identifier: .gregorian)
     let sortedTxns =
       transactions
       .filter { $0.legs.contains(where: { $0.accountId.map { accountIds.contains($0) } ?? false }) }
@@ -58,8 +57,8 @@ struct PositionsHistoryBuilder: Sendable {
     }
 
     let cutoff = range.cutoff(from: now) ?? firstTxnDate
-    let start = calendar.startOfDay(for: max(cutoff, firstTxnDate))
-    let endDay = calendar.startOfDay(for: now)
+    let start = Calendar.utc.startOfDay(for: max(cutoff, firstTxnDate))
+    let endDay = Calendar.utc.startOfDay(for: now)
     guard endDay >= start else {
       return HistoricalValueSeries(
         hostCurrency: hostCurrency, total: [], perInstrument: [:])
@@ -67,7 +66,7 @@ struct PositionsHistoryBuilder: Sendable {
 
     let context = BuildContext(
       sortedTxns: sortedTxns, accountIds: accountIds,
-      hostCurrency: hostCurrency, calendar: calendar)
+      hostCurrency: hostCurrency)
     var state = BuildState()
     do {
       try await preFoldHistory(before: start, context: context, state: &state)
@@ -91,7 +90,7 @@ struct PositionsHistoryBuilder: Sendable {
       let cancelled = await emitDailyPoints(
         for: day, hostCurrency: hostCurrency, state: &state)
       if cancelled { return state.series(hostCurrency: hostCurrency) }
-      guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+      guard let next = Calendar.utc.date(byAdding: .day, value: 1, to: day) else { break }
       day = next
     }
 
@@ -119,7 +118,7 @@ struct PositionsHistoryBuilder: Sendable {
     state: inout BuildState
   ) async throws {
     while state.txnIndex < context.sortedTxns.count
-      && context.calendar.startOfDay(for: context.sortedTxns[state.txnIndex].date) < start
+      && Calendar.utc.startOfDay(for: context.sortedTxns[state.txnIndex].date) < start
     {
       try await apply(
         transaction: context.sortedTxns[state.txnIndex],
@@ -138,7 +137,7 @@ struct PositionsHistoryBuilder: Sendable {
     state: inout BuildState
   ) async throws {
     while state.txnIndex < context.sortedTxns.count
-      && context.calendar.startOfDay(for: context.sortedTxns[state.txnIndex].date) == day
+      && Calendar.utc.startOfDay(for: context.sortedTxns[state.txnIndex].date) == day
     {
       try await apply(
         transaction: context.sortedTxns[state.txnIndex],
@@ -155,7 +154,6 @@ struct PositionsHistoryBuilder: Sendable {
     let sortedTxns: [Transaction]
     let accountIds: Set<UUID>
     let hostCurrency: Instrument
-    let calendar: Calendar
   }
 
   /// Emit one point per held instrument on `day` and, when every conversion
@@ -171,6 +169,12 @@ struct PositionsHistoryBuilder: Sendable {
     var aggOK = true
     var anyHeld = false
 
+    // `day` is UTC midnight — used for iteration, comparison, and conversion
+    // key lookups. `pointDate` is noon UTC — a zone-invariant positioning
+    // token for the chart axis (the ±12 h margin keeps the civil month stable
+    // even when a downstream read uses a non-UTC calendar).
+    let pointDate = Calendar.utc.date(byAdding: .hour, value: 12, to: day) ?? day
+
     // Host-currency legs are excluded from `quantities` in `apply()`, so every
     // instrument here is a non-host investment instrument and always requires
     // a conversion call.
@@ -184,7 +188,7 @@ struct PositionsHistoryBuilder: Sendable {
       if let value {
         state.perInstrument[instrument.id, default: []].append(
           HistoricalValueSeries.Point(
-            date: day, value: value, cost: cost, contributions: nil))
+            date: pointDate, value: value, cost: cost, contributions: nil))
         aggValue += value
         aggCost += cost
       } else {
@@ -195,7 +199,7 @@ struct PositionsHistoryBuilder: Sendable {
     if anyHeld && aggOK {
       state.total.append(
         HistoricalValueSeries.Point(
-          date: day, value: aggValue, cost: aggCost,
+          date: pointDate, value: aggValue, cost: aggCost,
           contributions: state.contributions))
     }
     return false

--- a/Shared/Views/Positions/PositionsChart.swift
+++ b/Shared/Views/Positions/PositionsChart.swift
@@ -89,7 +89,8 @@ struct PositionsChart: View {
     } else {
       let mode: PositionsChartMode =
         (selection == nil) ? .aggregate : .perInstrument
-      let rows = PositionsChartBaselineResolver.resolve(points: points, mode: mode)
+      let rows = PositionsChartBaselineResolver.resolve(
+        points: points, mode: mode, showBaseline: input.showsCostBaseline)
       Chart {
         ForEach(rows, id: \.date) { row in
           chartMarks(for: row)
@@ -252,15 +253,21 @@ extension PositionsChart: AXChartDescriptorRepresentable {
 
     // Pair each point with its baseline (or nil); drop nil-baseline rows
     // before they reach the AX descriptor so VoiceOver doesn't speak NaN.
-    let baselinePairs: [(label: String, value: Double)] = points.compactMap { point in
-      let baseline: Decimal? =
-        selection == nil ? point.contributions : point.cost
-      guard let baseline else { return nil }
-      return (
-        point.date.formatted(.dateTime.month(.abbreviated).day().year()),
-        Double(truncating: baseline as NSDecimalNumber)
-      )
-    }
+    // Gate entirely on `showsCostBaseline`: when the account has no cost basis
+    // (e.g. transfer-in / airdrop tokens), suppress the baseline series so
+    // VoiceOver doesn't announce a phantom zero baseline.
+    let baselinePairs: [(label: String, value: Double)] =
+      input.showsCostBaseline
+      ? points.compactMap { point in
+        let baseline: Decimal? =
+          selection == nil ? point.contributions : point.cost
+        guard let baseline else { return nil }
+        return (
+          point.date.formatted(.dateTime.month(.abbreviated).day().year()),
+          Double(truncating: baseline as NSDecimalNumber)
+        )
+      }
+      : []
 
     let allValues = valueDoubles + baselinePairs.map(\.value)
     let minVal = allValues.min() ?? 0
@@ -272,11 +279,16 @@ extension PositionsChart: AXChartDescriptorRepresentable {
         AXDataPoint(x: date, y: val)
       }
     )
-    let baselineName = selection == nil ? "Invested amount" : "Cost basis"
-    let baselineSeries = AXDataSeriesDescriptor(
-      name: baselineName, isContinuous: true,
-      dataPoints: baselinePairs.map { AXDataPoint(x: $0.label, y: $0.value) }
-    )
+
+    var series: [AXDataSeriesDescriptor] = [valueSeries]
+    if input.showsCostBaseline {
+      let baselineName = selection == nil ? "Invested amount" : "Cost basis"
+      let baselineSeries = AXDataSeriesDescriptor(
+        name: baselineName, isContinuous: true,
+        dataPoints: baselinePairs.map { AXDataPoint(x: $0.label, y: $0.value) }
+      )
+      series.append(baselineSeries)
+    }
 
     let summary: String? =
       points.isEmpty
@@ -290,7 +302,7 @@ extension PositionsChart: AXChartDescriptorRepresentable {
       yTitle: "Value (\(input.hostCurrency.id))",
       yMin: minVal,
       yMax: max(minVal + 1, maxVal),
-      series: [valueSeries, baselineSeries]
+      series: series
     )
   }
 

--- a/Shared/Views/Positions/PositionsChart.swift
+++ b/Shared/Views/Positions/PositionsChart.swift
@@ -89,8 +89,9 @@ struct PositionsChart: View {
     } else {
       let mode: PositionsChartMode =
         (selection == nil) ? .aggregate : .perInstrument
+      let showBaseline = PositionsChartBaselineResolver.showsBaseline(points: points, mode: mode)
       let rows = PositionsChartBaselineResolver.resolve(
-        points: points, mode: mode, showBaseline: input.showsCostBaseline)
+        points: points, mode: mode, showBaseline: showBaseline)
       Chart {
         ForEach(rows, id: \.date) { row in
           chartMarks(for: row)
@@ -124,7 +125,8 @@ struct PositionsChart: View {
       .accessibilityChartDescriptor(self)
 
       PositionsChartLegendRow(
-        rows: rows, mode: mode, gainLossOpacity: Self.gainLossOpacity)
+        rows: rows, mode: mode, gainLossOpacity: Self.gainLossOpacity,
+        showBaseline: showBaseline)
     }
   }
 
@@ -251,13 +253,19 @@ extension PositionsChart: AXChartDescriptorRepresentable {
     let dateLabels = points.map { $0.date.formatted(.dateTime.month(.abbreviated).day().year()) }
     let valueDoubles = points.map { Double(truncating: $0.value as NSDecimalNumber) }
 
+    // Derive the chart mode from whether a specific instrument is selected,
+    // then let the data decide whether a baseline is meaningful. This mirrors
+    // the data-driven decision in `chartBody` so VoiceOver and the visual chart
+    // agree: when the series carries no cost/contribution data (e.g. a wallet
+    // of transfer-in / airdrop tokens), neither the chart nor the AX descriptor
+    // exposes a phantom zero baseline.
+    let mode: PositionsChartMode = selection == nil ? .aggregate : .perInstrument
+    let showBaseline = PositionsChartBaselineResolver.showsBaseline(points: points, mode: mode)
+
     // Pair each point with its baseline (or nil); drop nil-baseline rows
     // before they reach the AX descriptor so VoiceOver doesn't speak NaN.
-    // Gate entirely on `showsCostBaseline`: when the account has no cost basis
-    // (e.g. transfer-in / airdrop tokens), suppress the baseline series so
-    // VoiceOver doesn't announce a phantom zero baseline.
     let baselinePairs: [(label: String, value: Double)] =
-      input.showsCostBaseline
+      showBaseline
       ? points.compactMap { point in
         let baseline: Decimal? =
           selection == nil ? point.contributions : point.cost
@@ -281,7 +289,7 @@ extension PositionsChart: AXChartDescriptorRepresentable {
     )
 
     var series: [AXDataSeriesDescriptor] = [valueSeries]
-    if input.showsCostBaseline {
+    if showBaseline {
       let baselineName = selection == nil ? "Invested amount" : "Cost basis"
       let baselineSeries = AXDataSeriesDescriptor(
         name: baselineName, isContinuous: true,

--- a/Shared/Views/Positions/PositionsChartBaselineResolver.swift
+++ b/Shared/Views/Positions/PositionsChartBaselineResolver.swift
@@ -6,6 +6,20 @@ import Foundation
 /// the data-shape tests can exercise the rendering decisions
 /// without spinning up a view harness.
 enum PositionsChartBaselineResolver {
+  /// `true` iff the series carries a non-zero baseline to plot for `mode`
+  /// (aggregate → `point.contributions`; per-instrument → `point.cost`).
+  ///
+  /// `false` for a wallet of transfer-in/airdrop tokens whose baseline is
+  /// uniformly zero/absent — plotting a zero baseline would misleadingly
+  /// render the whole holding as gain.
+  static func showsBaseline(points: [HistoricalValueSeries.Point], mode: PositionsChartMode) -> Bool
+  {
+    points.contains { point in
+      let baseline: Decimal? = (mode == .aggregate) ? point.contributions : point.cost
+      return (baseline ?? 0) != 0
+    }
+  }
+
   /// Turns a `[HistoricalValueSeries.Point]` into the per-row rendering inputs
   /// the chart consumes.
   ///

--- a/Shared/Views/Positions/PositionsChartBaselineResolver.swift
+++ b/Shared/Views/Positions/PositionsChartBaselineResolver.swift
@@ -6,16 +6,34 @@ import Foundation
 /// the data-shape tests can exercise the rendering decisions
 /// without spinning up a view harness.
 enum PositionsChartBaselineResolver {
+  /// Turns a `[HistoricalValueSeries.Point]` into the per-row rendering inputs
+  /// the chart consumes.
+  ///
+  /// - Parameters:
+  ///   - points: Raw data points from `HistoricalValueSeries`.
+  ///   - mode: Aggregate (uses `point.contributions`) or per-instrument (uses
+  ///     `point.cost`).
+  ///   - showBaseline: When `false`, `baseline` is forced to `nil` for every
+  ///     row, suppressing gain/loss shading and the dashed baseline line. Pass
+  ///     `false` when no position in the account carries a cost basis — a zero
+  ///     baseline would render the entire holding as gain, which is misleading
+  ///     for transfer-in or airdrop tokens.
   static func resolve(
-    points: [HistoricalValueSeries.Point], mode: PositionsChartMode
+    points: [HistoricalValueSeries.Point],
+    mode: PositionsChartMode,
+    showBaseline: Bool
   ) -> [PositionsChartRenderRow] {
     guard !points.isEmpty else { return [] }
     let lastIndex = points.count - 1
     return points.enumerated().map { index, point in
       let baseline: Decimal?
-      switch mode {
-      case .aggregate: baseline = point.contributions
-      case .perInstrument: baseline = point.cost
+      if showBaseline {
+        switch mode {
+        case .aggregate: baseline = point.contributions
+        case .perInstrument: baseline = point.cost
+        }
+      } else {
+        baseline = nil
       }
       let gain = baseline.map { max(point.value - $0, 0) } ?? 0
       let loss = baseline.map { max($0 - point.value, 0) } ?? 0

--- a/Shared/Views/Positions/PositionsChartLegendRow.swift
+++ b/Shared/Views/Positions/PositionsChartLegendRow.swift
@@ -11,14 +11,21 @@ struct PositionsChartLegendRow: View {
   /// preview at the same time as the chart, keeping the legend an
   /// accurate visual sample of the chart fill.
   let gainLossOpacity: Double
+  /// When `false`, the chart is rendering a value-only series (e.g. a wallet
+  /// of transfer-in or airdrop tokens). The dashed baseline item and the
+  /// Profit/Loss swatch are omitted so the legend accurately reflects what
+  /// the chart shows. When `true`, the full three-item legend renders.
+  let showBaseline: Bool
 
   var body: some View {
     let baselineLabel = (mode == .aggregate) ? "Invested amount" : "Cost basis"
     let unavailable = rows.last?.legendUnavailable == true
     HStack(spacing: 16) {
       PositionsChartLegendItem(color: .accentColor, label: "Value", dashed: false)
-      PositionsChartLegendItem(color: .secondary, label: baselineLabel, dashed: true)
-      ProfitLossLegendSwatch(unavailable: unavailable, opacity: gainLossOpacity)
+      if showBaseline {
+        PositionsChartLegendItem(color: .secondary, label: baselineLabel, dashed: true)
+        ProfitLossLegendSwatch(unavailable: unavailable, opacity: gainLossOpacity)
+      }
       Spacer()
     }
     .font(.caption2)

--- a/Shared/Views/Positions/PositionsTimeRange.swift
+++ b/Shared/Views/Positions/PositionsTimeRange.swift
@@ -43,15 +43,22 @@ enum PositionsTimeRange: Hashable, Sendable, CaseIterable, Identifiable {
 
   /// First date inside the range, given a `now` reference. `nil` for `.all`
   /// (caller treats as "from the earliest available data point").
+  ///
+  /// Uses the LOCAL Gregorian calendar — this is a now-relative range boundary
+  /// ("the user's year to date", "3 months ago from now"), not a timezoneless
+  /// carrier. Local calendar is correct here; see DATE_TIME_GUIDE.md §Local vs UTC.
+  /// The builder's day-bucketing (PositionsHistoryBuilder) uses Calendar.utc
+  /// separately — those are distinct concerns.
   func cutoff(from now: Date) -> Date? {
+    let calendar = Calendar(identifier: .gregorian)
     switch self {
-    case .oneMonth: return Calendar.utc.date(byAdding: .month, value: -1, to: now)
-    case .threeMonths: return Calendar.utc.date(byAdding: .month, value: -3, to: now)
-    case .sixMonths: return Calendar.utc.date(byAdding: .month, value: -6, to: now)
+    case .oneMonth: return calendar.date(byAdding: .month, value: -1, to: now)
+    case .threeMonths: return calendar.date(byAdding: .month, value: -3, to: now)
+    case .sixMonths: return calendar.date(byAdding: .month, value: -6, to: now)
     case .ytd:
-      let comps = Calendar.utc.dateComponents([.year], from: now)
-      return Calendar.utc.date(from: comps)
-    case .oneYear: return Calendar.utc.date(byAdding: .year, value: -1, to: now)
+      let comps = calendar.dateComponents([.year], from: now)
+      return calendar.date(from: comps)
+    case .oneYear: return calendar.date(byAdding: .year, value: -1, to: now)
     case .all: return nil
     }
   }

--- a/Shared/Views/Positions/PositionsTimeRange.swift
+++ b/Shared/Views/Positions/PositionsTimeRange.swift
@@ -44,15 +44,14 @@ enum PositionsTimeRange: Hashable, Sendable, CaseIterable, Identifiable {
   /// First date inside the range, given a `now` reference. `nil` for `.all`
   /// (caller treats as "from the earliest available data point").
   func cutoff(from now: Date) -> Date? {
-    let calendar = Calendar(identifier: .gregorian)
     switch self {
-    case .oneMonth: return calendar.date(byAdding: .month, value: -1, to: now)
-    case .threeMonths: return calendar.date(byAdding: .month, value: -3, to: now)
-    case .sixMonths: return calendar.date(byAdding: .month, value: -6, to: now)
+    case .oneMonth: return Calendar.utc.date(byAdding: .month, value: -1, to: now)
+    case .threeMonths: return Calendar.utc.date(byAdding: .month, value: -3, to: now)
+    case .sixMonths: return Calendar.utc.date(byAdding: .month, value: -6, to: now)
     case .ytd:
-      let comps = calendar.dateComponents([.year], from: now)
-      return calendar.date(from: comps)
-    case .oneYear: return calendar.date(byAdding: .year, value: -1, to: now)
+      let comps = Calendar.utc.dateComponents([.year], from: now)
+      return Calendar.utc.date(from: comps)
+    case .oneYear: return Calendar.utc.date(byAdding: .year, value: -1, to: now)
     case .all: return nil
     }
   }

--- a/plans/2026-06-18-multi-instrument-history-chart.md
+++ b/plans/2026-06-18-multi-instrument-history-chart.md
@@ -1,0 +1,463 @@
+# Multi-Instrument History Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the value/profit-loss history chart at the top of the positions surface for every multi-instrument host (crypto accounts, account groups, standard multi-currency accounts, exchange accounts) — the same chart investment accounts already get.
+
+**Architecture:** The chart is gated by `PositionsViewInput.showsChart`, which needs a non-empty `historicalValue` series *and* either `shouldHide` or at least one row with a cost basis. Today the investment path (`InvestmentStore.positionsViewInput`) builds both via `PositionsHistoryBuilder` + a cost-basis snapshot, while the shared `multiInstrumentPositionsSplit()` modifier hardcodes `historicalValue: nil` and `costBasis: [:]`. We extract the investment path's cost-basis-and-history assembly into a store-independent helper, generalize `PositionsHistoryBuilder` from a single `accountId` to a `Set<UUID>` (so account groups aggregate), and call the shared helper from the modifier — fetching transactions via `session.backend.transactions` and re-firing on range changes.
+
+**Tech Stack:** Swift, SwiftUI, GRDB-backed `TransactionRepository`, `InstrumentConversionService` (crypto/stock/FX price caches), Swift Testing, `just` toolchain.
+
+## Global Constraints
+
+- **Git:** `main` is protected. Work happens on branch `crypto-pl-chart` in worktree `/Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart`. Ship via PR. Use `git -C <path>`, never `cd && git`.
+- **Build/test/format:** Use `just` targets only (`just build-mac`, `just test-mac <filters>`, `just format`, `just format-check`). Never raw `swift`/`swiftlint`/`swift-format`/`xcodebuild`. Capture test output to `.agent-tmp/`.
+- **TDD:** Write the failing test before implementation. Tests use Swift Testing (`@Test`/`@Suite`/`#expect`/`#require`), not XCTest. One `extension` per protocol conformance (no inline conformances).
+- **Concurrency:** Follow `guides/CONCURRENCY_GUIDE.md`. Stores/UI-bound types `@MainActor`; cross-actor types `Sendable`. `PositionsHistoryBuilder` is already `@concurrent`/`Sendable`.
+- **Instrument safety:** Mismatched-instrument arithmetic traps. Never `abs()` monetary amounts — preserve sign. Never display a partial aggregate: a single failed conversion marks the whole total unavailable (Rule 11, `guides/INSTRUMENT_CONVERSION_GUIDE.md`).
+- **Dates:** Historical conversions use the snapshot date; "now" uses `Date()`. Day bucketing must be zone-stable (`guides/DATE_TIME_GUIDE.md`). `PositionsHistoryBuilder` already keys days via `Calendar(identifier: .gregorian)` startOfDay — keep that exact behavior.
+- **Thin views:** Business logic lives in the shared helper, not the `ViewModifier` body. The modifier's `.task` is allowed to *call* the helper (mirrors the existing `valuatePositions()` pattern).
+- **Lint:** No SwiftLint baseline. Fix violations by splitting files/types/functions, not by suppressing. Run `just format-check` at the end of every task.
+- **TODOs:** Any `TODO`/`FIXME` must be `TODO(#N): … — https://github.com/moolah-rocks/moolah-native/issues/N`.
+
+---
+
+## File Structure
+
+- **`Shared/PositionsHistoryBuilder.swift`** (modify) — generalize `accountId: UUID` → `accountIds: Set<UUID>` throughout; keep a single-account convenience overload so existing callers are untouched.
+- **`Shared/MultiInstrumentPositionsAssembler.swift`** (create) — store-independent helper that fetches transactions for a set of accounts, computes the cost-basis snapshot, overlays cost basis onto valued rows, builds the history series, and returns a fully-populated `PositionsViewInput`. This is the single home for the logic currently inlined in `InvestmentStore+PositionsInput.swift`.
+- **`Features/Investments/InvestmentStore+PositionsInput.swift`** (modify) — refactor `positionsViewInput` to delegate cost-basis snapshot + history assembly to the new helper (no behavior change; existing tests stay green). `fetchAllTransactions`, `costBasisSnapshot`, `hasAnyTradeLeg` move to the helper as static/free functions; the store keeps thin wrappers if other code references them.
+- **`Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift`** (modify) — accept `accountIds: [UUID]`; in the valuation task, call the assembler to produce a `PositionsViewInput` with `historicalValue` + cost-bearing rows; add `positionsRange` to the task key so the chart rebuilds on range change.
+- **Call sites** (modify): `Features/Crypto/CryptoWalletAccountView.swift`, `Features/Accounts/Views/GroupDetailView.swift`, `Features/Accounts/Views/StandardAccountView.swift`, `Features/Exchange/ExchangeAccountView.swift` — pass `accountIds`.
+- **Tests** (create): `MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift`, `MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift`.
+
+---
+
+## Task 1: Generalize `PositionsHistoryBuilder` to multiple accounts
+
+**Files:**
+- Modify: `Shared/PositionsHistoryBuilder.swift`
+- Test: `MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift` (create)
+
+**Interfaces:**
+- Produces:
+  - `func build(transactions:[Transaction], accountIds: Set<UUID>, hostCurrency: Instrument, range: PositionsTimeRange, now: Date = Date()) async -> HistoricalValueSeries`
+  - Convenience kept for existing callers: `func build(transactions:[Transaction], accountId: UUID, hostCurrency: Instrument, range: PositionsTimeRange, now: Date = Date()) async -> HistoricalValueSeries` → calls the set-based version with `[accountId]`.
+- Internals change: `BuildContext.accountId: UUID` → `accountIds: Set<UUID>`; the txn filter `legs.contains { $0.accountId == accountId }` → `legs.contains { accountIds.contains($0.accountId) }`; in `apply`, `legs.filter { $0.accountId == accountId }` → `legs.filter { accountIds.contains($0.accountId) }`. `AccountCashFlows.flowAmounts(for:accountId:…)` is called per-member in a loop (see Step 3) because its boundary predicate is single-account.
+
+**Why a Set:** account groups aggregate holdings across members (`aggregatedGroupPositions`). With all member accounts in `accountIds`, an internal same-instrument transfer between two members appears as `[+q (memberB), −q (memberA)]` in `accountLegs`, so quantities net to zero on that day — the value line is correct without special-casing transfers.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift`. Use the project's existing history-builder test as the reference for harness setup (a deterministic in-memory conversion service / fixed `now`). Cover:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("PositionsHistoryBuilder multi-account")
+struct PositionsHistoryBuilderMultiAccountTests {
+  // Two accounts each holding the same instrument: the aggregate value
+  // line equals the sum of both holdings converted on each day.
+  @Test func aggregatesHoldingsAcrossTwoAccounts() async {
+    // Build txns: account A buys 1 BTC, account B buys 2 BTC.
+    // build(..., accountIds: [A, B], hostCurrency: .AUD, range: .all, now: fixedNow)
+    // #expect aggregate total on the last day == convert(3 BTC) on that day.
+  }
+
+  // An internal transfer of the SAME instrument between two members nets to
+  // zero quantity change for the group — the group's value line is flat
+  // across the transfer date (no phantom buy/sell).
+  @Test func internalTransferBetweenMembersNetsOut() async {
+    // A buys 1 BTC on day0; on day1 A sends 1 BTC to B (one txn, two legs).
+    // accountIds: [A, B] → quantity held by the group is 1 BTC before and
+    // after; #expect the aggregate value on day1 == convert(1 BTC) on day1
+    // (NOT 0, NOT 2).
+  }
+
+  // The single-account convenience overload still produces the same series
+  // as the pre-change single-account API.
+  @Test func singleAccountConvenienceMatches() async {
+    // build(transactions:accountId:…) == build(transactions:accountIds:[id]:…)
+  }
+}
+```
+
+Fill the bodies using the existing builder test's fixtures (read `MoolahTests` for the current `PositionsHistoryBuilder` test to copy the deterministic conversion-service stub and `Transaction`/`TransactionLeg` builders). Assert exact host-currency quantities, never a currency symbol.
+
+- [ ] **Step 2: Run tests, verify they fail to compile**
+
+Run: `just test-mac PositionsHistoryBuilderMultiAccountTests 2>&1 | tee .agent-tmp/t1.txt`
+Expected: compile failure — `build(transactions:accountIds:…)` does not exist yet.
+
+- [ ] **Step 3: Implement the generalization**
+
+In `Shared/PositionsHistoryBuilder.swift`:
+- Change `BuildContext.accountId: UUID` to `accountIds: Set<UUID>`.
+- In `build`, rename the parameter and update the txn filter:
+  ```swift
+  func build(
+    transactions: [Transaction],
+    accountIds: Set<UUID>,
+    hostCurrency: Instrument,
+    range: PositionsTimeRange,
+    now: Date = Date()
+  ) async -> HistoricalValueSeries {
+    …
+    let sortedTxns = transactions
+      .filter { $0.legs.contains { accountIds.contains($0.accountId) } }
+      .sorted { $0.date < $1.date }
+    …
+    let context = BuildContext(
+      sortedTxns: sortedTxns, accountIds: accountIds,
+      hostCurrency: hostCurrency, calendar: calendar)
+    …
+  }
+  ```
+- Add the single-account convenience overload:
+  ```swift
+  func build(
+    transactions: [Transaction],
+    accountId: UUID,
+    hostCurrency: Instrument,
+    range: PositionsTimeRange,
+    now: Date = Date()
+  ) async -> HistoricalValueSeries {
+    await build(
+      transactions: transactions, accountIds: [accountId],
+      hostCurrency: hostCurrency, range: range, now: now)
+  }
+  ```
+- In `preFoldHistory`/`applyTransactions`, replace `accountId: context.accountId` with `accountIds: context.accountIds`.
+- In `apply`, change the signature to take `accountIds: Set<UUID>` and:
+  ```swift
+  let accountLegs = transaction.legs.filter { accountIds.contains($0.accountId) }
+  ```
+- **Contributions:** `AccountCashFlows.flowAmounts(for:accountId:hostCurrency:service:)` is single-account and its predicate is "crosses this account's boundary". For a group, an internal member↔member transfer must NOT count as a contribution. Compute contributions as the sum over members, then subtract flows whose counterpart leg is also in `accountIds`. Simplest correct implementation: call `flowAmounts` once per member id and only keep a flow if the transaction has **no** other leg inside `accountIds` (i.e. it crosses the *group* boundary, not just a member boundary). Implement a small helper:
+  ```swift
+  // A flow counts for the group only if the txn touches exactly one member
+  // of `accountIds` (single member → external counterpart). Touching ≥2
+  // members means an internal transfer → excluded.
+  let membersTouched = Set(transaction.legs.compactMap(\.accountId)).intersection(accountIds)
+  guard membersTouched.count == 1, let member = membersTouched.first else {
+    // internal transfer (or none) — no contribution
+    return  // after the quantity/cost-basis fold above
+  }
+  let amounts = try await AccountCashFlows.flowAmounts(
+    for: transaction, accountId: member,
+    hostCurrency: hostCurrency, service: conversionService)
+  ```
+  Keep the existing sticky-latch semantics for the contributions accumulator unchanged.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `just test-mac PositionsHistoryBuilderMultiAccountTests 2>&1 | tee .agent-tmp/t1.txt`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Verify existing history-builder tests still pass + format**
+
+Run: `just test-mac PositionsHistoryBuilderTests 2>&1 | tee .agent-tmp/t1b.txt` (use the exact existing suite type name — confirm via grep) then `just format-check`.
+Expected: existing suite green; format-check clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart add Shared/PositionsHistoryBuilder.swift MoolahTests/Shared/PositionsHistoryBuilderMultiAccountTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart commit -m "feat(positions): generalize PositionsHistoryBuilder to multiple accounts"
+```
+
+---
+
+## Task 2: Extract the cost-basis + input assembly into a shared helper
+
+**Files:**
+- Create: `Shared/MultiInstrumentPositionsAssembler.swift`
+- Modify: `Features/Investments/InvestmentStore+PositionsInput.swift`
+- Test: `MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `PositionsHistoryBuilder.build(transactions:accountIds:…)` (Task 1).
+- Produces:
+  ```swift
+  struct MultiInstrumentPositionsAssembler: Sendable {
+    let conversionService: any InstrumentConversionService
+
+    // Page through all transactions touching any of `accountIds`.
+    func fetchTransactions(
+      repository: any TransactionRepository, accountIds: Set<UUID>) async throws -> [Transaction]
+
+    // Open-lot remaining cost per instrument id (host currency Decimal).
+    // Instruments whose classification failed are omitted (cost unavailable,
+    // not zero) — Rule 11. accountIds-aware: only legs in `accountIds` drive
+    // the engine, so internal transfers net out.
+    func costBasisSnapshot(
+      transactions: [Transaction], accountIds: Set<UUID>, hostCurrency: Instrument
+    ) async -> [String: Decimal]
+
+    // Build the full input: overlays cost basis on `valuedRows`, builds the
+    // history series, sets hasAnyHistoricalActivity. `alwaysShowsFullSurface`
+    // defaults false (multi-instrument hosts collapse when shouldHide);
+    // investment caller passes true.
+    func assemble(
+      title: String, hostCurrency: Instrument, accountIds: Set<UUID>,
+      valuedRows: [ValuedPosition], transactions: [Transaction],
+      range: PositionsTimeRange, assetKeysByInstrumentId: [String: String],
+      performance: AccountPerformance?, alwaysShowsFullSurface: Bool
+    ) async -> PositionsViewInput
+
+    static func hasAnyTradeLeg(
+      in transactions: [Transaction], accountIds: Set<UUID>, hostCurrency: Instrument) -> Bool
+  }
+  ```
+  `costBasisSnapshot` must classify with the **account-scoped** legs (`legs.filter { accountIds.contains($0.accountId) }`) to match the builder's internal-transfer netting, but pass the txn date and host currency exactly as the current `InvestmentStore.costBasisSnapshot` does. The current investment behavior is the single-account case of this, so existing investment cost-basis tests must remain green.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("MultiInstrumentPositionsAssembler")
+struct MultiInstrumentPositionsAssemblerTests {
+  // A crypto account holding a non-host token with a buy history produces an
+  // input whose showsChart == true (non-empty series + a cost-bearing row).
+  @Test func cryptoAccountInputShowsChart() async throws {
+    // Seed a deterministic conversion service with daily prices for the token.
+    // valuedRows = [ValuedPosition(token, qty, unitPrice, costBasis: nil, value)]
+    // transactions = a single buy of the token in the account.
+    // assemble(... alwaysShowsFullSurface: false ...)
+    // #expect(input.historicalValue != nil)
+    // #expect(input.showsChart == true)
+    // #expect(input.showsPLPill == true)   // cost basis present
+  }
+
+  // hasAnyTradeLeg is true when any account in the set has a non-host trade leg.
+  @Test func hasAnyTradeLegAcrossAccounts() { /* assert true/false cases */ }
+
+  // costBasisSnapshot omits an instrument whose classification fails
+  // (unavailable, not zero).
+  @Test func costBasisOmitsUnclassifiableInstrument() async { /* … */ }
+}
+```
+
+Fill bodies using the deterministic conversion-service stub from Task 1's tests and the existing `TestBackend`/`Transaction` builders.
+
+- [ ] **Step 2: Run tests, verify they fail to compile**
+
+Run: `just test-mac MultiInstrumentPositionsAssemblerTests 2>&1 | tee .agent-tmp/t2.txt`
+Expected: compile failure — type does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `Shared/MultiInstrumentPositionsAssembler.swift`. Move the bodies of `fetchAllTransactions`, `costBasisSnapshot`, and `hasAnyTradeLeg` from `InvestmentStore+PositionsInput.swift` into this type, generalizing `accountId`→`accountIds` (paging filter uses `TransactionFilter(accountIds: accountIds)`). `assemble` mirrors the tail of `positionsViewInput`:
+```swift
+func assemble(…) async -> PositionsViewInput {
+  let costSnapshot = await costBasisSnapshot(
+    transactions: transactions, accountIds: accountIds, hostCurrency: hostCurrency)
+  let rowsWithCost = valuedRows.map { row in
+    ValuedPosition(
+      instrument: row.instrument, quantity: row.quantity, unitPrice: row.unitPrice,
+      costBasis: costSnapshot[row.instrument.id].map {
+        InstrumentAmount(quantity: $0, instrument: hostCurrency) },
+      value: row.value)
+  }
+  let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
+    transactions: transactions, accountIds: accountIds,
+    hostCurrency: hostCurrency, range: range)
+  return PositionsViewInput(
+    title: title, hostCurrency: hostCurrency, positions: rowsWithCost,
+    historicalValue: series, assetKeysByInstrumentId: assetKeysByInstrumentId,
+    performance: performance,
+    hasAnyHistoricalActivity: Self.hasAnyTradeLeg(
+      in: transactions, accountIds: accountIds, hostCurrency: hostCurrency),
+    alwaysShowsFullSurface: alwaysShowsFullSurface)
+}
+```
+Use a `Logger` consistent with the existing one. Keep `TransactionFilter(accountIds:)` paging at pageSize 200 with cancellation checks, identical to the original.
+
+- [ ] **Step 4: Refactor `InvestmentStore.positionsViewInput` to delegate**
+
+Replace the cost-basis/history tail of `positionsViewInput` with a call to `MultiInstrumentPositionsAssembler(conversionService: conversionService)`:
+- `fetchTransactions(repository:accountIds:[accountId])`
+- `assemble(title:…, accountIds:[accountId], valuedRows: valuedPositions, transactions: txns, range:, assetKeysByInstrumentId: assetKeysByInstrumentId, performance: accountPerformance, alwaysShowsFullSurface: true)`
+
+Keep the `guard let transactionRepository else { … historicalValue: nil … }` early return as-is. If `fetchAllTransactions`/`costBasisSnapshot`/`hasAnyTradeLeg` are referenced elsewhere, leave thin forwarding wrappers; otherwise delete them. Behavior must be unchanged.
+
+- [ ] **Step 5: Run assembler tests + full investment suite + format**
+
+Run:
+```bash
+just test-mac MultiInstrumentPositionsAssemblerTests InvestmentStoreTests 2>&1 | tee .agent-tmp/t2.txt
+just format-check
+```
+Expected: new tests PASS; all existing investment-store tests PASS (no behavior change); format-check clean. (Confirm exact existing suite type names via grep before running.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart add Shared/MultiInstrumentPositionsAssembler.swift Features/Investments/InvestmentStore+PositionsInput.swift MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart commit -m "refactor(positions): extract shared cost-basis + history assembler"
+```
+
+---
+
+## Task 3: Wire the assembler into `MultiInstrumentPositionsSplitModifier`
+
+**Files:**
+- Modify: `Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift`
+
+**Interfaces:**
+- Consumes: `MultiInstrumentPositionsAssembler` (Task 2), `session.backend.transactions` (a `TransactionRepository`).
+- Produces: `multiInstrumentPositionsSplit(positions:hostCurrency:title:conversionService:accountIds:registrationsVersion:)` — adds `accountIds: [UUID]` (default `[]` so previews/callers without ids degrade gracefully to the current no-chart behavior).
+
+- [ ] **Step 1: Add `accountIds` and range-aware history build**
+
+- Add stored property `let accountIds: [UUID]` to `MultiInstrumentPositionsSplitModifier` and the `multiInstrumentPositionsSplit` extension (default `[]`).
+- Add `positionsRange` to the task key so the chart rebuilds on range change:
+  ```swift
+  .task(id: PositionsTaskKey(
+    positions: positions, registrationsVersion: registrationsVersion, range: positionsRange))
+  ```
+  and add `let range: PositionsTimeRange` to `PositionsTaskKey`.
+- In `valuatePositions()`, after computing `rows` and `assetKeys`, build the full input via the assembler **when** `accountIds` is non-empty and a transaction repository is available; otherwise keep the current `historicalValue: nil` input (back-compat for preview/no-id callers):
+  ```swift
+  if !accountIds.isEmpty, let repository = session?.backend.transactions {
+    let assembler = MultiInstrumentPositionsAssembler(conversionService: conversionService)
+    let txns: [Transaction]
+    do {
+      txns = try await assembler.fetchTransactions(
+        repository: repository, accountIds: Set(accountIds))
+    } catch is CancellationError { return } catch {
+      Self.logger.warning("history txn fetch failed: \(error.localizedDescription, privacy: .public)")
+      txns = []
+    }
+    guard !Task.isCancelled else { return }
+    positionsInput = await assembler.assemble(
+      title: title, hostCurrency: hostCurrency, accountIds: Set(accountIds),
+      valuedRows: rows, transactions: txns, range: positionsRange,
+      assetKeysByInstrumentId: assetKeys, performance: nil, alwaysShowsFullSurface: false)
+    return
+  }
+  positionsInput = PositionsViewInput(
+    title: title, hostCurrency: hostCurrency, positions: rows,
+    historicalValue: nil, assetKeysByInstrumentId: assetKeys)
+  ```
+  Keep all existing `Task.isCancelled` guards. Note `range: positionsRange` flows from the `@State` so the rebuild reflects the user's selection.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/t3.txt`
+Expected: build succeeds, zero warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart add Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart commit -m "feat(positions): build history series in multi-instrument split"
+```
+
+---
+
+## Task 4: Pass `accountIds` from the four call sites
+
+**Files:**
+- Modify: `Features/Crypto/CryptoWalletAccountView.swift`
+- Modify: `Features/Accounts/Views/GroupDetailView.swift`
+- Modify: `Features/Accounts/Views/StandardAccountView.swift`
+- Modify: `Features/Exchange/ExchangeAccountView.swift`
+
+- [ ] **Step 1: Thread the ids**
+
+- `CryptoWalletAccountView` (`.multiInstrumentPositionsSplit(...)`): add `accountIds: [account.id]`.
+- `GroupDetailView`: add `accountIds: context.accountIds`.
+- `StandardAccountView`: add `accountIds: [account.id]`.
+- `ExchangeAccountView`: add `accountIds: [account.id]` (confirm the local property name for the account/id via grep first).
+
+Leave previews as-is — they pass no `accountIds`, so they keep the current no-chart behavior and won't try to reach a real repository.
+
+- [ ] **Step 2: Build**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/t4.txt`
+Expected: build succeeds, zero warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart add Features/Crypto/CryptoWalletAccountView.swift Features/Accounts/Views/GroupDetailView.swift Features/Accounts/Views/StandardAccountView.swift Features/Exchange/ExchangeAccountView.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart commit -m "feat(positions): pass accountIds so crypto/group/standard/exchange chart history"
+```
+
+---
+
+## Task 5: End-to-end store test through a backend
+
+**Files:**
+- Test: `MoolahTests/Shared/MultiInstrumentPositionsAssemblerTests.swift` (extend) or a new `@Suite` file if the type body would exceed the 250-line limit.
+
+**Interfaces:** Consumes `TestBackend` (CloudKitBackend + in-memory GRDB) and a deterministic conversion service / seeded prices.
+
+- [ ] **Step 1: Write the failing end-to-end test**
+
+Through a `TestBackend`, seed: one crypto account holding a non-host token, a buy transaction, and daily prices spanning the range. Fetch via `assembler.fetchTransactions(repository: backend.transactions, accountIds:)`, valuate the rows with `PositionsValuator`, then `assemble(...)`. Assert:
+- `input.historicalValue?.total` is non-empty and its last point's value equals `convert(qty, token, host, on: now)` (exact host quantity).
+- `input.showsChart == true`.
+- For a **group** of two accounts each holding the same token, the aggregate last-day value equals the summed holdings converted — and an internal transfer between the two members does not change the group's last-day value.
+
+- [ ] **Step 2: Run, verify fail, implement nothing new, verify pass**
+
+Run: `just test-mac MultiInstrumentPositionsAssemblerTests 2>&1 | tee .agent-tmp/t5.txt`
+The behavior already exists from Tasks 1–2; this test pins it. If it fails, fix the helper, not the test. Expected after: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart add MoolahTests/Shared/
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart commit -m "test(positions): end-to-end crypto + group history chart"
+```
+
+---
+
+## Task 6: Full verification, reviews, PR
+
+- [ ] **Step 1: Full suite + format**
+
+Run:
+```bash
+just format
+just format-check
+just test 2>&1 | tee .agent-tmp/full.txt
+grep -iE 'failed|error:' .agent-tmp/full.txt || echo "clean"
+```
+Expected: 0 failures on iOS + macOS, format-check clean.
+
+- [ ] **Step 2: Run review agents**
+
+Dispatch `code-review`, `concurrency-review`, `instrument-conversion-review`, and `datetime-review` over the diff. Apply all Critical/Important/Minor findings (separate PR only if genuinely out of scope). The instrument-conversion and datetime agents matter most here (daily conversions over a date axis).
+
+- [ ] **Step 3: Manual smoke via the running app (optional but recommended)**
+
+Use the `automate-app` skill to open a real crypto account and an account group on the dev profile and confirm the chart renders. Do not touch the production profile.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native.crypto-pl-chart push origin crypto-pl-chart:crypto-pl-chart
+gh pr create --title "Show value/P&L history chart for crypto, groups, standard & exchange accounts" --body "<summary + test plan>"
+```
+Then land via the `landing-prs` skill.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** value chart for crypto ✅ (Task 4 + 1–3), account groups ✅ (Set<UUID> in Task 1, `context.accountIds` in Task 4, group test in Task 5), standard & exchange ✅ (Task 4). Cost basis / PL pill ✅ via the assembler (Task 2).
+- **Chart gate:** `showsChart` needs a cost-bearing row when `shouldHide` is false — Task 2 supplies cost basis, so crypto accounts with open non-host positions clear the gate (verified in Task 2 Step 1 + Task 5).
+- **Group internal transfers:** handled by the `Set<UUID>` netting in the builder (value line) and the group-boundary contributions guard (Task 1 Step 3); pinned by tests in Task 1 + Task 5.
+- **Partial-sum safety:** unchanged — `PositionsHistoryBuilder` still omits aggregate points when any contributing conversion fails (Rule 11).
+- **Open risk:** crypto accounts with many tokens × a long range = many daily conversion calls. Mitigated by the price caches (same path investments use). If Task 6 smoke shows a hang, add a perf note / consider sampling — but do not pre-optimize.


### PR DESCRIPTION
## Why

A profit/loss history chart already renders at the top of **stock (investment) account** views, but it never appeared for **crypto accounts, account groups, standard multi-currency accounts, or exchange accounts** — even with full price history available. Root cause: those four hosts share the `multiInstrumentPositionsSplit` path, which hardcoded `historicalValue: nil` (and `costBasis: [:]`), so `PositionsViewInput.showsChart` was always `false`. Only the investment path called `PositionsHistoryBuilder`.

## What

- **Generalised `PositionsHistoryBuilder`** from a single `accountId` to a `Set<UUID>` so account groups aggregate across members, and internal member-to-member transfers net out (value line stays flat across the transfer; contributions exclude internal transfers).
- **Extracted a shared `MultiInstrumentPositionsAssembler`** (fetch transactions → cost-basis snapshot → overlay on rows → build history series → assemble `PositionsViewInput`). The investment store now delegates to it (no behaviour change); the multi-instrument modifier calls it, fetching via `session.backend.transactions` and rebuilding on range change.
- **Passed `accountIds`** from all four call sites (crypto, group, standard, exchange).
- **Value-only chart for held accounts without cost basis.** Crypto wallet tokens received via transfer/airdrop/bridge have no cost basis; the chart now appears for them as a pure value line, with the cost/P&L baseline + gain/loss shading + legend item suppressed (a zero-cost baseline would misleadingly render the whole holding as gain). The P&L pill stays gated on cost basis. The baseline decision is data-driven per chart mode (`showsBaseline(points:mode:)`), so a closed-out/fully-sold account still shows its historical cost line.
- **UTC day bucketing.** The chart's day axis now buckets in UTC with noon-UTC anchored points (`Calendar.utc`, following the `FinancialMonth` positioning-token convention) so output no longer depends on the builder machine's timezone. Range cutoffs (`PositionsTimeRange.cutoff`) stay local — "year to date" / "N months ago" is a now-relative, user-local concept, not a timezoneless carrier. New multi-zone invariance test (LA/UTC/Brisbane/Kiritimati).

## Concurrency / correctness hardening (from review)

- `costBasisSnapshot` throws on cancellation (no partial snapshot); `assemble` runs the cost-basis pass and the history build concurrently via `async let`; cancellation guarded before every `positionsInput` write.

## Testing

- Full iOS + macOS suite green (4176 + 4281 tests, 0 failures); `just format-check` clean.
- New tests: multi-account aggregation + internal-transfer netting; shared assembler (chart shows, Rule 11 cost-basis omission, per-day rate threading); end-to-end crypto + group through `TestBackend`; value-only gate + baseline suppression; multi-zone day-bucketing invariance.
- Reviewed across 7 review passes (datetime, instrument-conversion, concurrency, code-guide, whole-branch, plus per-task gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
