### PR TITLE
Keep AI insight summaries from spelling amounts out in words

### DIFF
--- a/Domain/Insights/Narration/NarrationPromptBuilder.swift
+++ b/Domain/Insights/Narration/NarrationPromptBuilder.swift
@@ -37,6 +37,9 @@ extension NarrationPromptBuilder {
     • Use ONLY the figures provided verbatim in the prompt. Do not invent, recompute, \
     round, or approximate any number. Every figure you write must appear exactly in \
     the supplied facts.
+    • Write every amount exactly as supplied — keep its digits and currency symbol \
+    (for example "$50,000"). Never spell a number out in words ("fifty thousand \
+    dollars") or convert it to any other form.
     • Do not quote fact labels verbatim. Weave the numbers into natural prose. Omit any \
     statistical or technical fact — z-scores, p-values, counts of months, direction \
     labels — those are evidence for you, not for the user.

--- a/MoolahTests/Domain/Insights/NarrationPromptBuilderTests.swift
+++ b/MoolahTests/Domain/Insights/NarrationPromptBuilderTests.swift
@@ -44,6 +44,16 @@ struct NarrationPromptBuilderTests {
   }
 
   @Test
+  func instructionsForbidSpellingAmountsInWords() {
+    let req = NarrationRequest.singleInsight(
+      title: "Net worth crossed $50,000",
+      facts: [InsightFact("Now", "$50,000")])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.instructions.localizedCaseInsensitiveContains("never spell"))
+    #expect(built.instructions.localizedCaseInsensitiveContains("currency symbol"))
+  }
+
+  @Test
   func instructionsRequireOmittingStatisticalFacts() {
     let req = NarrationRequest.singleInsight(
       title: "Test",


### PR DESCRIPTION
## What

Insight headline narration (the on-device AI summary) sometimes rendered figures as words — "fifty thousand dollars" — instead of the supplied numeric form, "$50,000".

## Why

All figures are pre-formatted (currency symbol + locale digits) before they reach the model; the narrator is only meant to weave them into prose verbatim. The system prompt forbade *inventing/recomputing* numbers but said nothing about keeping their written form, so the model was free to spell them out. The numeric-provenance guard only validates digit tokens, so a spelled-out amount slipped through.

## Change

Add one explicit rule to `NarrationPromptBuilder.singleInsightInstructions`: write every amount exactly as supplied — keep its digits and currency symbol — and never spell it out in words or convert it to another form. Adds a test asserting the rule is present in the built instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)