### PR TITLE
Graduate history-chart files off the multiline_arguments disable

### DIFF
--- a/Shared/MultiInstrumentPositionsAssembler.swift
+++ b/Shared/MultiInstrumentPositionsAssembler.swift
@@ -1,8 +1,3 @@
-// `costBasisSnapshot` passes enough labelled parameters to trigger
-// multiline_arguments; scoped to this file rather than reformatting
-// every call site.
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import OSLog
 
@@ -34,7 +29,8 @@ struct MultiInstrumentPositionsAssembler: Sendable {
     while true {
       let result = try await repository.fetch(
         filter: TransactionFilter(accountIds: accountIds),
-        page: page, pageSize: 200
+        page: page,
+        pageSize: 200
       )
       try Task.checkCancellation()
       all.append(contentsOf: result.transactions)
@@ -72,18 +68,24 @@ struct MultiInstrumentPositionsAssembler: Sendable {
       guard !scopedLegs.isEmpty else { continue }
       do {
         let classification = try await TradeEventClassifier.classify(
-          legs: scopedLegs, on: txn.date,
-          hostCurrency: hostCurrency, conversionService: conversionService
+          legs: scopedLegs,
+          on: txn.date,
+          hostCurrency: hostCurrency,
+          conversionService: conversionService
         )
         for buy in classification.buys {
           engine.processBuy(
-            instrument: buy.instrument, quantity: buy.quantity,
-            costPerUnit: buy.costPerUnit, date: txn.date)
+            instrument: buy.instrument,
+            quantity: buy.quantity,
+            costPerUnit: buy.costPerUnit,
+            date: txn.date)
         }
         for sell in classification.sells {
           _ = engine.processSell(
-            instrument: sell.instrument, quantity: sell.quantity,
-            proceedsPerUnit: sell.proceedsPerUnit, date: txn.date)
+            instrument: sell.instrument,
+            quantity: sell.quantity,
+            proceedsPerUnit: sell.proceedsPerUnit,
+            date: txn.date)
         }
       } catch is CancellationError {
         throw CancellationError()
@@ -133,8 +135,11 @@ struct MultiInstrumentPositionsAssembler: Sendable {
       accountIds: context.accountIds,
       hostCurrency: context.hostCurrency)
     let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
-      transactions: transactions, accountIds: context.accountIds,
-      hostCurrency: context.hostCurrency, range: range, now: now)
+      transactions: transactions,
+      accountIds: context.accountIds,
+      hostCurrency: context.hostCurrency,
+      range: range,
+      now: now)
     let costSnapshot: [String: Decimal]
     do {
       costSnapshot = try await snapshotTask
@@ -150,7 +155,9 @@ struct MultiInstrumentPositionsAssembler: Sendable {
     }
     let rowsWithCost = valuedRows.map { row in
       ValuedPosition(
-        instrument: row.instrument, quantity: row.quantity, unitPrice: row.unitPrice,
+        instrument: row.instrument,
+        quantity: row.quantity,
+        unitPrice: row.unitPrice,
         costBasis: costSnapshot[row.instrument.id].map {
           InstrumentAmount(quantity: $0, instrument: context.hostCurrency)
         },

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -1,8 +1,3 @@
-// Reason: the apply() call sites and the per-day point emission both
-// pass enough labelled parameters to trigger multiline_arguments;
-// scoped to this file rather than reformatting every call site.
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import OSLog
 
@@ -65,7 +60,8 @@ struct PositionsHistoryBuilder: Sendable {
     }
 
     let context = BuildContext(
-      sortedTxns: sortedTxns, accountIds: accountIds,
+      sortedTxns: sortedTxns,
+      accountIds: accountIds,
       hostCurrency: hostCurrency)
     var state = BuildState()
     do {
@@ -106,8 +102,11 @@ struct PositionsHistoryBuilder: Sendable {
     now: Date = Date()
   ) async -> HistoricalValueSeries {
     await build(
-      transactions: transactions, accountIds: [accountId],
-      hostCurrency: hostCurrency, range: range, now: now)
+      transactions: transactions,
+      accountIds: [accountId],
+      hostCurrency: hostCurrency,
+      range: range,
+      now: now)
   }
 
   /// Pre-fold any transactions strictly before `start` so the snapshot at
@@ -184,11 +183,17 @@ struct PositionsHistoryBuilder: Sendable {
       let cost = state.engine.openLots(for: instrument)
         .reduce(Decimal(0)) { $0 + $1.remainingCost }
       let value = await convertValue(
-        qty: qty, instrument: instrument, hostCurrency: hostCurrency, on: day)
+        qty: qty,
+        instrument: instrument,
+        hostCurrency: hostCurrency,
+        on: day)
       if let value {
         state.perInstrument[instrument.id, default: []].append(
           HistoricalValueSeries.Point(
-            date: pointDate, value: value, cost: cost, contributions: nil))
+            date: pointDate,
+            value: value,
+            cost: cost,
+            contributions: nil))
         aggValue += value
         aggCost += cost
       } else {
@@ -199,7 +204,9 @@ struct PositionsHistoryBuilder: Sendable {
     if anyHeld && aggOK {
       state.total.append(
         HistoricalValueSeries.Point(
-          date: pointDate, value: aggValue, cost: aggCost,
+          date: pointDate,
+          value: aggValue,
+          cost: aggCost,
           contributions: state.contributions))
     }
     return false
@@ -261,11 +268,8 @@ struct PositionsHistoryBuilder: Sendable {
   /// Their contribution is captured by the cost basis via
   /// `TradeEventClassifier`.
   ///
-  /// Contributions are folded via `AccountCashFlows.flowAmounts(for:)`
-  /// — the same boundary-crossing predicate the
-  /// `AccountPerformanceCalculator` tile path uses, so the chart and
-  /// the tile cannot disagree on a per-flow basis. Throws
-  /// `CancellationError` (and only `CancellationError`); general
+  /// Contributions are folded via `foldContributions(transaction:accountIds:hostCurrency:state:)`.
+  /// Throws `CancellationError` (and only `CancellationError`); general
   /// conversion errors set the sticky latch and stay swallowed.
   private func apply(
     transaction: Transaction,
@@ -282,18 +286,24 @@ struct PositionsHistoryBuilder: Sendable {
 
     do {
       let classification = try await TradeEventClassifier.classify(
-        legs: accountLegs, on: transaction.date,
-        hostCurrency: hostCurrency, conversionService: conversionService
+        legs: accountLegs,
+        on: transaction.date,
+        hostCurrency: hostCurrency,
+        conversionService: conversionService
       )
       for buy in classification.buys {
         state.engine.processBuy(
-          instrument: buy.instrument, quantity: buy.quantity,
-          costPerUnit: buy.costPerUnit, date: transaction.date)
+          instrument: buy.instrument,
+          quantity: buy.quantity,
+          costPerUnit: buy.costPerUnit,
+          date: transaction.date)
       }
       for sell in classification.sells {
         _ = state.engine.processSell(
-          instrument: sell.instrument, quantity: sell.quantity,
-          proceedsPerUnit: sell.proceedsPerUnit, date: transaction.date)
+          instrument: sell.instrument,
+          quantity: sell.quantity,
+          proceedsPerUnit: sell.proceedsPerUnit,
+          date: transaction.date)
       }
     } catch is CancellationError {
       throw CancellationError()
@@ -308,10 +318,35 @@ struct PositionsHistoryBuilder: Sendable {
       )
     }
 
-    // Contributions fold (sticky latch — see BuildState docs).
-    // A flow counts for the group only if the transaction touches exactly
-    // one member of `accountIds` (single member → external counterpart).
-    // Touching ≥2 members means an internal transfer → excluded.
+    try await foldContributions(
+      transaction: transaction,
+      accountIds: accountIds,
+      hostCurrency: hostCurrency,
+      state: &state)
+  }
+
+}
+
+// MARK: - Contributions folding
+
+extension PositionsHistoryBuilder {
+  /// Fold cash-flow contributions for one transaction into the running total
+  /// (sticky latch — see `BuildState` docs).
+  ///
+  /// A flow counts for the group only if the transaction touches exactly one
+  /// member of `accountIds` (single member → external counterpart). Touching
+  /// ≥2 members means an internal transfer → excluded. Uses
+  /// `AccountCashFlows.flowAmounts(for:)` — the same boundary-crossing
+  /// predicate `AccountPerformanceCalculator` uses, so the chart and the tile
+  /// cannot disagree on a per-flow basis. Throws `CancellationError` (and
+  /// only `CancellationError`); general conversion errors latch
+  /// `state.contributions` to `nil` and stay swallowed.
+  private func foldContributions(
+    transaction: Transaction,
+    accountIds: Set<UUID>,
+    hostCurrency: Instrument,
+    state: inout BuildState
+  ) async throws {
     guard let running = state.contributions else { return }
     let membersTouched = Set(transaction.legs.compactMap(\.accountId)).intersection(accountIds)
     guard membersTouched.count == 1, let member = membersTouched.first else {
@@ -319,8 +354,10 @@ struct PositionsHistoryBuilder: Sendable {
     }
     do {
       let amounts = try await AccountCashFlows.flowAmounts(
-        for: transaction, accountId: member,
-        hostCurrency: hostCurrency, service: conversionService
+        for: transaction,
+        accountId: member,
+        hostCurrency: hostCurrency,
+        service: conversionService
       )
       if !amounts.isEmpty {
         state.contributions = running + amounts.reduce(0, +)


### PR DESCRIPTION
## Why

Follow-up to the multi-instrument history chart work. Two of the files we created/rewrote there carried a file-level `// swiftlint:disable multiline_arguments`. Per the project's own `.swiftlint.yml` policy, that rule is *enabled* and files are meant to "graduate piecemeal as they're refactored" — so files we just rewrote should comply rather than keep the transitional suppression.

`swift-format` tolerates one-argument-per-line layouts (it won't repack them), so the files can genuinely comply: each wrapped call is expanded to one argument per line and the disable removed. Verified empirically before doing it.

## What

- `Shared/MultiInstrumentPositionsAssembler.swift` — removed the disable; expanded 7 wrapped call sites to one-arg-per-line.
- `Shared/PositionsHistoryBuilder.swift` — removed the disable; expanded 8 call sites. The expansion pushed `apply()` past `function_body_length` (50), so the contributions-folding logic was extracted into a `foldContributions(...)` helper (a clean semantic unit: boundary-crossing predicate + sticky latch), which also keeps the type under `type_body_length`.

Pure formatting + one semantic extraction — no behavior change. `.swiftlint.yml` is untouched (no threshold bumps, no baseline). The other ~26 pre-existing files that carry this disable are out of scope.

## Testing

- `just format-check` clean (zero `multiline_arguments` violations, no new violations of any rule).
- Full iOS + macOS suite green, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
