### PR TITLE
style: graduate all remaining files off the multiline_arguments disable

### DIFF
--- a/Features/Accounts/Views/CreateAccountView.swift
+++ b/Features/Accounts/Views/CreateAccountView.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 struct CreateAccountView: View {
@@ -135,7 +133,8 @@ struct CreateAccountView: View {
     InstrumentPickerField(label: "Currency", kinds: [.fiatCurrency], selection: $currency)
 
     TextField(
-      "Initial Balance", value: $balanceDecimal,
+      "Initial Balance",
+      value: $balanceDecimal,
       format: .number.precision(.fractionLength(currency.decimals))
     )
     .monospacedDigit()
@@ -214,7 +213,8 @@ struct CreateAccountView: View {
 
   private func submitCrypto() async {
     let logic = CryptoAccountCreationLogic(
-      accountStore: accountStore, cryptoSyncStore: cryptoSyncStore,
+      accountStore: accountStore,
+      cryptoSyncStore: cryptoSyncStore,
       accountInstrument: instrument)
     let outcome = await logic.submit(
       name: name, chain: cryptoChain, walletAddressInput: cryptoWalletAddress)

--- a/Features/Accounts/Views/StandardAccountView.swift
+++ b/Features/Accounts/Views/StandardAccountView.swift
@@ -10,12 +10,6 @@
 // with no behaviour of their own. See `guides/UI_GUIDE.md` §3 for the
 // per-leaf-leaf-view pattern these implement.
 
-// Reason: SwiftUI declarative chains and the Transaction-leg seeding
-// helpers at the bottom wrap arguments across multiple lines for
-// readability; enforcing the rule would fight the formatter and the
-// SwiftUI idiom without improving clarity.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 /// Detail view for bank, asset, and other non-investment, non-crypto
@@ -83,13 +77,15 @@ private func seedStandardAccountPreview(
 ) async {
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date(), payee: "Woolworths",
+      date: Date(),
+      payee: "Woolworths",
       legs: [
         TransactionLeg(accountId: accountId, instrument: .AUD, quantity: -50.23, type: .expense)
       ]))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date().addingTimeInterval(-86400), payee: "Employer",
+      date: Date().addingTimeInterval(-86400),
+      payee: "Employer",
       legs: [
         TransactionLeg(accountId: accountId, instrument: .AUD, quantity: 3500, type: .income)
       ]))
@@ -99,7 +95,10 @@ private func seedStandardAccountPreview(
 #Preview {
   let accountId = UUID()
   let account = Account(
-    id: accountId, name: "Checking", type: .bank, instrument: .AUD,
+    id: accountId,
+    name: "Checking",
+    type: .bank,
+    instrument: .AUD,
     positions: [Position(instrument: .AUD, quantity: 3449.77)])
   let backend = PreviewBackend.create()
   let store = TransactionStore(

--- a/Features/Earmarks/Views/EarmarkDetailView.swift
+++ b/Features/Earmarks/Views/EarmarkDetailView.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 struct EarmarkDetailView: View {
@@ -206,18 +204,26 @@ private func seedEarmarkDetailPreview(
   _ = try? await backend.earmarks.create(earmark)
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date(), payee: "Flight Booking",
+      date: Date(),
+      payee: "Flight Booking",
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: .AUD, quantity: -50.23, type: .expense,
+          accountId: accountId,
+          instrument: .AUD,
+          quantity: -50.23,
+          type: .expense,
           earmarkId: earmark.id)
       ]))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date().addingTimeInterval(-86400), payee: "Savings Transfer",
+      date: Date().addingTimeInterval(-86400),
+      payee: "Savings Transfer",
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: .AUD, quantity: 500, type: .income,
+          accountId: accountId,
+          instrument: .AUD,
+          quantity: 500,
+          type: .income,
           earmarkId: earmark.id)
       ]))
   // No `earmarkStore.load()` — the reactive store subscribes in init.

--- a/Features/Import/ImportRuleStore.swift
+++ b/Features/Import/ImportRuleStore.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import OSLog
 import Observation
@@ -237,8 +235,10 @@ final class ImportRuleStore {
             date: transaction.date,
             legs: transaction.legs.map {
               ParsedLeg(
-                accountId: $0.accountId, instrument: $0.instrument,
-                quantity: $0.quantity, type: $0.type)
+                accountId: $0.accountId,
+                instrument: $0.instrument,
+                quantity: $0.quantity,
+                type: $0.type)
             },
             rawRow: [],
             rawDescription: origin.rawDescription,
@@ -293,8 +293,10 @@ final class ImportRuleStore {
           date: transaction.date,
           legs: transaction.legs.map {
             ParsedLeg(
-              accountId: $0.accountId, instrument: $0.instrument,
-              quantity: $0.quantity, type: $0.type)
+              accountId: $0.accountId,
+              instrument: $0.instrument,
+              quantity: $0.quantity,
+              type: $0.type)
           },
           rawRow: [],
           rawDescription: origin.rawDescription,

--- a/Features/Import/ImportStore+Pipeline.swift
+++ b/Features/Import/ImportStore+Pipeline.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import OSLog
 import os
@@ -86,11 +84,15 @@ extension ImportStore {
   func tokenize(_ data: Data) throws -> [[String]] {
     let tokenizeSignpost = OSSignpostID(log: Signposts.importPipeline)
     os_signpost(
-      .begin, log: Signposts.importPipeline, name: "tokenize",
+      .begin,
+      log: Signposts.importPipeline,
+      name: "tokenize",
       signpostID: tokenizeSignpost)
     defer {
       os_signpost(
-        .end, log: Signposts.importPipeline, name: "tokenize",
+        .end,
+        log: Signposts.importPipeline,
+        name: "tokenize",
         signpostID: tokenizeSignpost)
     }
     do {
@@ -114,7 +116,8 @@ extension ImportStore {
   ) async throws -> ParseOutcome {
     let parser = registry.select(for: headers)
     let profileForOverride = try? await preExistingProfile(
-      parserIdentifier: parser.identifier, headers: headers,
+      parserIdentifier: parser.identifier,
+      headers: headers,
       forcedAccountId: source.forcedAccountId)
     let dateFormatOverride = profileForOverride?.dateFormatRawValue
       .flatMap(GenericBankCSVParser.DateFormat.fromRawValue)
@@ -137,7 +140,8 @@ extension ImportStore {
     }()
 
     let records = try runParse(
-      parser: parser, rows: rows,
+      parser: parser,
+      rows: rows,
       columnMappingOverride: columnMappingOverride,
       dateFormatOverride: dateFormatOverride)
     let candidates = records.compactMap { record -> ParsedTransaction? in
@@ -188,7 +192,8 @@ extension ImportStore {
     }
     let existingPage = try await backend.transactions.fetch(
       filter: TransactionFilter(accountId: accountId),
-      page: 0, pageSize: 1000)
+      page: 0,
+      pageSize: 1000)
     return CSVDeduplicator.filter(
       candidates,
       against: existingPage.transactions,

--- a/Features/Import/ImportStore+ProfileResolution.swift
+++ b/Features/Import/ImportStore+ProfileResolution.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
 // Profile-matching and column-mapping-rebuild helpers for `ImportStore`.
@@ -73,7 +71,8 @@ extension ImportStore {
     for profile in candidateProfiles {
       let page = try await backend.transactions.fetch(
         filter: TransactionFilter(accountId: profile.accountId),
-        page: 0, pageSize: 1000)
+        page: 0,
+        pageSize: 1000)
       existingByAccount[profile.accountId] = page.transactions
     }
     let matcherInput = MatcherInput(

--- a/Features/Import/ImportStore+Transactions.swift
+++ b/Features/Import/ImportStore+Transactions.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import OSLog
 
@@ -102,13 +100,15 @@ extension ImportStore {
         instrument: cash.instrument,
         quantity: -abs(cash.quantity),
         type: .transfer,
-        categoryId: nil, earmarkId: nil),
+        categoryId: nil,
+        earmarkId: nil),
       TransactionLeg(
         accountId: toAccountId,
         instrument: destinationInstrument,
         quantity: abs(cash.quantity),
         type: .transfer,
-        categoryId: nil, earmarkId: nil),
+        categoryId: nil,
+        earmarkId: nil),
     ]
   }
 

--- a/Features/Import/ImportStore+WebReview.swift
+++ b/Features/Import/ImportStore+WebReview.swift
@@ -1,8 +1,3 @@
-// swiftlint:disable multiline_arguments
-// Reason: swift-format wraps long os_signpost and resolveProfile calls in
-// ways the multiline_arguments rule disagrees with; matching the existing
-// disable+reason pattern from MoolahApp+Setup.swift.
-
 import Foundation
 import ImportExtensionKit
 import OSLog
@@ -29,11 +24,15 @@ extension ImportStore {
   ) async throws -> ImportSessionResult {
     let pipelineSignpost = OSSignpostID(log: Signposts.importPipeline)
     os_signpost(
-      .begin, log: Signposts.importPipeline, name: "ingestWeb",
+      .begin,
+      log: Signposts.importPipeline,
+      name: "ingestWeb",
       signpostID: pipelineSignpost)
     defer {
       os_signpost(
-        .end, log: Signposts.importPipeline, name: "ingestWeb",
+        .end,
+        log: Signposts.importPipeline,
+        name: "ingestWeb",
         signpostID: pipelineSignpost)
     }
 
@@ -91,13 +90,15 @@ extension ImportStore {
       guard let date = Self.parseWebDate(row.date) else {
         throw IngestError.parse(
           .malformedRow(
-            index: rowIndex, reason: "invalid date: \(row.date)",
+            index: rowIndex,
+            reason: "invalid date: \(row.date)",
             row: Self.rawRow(from: row)))
       }
       guard let amount = Self.parseWebAmount(row.amount) else {
         throw IngestError.parse(
           .malformedRow(
-            index: rowIndex, reason: "invalid amount: \(row.amount)",
+            index: rowIndex,
+            reason: "invalid amount: \(row.amount)",
             row: Self.rawRow(from: row)))
       }
       let balance = row.balance.flatMap { Self.parseWebAmount($0) }

--- a/Features/Import/Views/RecentlyAddedNeedsSetupPanel.swift
+++ b/Features/Import/Views/RecentlyAddedNeedsSetupPanel.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 // Needs Setup / Failed Files panel for the Recently Added screen, with its
@@ -64,8 +62,10 @@ struct RecentlyAddedPendingRow: View {
         // don't wipe user-entered form state. Held in @State for stability
         // across sheet dismiss/show cycles.
         setupStore = CSVImportSetupStore(
-          pending: file, backend: backend,
-          importStore: importStore, staging: staging)
+          pending: file,
+          backend: backend,
+          importStore: importStore,
+          staging: staging)
       }
       .buttonStyle(.borderless)
       Button("Dismiss") {

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 /// Main Reports view displaying income and expense breakdown by category.
@@ -171,26 +169,38 @@ private func seedReportsPreview(
   _ = try? await backend.categories.create(Category(id: ids.rentId, name: "Rent"))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date(), payee: "Employer",
+      date: Date(),
+      payee: "Employer",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: .AUD, quantity: 4500, type: .income,
+          accountId: account.id,
+          instrument: .AUD,
+          quantity: 4500,
+          type: .income,
           categoryId: ids.salaryId)
       ]))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date().addingTimeInterval(-86400), payee: "Supermarket",
+      date: Date().addingTimeInterval(-86400),
+      payee: "Supermarket",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: .AUD, quantity: -220, type: .expense,
+          accountId: account.id,
+          instrument: .AUD,
+          quantity: -220,
+          type: .expense,
           categoryId: ids.groceriesId)
       ]))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date().addingTimeInterval(-2 * 86400), payee: "Landlord",
+      date: Date().addingTimeInterval(-2 * 86400),
+      payee: "Landlord",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: .AUD, quantity: -1800, type: .expense,
+          accountId: account.id,
+          instrument: .AUD,
+          quantity: -1800,
+          type: .expense,
           categoryId: ids.rentId)
       ]))
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailView+Previews.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailView+Previews.swift
@@ -1,10 +1,3 @@
-// swift-format wraps `TransactionLeg(...)` calls with one argument per line
-// inside these previews; SwiftLint's multiline_arguments rule (which
-// expects "all on one line OR one per line including the first") then
-// trips on the formatter's chosen style. The formatter wins per project
-// policy (.swift-format is the layout source of truth), so suppress here.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 @MainActor
@@ -46,23 +39,33 @@ private func previewStore() -> TransactionStore {
   }
 }
 
+private func customTransaction(accountId1: UUID, accountId2: UUID) -> Transaction {
+  Transaction(
+    date: Date(),
+    payee: "Split Purchase",
+    legs: [
+      TransactionLeg(
+        accountId: accountId1,
+        instrument: .AUD,
+        quantity: -30.00,
+        type: .expense,
+        categoryId: nil),
+      TransactionLeg(
+        accountId: accountId2,
+        instrument: .AUD,
+        quantity: -20.00,
+        type: .expense,
+        categoryId: nil),
+    ]
+  )
+}
+
 #Preview("Custom Transaction") {
   let accountId1 = UUID()
   let accountId2 = UUID()
   return NavigationStack {
     TransactionDetailView(
-      transaction: Transaction(
-        date: Date(),
-        payee: "Split Purchase",
-        legs: [
-          TransactionLeg(
-            accountId: accountId1, instrument: .AUD, quantity: -30.00, type: .expense,
-            categoryId: nil),
-          TransactionLeg(
-            accountId: accountId2, instrument: .AUD, quantity: -20.00, type: .expense,
-            categoryId: nil),
-        ]
-      ),
+      transaction: customTransaction(accountId1: accountId1, accountId2: accountId2),
       accounts: Accounts(from: [
         Account(id: accountId1, name: "Checking", type: .bank, instrument: .AUD),
         Account(id: accountId2, name: "Credit Card", type: .creditCard, instrument: .AUD),
@@ -87,7 +90,10 @@ private func previewStore() -> TransactionStore {
         date: Date(),
         legs: [
           TransactionLeg(
-            accountId: nil, instrument: .AUD, quantity: 500, type: .income,
+            accountId: nil,
+            instrument: .AUD,
+            quantity: 500,
+            type: .income,
             earmarkId: earmarkId)
         ]
       ),

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 struct TransactionFilterView: View {
@@ -249,7 +247,10 @@ struct TransactionFilterView: View {
 
   let accounts = Accounts(from: [
     Account(
-      id: accountId, name: "Checking", type: .bank, instrument: .AUD,
+      id: accountId,
+      name: "Checking",
+      type: .bank,
+      instrument: .AUD,
       positions: [Position(instrument: .AUD, quantity: 2449.77)]
     )
   ])

--- a/Features/Transactions/Views/TransactionListView+Create.swift
+++ b/Features/Transactions/Views/TransactionListView+Create.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 extension TransactionListView {
@@ -30,7 +28,10 @@ extension TransactionListView {
         payee: "",
         legs: [
           TransactionLeg(
-            accountId: nil, instrument: instrument, quantity: 0, type: .income,
+            accountId: nil,
+            instrument: instrument,
+            quantity: 0,
+            type: .income,
             earmarkId: earmarkId)
         ]
       )

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -1,7 +1,3 @@
-// Multi-argument SwiftUI modifier chains here require wrapping
-// that would otherwise trip multiline_arguments.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 extension TransactionListView {
@@ -264,9 +260,13 @@ extension TransactionListView {
   private func transactionRow(for entry: TransactionWithBalance) -> some View {
     let scheduled = scheduledRowConfig(for: entry)
     TransactionRowView(
-      transaction: entry.transaction, accounts: accounts,
-      categories: categories, earmarks: earmarks, displayAmounts: entry.displayAmounts,
-      balance: entry.balance, scopeReferenceInstrument: scopeReferenceInstrument,
+      transaction: entry.transaction,
+      accounts: accounts,
+      categories: categories,
+      earmarks: earmarks,
+      displayAmounts: entry.displayAmounts,
+      balance: entry.balance,
+      scopeReferenceInstrument: scopeReferenceInstrument,
       hideEarmark: filter.earmarkId != nil,
       accountContext: accountContext(for: entry.transaction),
       isOverdue: scheduled?.isOverdue ?? false,

--- a/Features/Transactions/Views/TransactionListView+Preview.swift
+++ b/Features/Transactions/Views/TransactionListView+Preview.swift
@@ -1,8 +1,3 @@
-// Reason: SwiftUI declarative chains (List, ForEach, modifier groups) wrap
-// arguments across multiple lines for readability; enforcing the rule would
-// fight the formatter and the SwiftUI idiom without improving clarity.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 @MainActor
@@ -14,13 +9,15 @@ private func seedTransactionListPreview(
 ) async {
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date(), payee: "Woolworths",
+      date: Date(),
+      payee: "Woolworths",
       legs: [
         TransactionLeg(accountId: accountId, instrument: .AUD, quantity: -50.23, type: .expense)
       ]))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: Date().addingTimeInterval(-86400), payee: "Employer",
+      date: Date().addingTimeInterval(-86400),
+      payee: "Employer",
       legs: [
         TransactionLeg(accountId: accountId, instrument: .AUD, quantity: 3500, type: .income)
       ]))
@@ -34,18 +31,27 @@ private func seedTransactionListPreview(
   await store.load(filter: TransactionFilter(accountId: accountId))
 }
 
+private func previewAccounts(checkingId: UUID, savingsId: UUID) -> Accounts {
+  Accounts(from: [
+    Account(
+      id: checkingId,
+      name: "Checking",
+      type: .bank,
+      instrument: .AUD,
+      positions: [Position(instrument: .AUD, quantity: 2449.77)]),
+    Account(
+      id: savingsId,
+      name: "Savings",
+      type: .bank,
+      instrument: .AUD,
+      positions: [Position(instrument: .AUD, quantity: 5000)]),
+  ])
+}
+
 #Preview {
   let accountId = UUID()
   let savingsId = UUID()
-  let account = Account(
-    id: accountId, name: "Checking", type: .bank, instrument: .AUD,
-    positions: [Position(instrument: .AUD, quantity: 2449.77)])
-  let accounts = Accounts(from: [
-    account,
-    Account(
-      id: savingsId, name: "Savings", type: .bank, instrument: .AUD,
-      positions: [Position(instrument: .AUD, quantity: 5000)]),
-  ])
+  let accounts = previewAccounts(checkingId: accountId, savingsId: savingsId)
   let backend = PreviewBackend.create()
   let store = TransactionStore(
     repository: backend.transactions,
@@ -53,14 +59,19 @@ private func seedTransactionListPreview(
     targetInstrument: .AUD)
   return NavigationStack {
     TransactionListView(
-      title: account.name, filter: TransactionFilter(accountId: accountId),
-      accounts: accounts, categories: Categories(from: []),
+      title: "Checking",
+      filter: TransactionFilter(accountId: accountId),
+      accounts: accounts,
+      categories: Categories(from: []),
       earmarks: Earmarks(from: []),
       transactionStore: store)
   }
   .previewProfileEnvironment()
   .task {
     await seedTransactionListPreview(
-      backend: backend, accountId: accountId, savingsId: savingsId, store: store)
+      backend: backend,
+      accountId: accountId,
+      savingsId: savingsId,
+      store: store)
   }
 }

--- a/Features/Transactions/Views/TransactionRowView+Preview.swift
+++ b/Features/Transactions/Views/TransactionRowView+Preview.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 // File-private namespace satisfies the SwiftLint `file_name` rule which
@@ -13,13 +11,19 @@ private struct PreviewData {
   let groceriesId = UUID()
   let holidayFundId = UUID()
   let scam = Instrument.crypto(
-    chainId: 1, contractAddress: "0xdeadbeef", symbol: "SCAM",
-    name: "Scam Token", decimals: 18)
+    chainId: 1,
+    contractAddress: "0xdeadbeef",
+    symbol: "SCAM",
+    name: "Scam Token",
+    decimals: 18)
 
   var accounts: Accounts {
     Accounts(from: [
       Account(
-        id: savingsId, name: "Savings", type: .bank, instrument: .AUD,
+        id: savingsId,
+        name: "Savings",
+        type: .bank,
+        instrument: .AUD,
         positions: [Position(instrument: .AUD, quantity: 5000)])
     ])
   }
@@ -63,12 +67,17 @@ private func previewRow(
   pendingPayId: Transaction.ID? = nil
 ) -> TransactionRowView {
   let transaction = Transaction(
-    id: id, date: date, payee: payee ?? "",
-    recurPeriod: recurPeriod, recurEvery: recurEvery,
+    id: id,
+    date: date,
+    payee: payee ?? "",
+    recurPeriod: recurPeriod,
+    recurEvery: recurEvery,
     legs: legs)
   return TransactionRowView(
     transaction: transaction,
-    accounts: data.accounts, categories: data.categories, earmarks: data.earmarks,
+    accounts: data.accounts,
+    categories: data.categories,
+    earmarks: data.earmarks,
     displayAmounts: displayAmounts,
     balance: InstrumentAmount(quantity: balance, instrument: .AUD),
     scopeReferenceInstrument: scopeReferenceInstrument,
@@ -89,7 +98,10 @@ private func simplePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
       payee: "Woolworths",
       legs: [
         TransactionLeg(
-          accountId: data.sourceId, instrument: .AUD, quantity: -50.23, type: .expense,
+          accountId: data.sourceId,
+          instrument: .AUD,
+          quantity: -50.23,
+          type: .expense,
           categoryId: data.groceriesId)
       ],
       displayAmounts: [InstrumentAmount(quantity: -50.23, instrument: .AUD)],
@@ -98,7 +110,10 @@ private func simplePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
       payee: "Employer Pty Ltd",
       legs: [
         TransactionLeg(
-          accountId: data.sourceId, instrument: .AUD, quantity: 3500, type: .income,
+          accountId: data.sourceId,
+          instrument: .AUD,
+          quantity: 3500,
+          type: .income,
           earmarkId: data.holidayFundId)
       ],
       displayAmounts: [InstrumentAmount(quantity: 3500, instrument: .AUD)],
@@ -112,7 +127,8 @@ private func simplePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
           accountId: data.savingsId, instrument: .AUD, quantity: 1000, type: .transfer),
       ],
       displayAmounts: [InstrumentAmount(quantity: -1000, instrument: .AUD)],
-      balance: -2449.77, accountContext: data.sourceId),
+      balance: -2449.77,
+      accountContext: data.sourceId),
     PreviewRowSpec(
       payee: "Rent Split",
       legs: [
@@ -122,7 +138,8 @@ private func simplePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
           accountId: data.savingsId, instrument: .AUD, quantity: 500, type: .transfer),
       ],
       displayAmounts: [InstrumentAmount(quantity: -500, instrument: .AUD)],
-      balance: -1449.77, accountContext: data.sourceId),
+      balance: -1449.77,
+      accountContext: data.sourceId),
   ]
 }
 
@@ -143,7 +160,8 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
         InstrumentAmount(quantity: 950, instrument: .AUD),
         InstrumentAmount(quantity: -50, instrument: .AUD),
       ],
-      balance: -2499.77, accountContext: data.sourceId),
+      balance: -2499.77,
+      accountContext: data.sourceId),
     PreviewRowSpec(
       payee: "",
       legs: [
@@ -156,7 +174,8 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
         InstrumentAmount(quantity: -100, instrument: .AUD),
         InstrumentAmount(quantity: 1_000_000, instrument: data.scam),
       ],
-      balance: -1_549.77, accountContext: data.sourceId),
+      balance: -1_549.77,
+      accountContext: data.sourceId),
   ]
 }
 
@@ -165,8 +184,11 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
   return List {
     ForEach(Array(previewRowSpecs(data: data).enumerated()), id: \.offset) { _, spec in
       previewRow(
-        data: data, payee: spec.payee, legs: spec.legs,
-        displayAmounts: spec.displayAmounts, balance: spec.balance,
+        data: data,
+        payee: spec.payee,
+        legs: spec.legs,
+        displayAmounts: spec.displayAmounts,
+        balance: spec.balance,
         accountContext: spec.accountContext)
     }
   }
@@ -177,7 +199,8 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
 private func overdueScheduledRow(data: PreviewData) -> TransactionRowView {
   let overdueDate = Calendar.current.date(byAdding: .day, value: -3, to: Date()) ?? Date()
   return previewRow(
-    data: data, payee: "Rent",
+    data: data,
+    payee: "Rent",
     legs: [
       TransactionLeg(
         accountId: data.sourceId, instrument: .AUD, quantity: -2000, type: .expense)
@@ -185,7 +208,8 @@ private func overdueScheduledRow(data: PreviewData) -> TransactionRowView {
     displayAmounts: [InstrumentAmount(quantity: -2000, instrument: .AUD)],
     balance: 1000,
     date: overdueDate,
-    recurPeriod: .month, recurEvery: 1,
+    recurPeriod: .month,
+    recurEvery: 1,
     isOverdue: true,
     onPay: {})
 }
@@ -193,14 +217,16 @@ private func overdueScheduledRow(data: PreviewData) -> TransactionRowView {
 @MainActor
 private func dueTodayScheduledRow(data: PreviewData) -> TransactionRowView {
   previewRow(
-    data: data, payee: "Internet",
+    data: data,
+    payee: "Internet",
     legs: [
       TransactionLeg(
         accountId: data.sourceId, instrument: .AUD, quantity: -150, type: .expense)
     ],
     displayAmounts: [InstrumentAmount(quantity: -150, instrument: .AUD)],
     balance: 850,
-    recurPeriod: .month, recurEvery: 1,
+    recurPeriod: .month,
+    recurEvery: 1,
     isDueToday: true,
     onPay: {})
 }
@@ -208,14 +234,16 @@ private func dueTodayScheduledRow(data: PreviewData) -> TransactionRowView {
 @MainActor
 private func payAffordanceScheduledRow(data: PreviewData) -> TransactionRowView {
   previewRow(
-    data: data, payee: "Phone",
+    data: data,
+    payee: "Phone",
     legs: [
       TransactionLeg(
         accountId: data.sourceId, instrument: .AUD, quantity: -75, type: .expense)
     ],
     displayAmounts: [InstrumentAmount(quantity: -75, instrument: .AUD)],
     balance: 775,
-    recurPeriod: .month, recurEvery: 1,
+    recurPeriod: .month,
+    recurEvery: 1,
     onPay: {})
 }
 
@@ -224,14 +252,17 @@ private func payingScheduledRow(
   data: PreviewData, pendingId: UUID
 ) -> TransactionRowView {
   previewRow(
-    data: data, id: pendingId, payee: "Insurance",
+    data: data,
+    id: pendingId,
+    payee: "Insurance",
     legs: [
       TransactionLeg(
         accountId: data.sourceId, instrument: .AUD, quantity: -200, type: .expense)
     ],
     displayAmounts: [InstrumentAmount(quantity: -200, instrument: .AUD)],
     balance: 575,
-    recurPeriod: .month, recurEvery: 1,
+    recurPeriod: .month,
+    recurEvery: 1,
     onPay: {},
     pendingPayId: pendingId)
 }

--- a/Features/Transactions/Views/UpcomingView.swift
+++ b/Features/Transactions/Views/UpcomingView.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 struct UpcomingView: View {
@@ -83,20 +81,30 @@ private func previewSeedTransactions(
 
   _ = try? await backend.transactions.create(
     Transaction(
-      date: overdue, payee: "Rent",
-      recurPeriod: .month, recurEvery: 1,
+      date: overdue,
+      payee: "Rent",
+      recurPeriod: .month,
+      recurEvery: 1,
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: .AUD, quantity: -2000, type: .expense,
+          accountId: accountId,
+          instrument: .AUD,
+          quantity: -2000,
+          type: .expense,
           categoryId: categoryId)
       ]))
   _ = try? await backend.transactions.create(
     Transaction(
-      date: upcoming, payee: "Internet",
-      recurPeriod: .month, recurEvery: 1,
+      date: upcoming,
+      payee: "Internet",
+      recurPeriod: .month,
+      recurEvery: 1,
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: .AUD, quantity: -150, type: .expense,
+          accountId: accountId,
+          instrument: .AUD,
+          quantity: -150,
+          type: .expense,
           categoryId: categoryId)
       ]))
   await store.load(filter: TransactionFilter(scheduled: .scheduledOnly))
@@ -107,7 +115,10 @@ private func previewSeedTransactions(
   let categoryId = UUID()
   let accounts = Accounts(from: [
     Account(
-      id: accountId, name: "Checking", type: .bank, instrument: .AUD,
+      id: accountId,
+      name: "Checking",
+      type: .bank,
+      instrument: .AUD,
       positions: [Position(instrument: .AUD, quantity: 2449.77)])
   ])
   let categories = Categories(from: [
@@ -120,8 +131,10 @@ private func previewSeedTransactions(
     targetInstrument: .AUD)
   return NavigationStack {
     UpcomingView(
-      accounts: accounts, categories: categories,
-      earmarks: Earmarks(from: []), transactionStore: store)
+      accounts: accounts,
+      categories: categories,
+      earmarks: Earmarks(from: []),
+      transactionStore: store)
   }
   .previewProfileEnvironment()
   .task {

--- a/Shared/CSVImport/SelfWealthCashReportParser.swift
+++ b/Shared/CSVImport/SelfWealthCashReportParser.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
 /// Parser for SelfWealth's "Cash Report" — pure cash-flow ledger.
@@ -113,7 +111,8 @@ struct SelfWealthCashReportParser: CSVParser, Sendable {
 
     let isDividend =
       Self.dividendRegex.regex.firstMatch(
-        in: comment, options: [],
+        in: comment,
+        options: [],
         range: NSRange(comment.startIndex..., in: comment)) != nil
     let bankReference: String? = isDividend ? comment : nil
 
@@ -131,8 +130,12 @@ struct SelfWealthCashReportParser: CSVParser, Sendable {
 
     return .transaction(
       ParsedTransaction(
-        date: date, legs: [leg], rawRow: row,
-        rawDescription: comment, rawAmount: amount, rawBalance: balance,
+        date: date,
+        legs: [leg],
+        rawRow: row,
+        rawDescription: comment,
+        rawAmount: amount,
+        rawBalance: balance,
         bankReference: bankReference))
   }
 

--- a/Shared/CSVImport/SelfWealthMovementsParser.swift
+++ b/Shared/CSVImport/SelfWealthMovementsParser.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
 /// Parser for SelfWealth's "Movements" report — positions and trades only.
@@ -79,8 +77,12 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
       throw CSVParserError.headerMismatch
     }
     return Columns(
-      tradeDate: tradeDate, action: action, reference: reference, code: code,
-      name: findOptional("name"), units: units,
+      tradeDate: tradeDate,
+      action: action,
+      reference: reference,
+      code: code,
+      name: findOptional("name"),
+      units: units,
       consideration: findOptional("consideration"),
       brokerage: findOptional("brokerage"))
   }
@@ -124,8 +126,13 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
     }
 
     let context = RowContext(
-      row: row, rowIndex: rowIndex, columns: columns, date: date,
-      code: code, units: units, reference: reference,
+      row: row,
+      rowIndex: rowIndex,
+      columns: columns,
+      date: date,
+      code: code,
+      units: units,
+      reference: reference,
       rawDescription: "\(action) \(code) \(name)".trimmingCharacters(in: .whitespaces))
 
     switch action.lowercased() {
@@ -144,7 +151,8 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
     let brokerageField = SelfWealthCSVParsing.safe(context.row, context.columns.brokerage)
     guard let consideration = SelfWealthCSVParsing.parseDecimal(considerationField) else {
       throw CSVParserError.malformedRow(
-        index: context.rowIndex, reason: "invalid consideration: \(considerationField)",
+        index: context.rowIndex,
+        reason: "invalid consideration: \(considerationField)",
         row: context.row)
     }
     let brokerage = SelfWealthCSVParsing.parseDecimal(brokerageField) ?? 0
@@ -153,24 +161,35 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
 
     var legs = [
       ParsedLeg(
-        accountId: nil, instrument: .AUD, quantity: cashAmount,
-        type: .trade, isInstrumentPlaceholder: true),
+        accountId: nil,
+        instrument: .AUD,
+        quantity: cashAmount,
+        type: .trade,
+        isInstrumentPlaceholder: true),
       ParsedLeg(
-        accountId: nil, instrument: stockInstrument,
+        accountId: nil,
+        instrument: stockInstrument,
         quantity: isBuy ? context.units : -context.units,
-        type: .trade, isInstrumentPlaceholder: false),
+        type: .trade,
+        isInstrumentPlaceholder: false),
     ]
     if brokerage > 0 {
       legs.append(
         ParsedLeg(
-          accountId: nil, instrument: .AUD, quantity: -brokerage,
-          type: .expense, isInstrumentPlaceholder: true))
+          accountId: nil,
+          instrument: .AUD,
+          quantity: -brokerage,
+          type: .expense,
+          isInstrumentPlaceholder: true))
     }
     return .transaction(
       ParsedTransaction(
-        date: context.date, legs: legs, rawRow: context.row,
+        date: context.date,
+        legs: legs,
+        rawRow: context.row,
         rawDescription: context.rawDescription,
-        rawAmount: cashAmount, rawBalance: nil,
+        rawAmount: cashAmount,
+        rawBalance: nil,
         bankReference: context.reference.isEmpty ? nil : context.reference))
   }
 
@@ -193,9 +212,12 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
       isInstrumentPlaceholder: false)
     return .transaction(
       ParsedTransaction(
-        date: context.date, legs: [leg], rawRow: context.row,
+        date: context.date,
+        legs: [leg],
+        rawRow: context.row,
         rawDescription: context.rawDescription,
-        rawAmount: signedUnits, rawBalance: nil,
+        rawAmount: signedUnits,
+        rawBalance: nil,
         bankReference: context.reference.isEmpty ? nil : context.reference))
   }
 }

--- a/Shared/CapitalGainsCalculator.swift
+++ b/Shared/CapitalGainsCalculator.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
 /// Input type: a transaction's legs with its date.
@@ -54,20 +52,25 @@ enum CapitalGainsCalculator {
 
     for transaction in sorted {
       let classification = try await TradeEventClassifier.classify(
-        legs: transaction.legs, on: transaction.date,
+        legs: transaction.legs,
+        on: transaction.date,
         hostCurrency: profileCurrency,
         conversionService: conversionService
       )
       for buy in classification.buys {
         engine.processBuy(
-          instrument: buy.instrument, quantity: buy.quantity,
-          costPerUnit: buy.costPerUnit, date: transaction.date)
+          instrument: buy.instrument,
+          quantity: buy.quantity,
+          costPerUnit: buy.costPerUnit,
+          date: transaction.date)
       }
       for sell in classification.sells {
         let inRange = sellDateRange.map { $0.contains(transaction.date) } ?? true
         let events = engine.processSell(
-          instrument: sell.instrument, quantity: sell.quantity,
-          proceedsPerUnit: sell.proceedsPerUnit, date: transaction.date)
+          instrument: sell.instrument,
+          quantity: sell.quantity,
+          proceedsPerUnit: sell.proceedsPerUnit,
+          date: transaction.date)
         if inRange { allEvents.append(contentsOf: events) }
       }
     }

--- a/Shared/DataExporter.swift
+++ b/Shared/DataExporter.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import os
 
@@ -81,12 +79,7 @@ actor DataExporter {
     let (earmarks, budgets) = try await runStage(
       "earmarks", signpost: "export.earmarks", signpostID: signpostID
     ) {
-      let earmarks = try await backend.earmarks.fetchAll()
-      var budgets: [UUID: [EarmarkBudgetItem]] = [:]
-      for earmark in earmarks {
-        budgets[earmark.id] = try await backend.earmarks.fetchBudget(earmarkId: earmark.id)
-      }
-      return (earmarks, budgets)
+      try await downloadEarmarksWithBudgets()
     }
 
     progress(.downloading(step: "transactions"))
@@ -108,9 +101,27 @@ actor DataExporter {
     }
 
     return StagedDownloads(
-      accounts: accounts, accountGroups: accountGroups, categories: categories,
-      earmarks: earmarks, earmarkBudgets: budgets,
-      transactions: transactions, investmentValues: investmentValues)
+      accounts: accounts,
+      accountGroups: accountGroups,
+      categories: categories,
+      earmarks: earmarks,
+      earmarkBudgets: budgets,
+      transactions: transactions,
+      investmentValues: investmentValues)
+  }
+
+  /// Fetch every earmark plus its budget items, keyed by earmark id. Pulled
+  /// out of `downloadAllStages` so the earmarks stage closure stays a single
+  /// call, keeping that orchestration method focused on the per-stage fan-out.
+  private func downloadEarmarksWithBudgets() async throws -> (
+    [Earmark], [UUID: [EarmarkBudgetItem]]
+  ) {
+    let earmarks = try await backend.earmarks.fetchAll()
+    var budgets: [UUID: [EarmarkBudgetItem]] = [:]
+    for earmark in earmarks {
+      budgets[earmark.id] = try await backend.earmarks.fetchBudget(earmarkId: earmark.id)
+    }
+    return (earmarks, budgets)
   }
 
   private func buildExportedData(

--- a/Shared/DataExporter.swift
+++ b/Shared/DataExporter.swift
@@ -110,9 +110,8 @@ actor DataExporter {
       investmentValues: investmentValues)
   }
 
-  /// Fetch every earmark plus its budget items, keyed by earmark id. Pulled
-  /// out of `downloadAllStages` so the earmarks stage closure stays a single
-  /// call, keeping that orchestration method focused on the per-stage fan-out.
+  /// Fetch every earmark together with its budget items, returned as a
+  /// parallel pair keyed by earmark id.
   private func downloadEarmarksWithBudgets() async throws -> (
     [Earmark], [UUID: [EarmarkBudgetItem]]
   ) {

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -1,8 +1,3 @@
-// Reason: convenience initialisers pass multi-field LegDraft / TransactionLeg
-// values inline; pinning each field to its own line trades readability for a
-// rule conformance that adds nothing here.
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
 /// A value type that captures transaction form state and encapsulates
@@ -162,7 +157,9 @@ extension TransactionDraft {
         type: leg.type,
         accountId: leg.accountId,
         amountText: Self.displayText(
-          quantity: leg.quantity, type: leg.type, decimals: leg.instrument.decimals),
+          quantity: leg.quantity,
+          type: leg.type,
+          decimals: leg.instrument.decimals),
         categoryId: leg.categoryId,
         categoryText: "",
         earmarkId: leg.earmarkId,
@@ -217,8 +214,12 @@ extension TransactionDraft {
       legDrafts: [
         LegDraft(
           legId: nil,
-          type: .income, accountId: nil, amountText: "0",
-          categoryId: nil, categoryText: "", earmarkId: earmarkId,
+          type: .income,
+          accountId: nil,
+          amountText: "0",
+          categoryId: nil,
+          categoryText: "",
+          earmarkId: earmarkId,
           instrument: instrument)
       ],
       relevantLegIndex: 0,
@@ -239,8 +240,12 @@ extension TransactionDraft {
       legDrafts: [
         LegDraft(
           legId: nil,
-          type: .expense, accountId: accountId, amountText: "0",
-          categoryId: nil, categoryText: "", earmarkId: nil,
+          type: .expense,
+          accountId: accountId,
+          amountText: "0",
+          categoryId: nil,
+          categoryText: "",
+          earmarkId: nil,
           instrument: instrument)
       ],
       relevantLegIndex: 0,
@@ -366,8 +371,12 @@ extension TransactionDraft {
     legDrafts.append(
       LegDraft(
         legId: nil,
-        type: .expense, accountId: defaultAccountId, amountText: "0",
-        categoryId: nil, categoryText: "", earmarkId: nil,
+        type: .expense,
+        accountId: defaultAccountId,
+        amountText: "0",
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
         instrument: instrument
       ))
   }

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 import OSLog
 
@@ -125,7 +123,9 @@ struct PositionBook: Equatable, Sendable {
     for leg in txn.legs {
       let isInvestment = leg.accountId.map(investmentAccountIds.contains) ?? false
       apply(
-        leg, sign: sign, isInvestmentAccount: isInvestment,
+        leg,
+        sign: sign,
+        isInvestmentAccount: isInvestment,
         asStartingBalance: asStartingBalance)
     }
   }

--- a/Shared/Views/Positions/PositionRow.swift
+++ b/Shared/Views/Positions/PositionRow.swift
@@ -1,7 +1,3 @@
-// Reason: AssetHolding preview literals span many labelled arguments; the
-// rule fires on every previewRows() call site.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 /// Single-row presentation in `PositionsTable`. Used by both the wide
@@ -142,28 +138,66 @@ struct KindBadge: View {
   }
 }
 
+private func previewAmount(_ value: Decimal) -> InstrumentAmount {
+  InstrumentAmount(quantity: value, instrument: .AUD)
+}
+
+private func previewStockRow() -> AssetHolding {
+  AssetHolding(
+    id: "ASX:BHP.AX",
+    kind: .stock,
+    name: "BHP",
+    displayLabel: "BHP.AX",
+    decimals: 0,
+    currencyCode: nil,
+    chainId: nil,
+    exchange: "ASX",
+    quantity: 250,
+    unitPrice: previewAmount(45.30),
+    costBasis: previewAmount(10_125),
+    value: previewAmount(11_325),
+    contributingInstrumentIds: ["ASX:BHP.AX"],
+    contributingChainIds: [])
+}
+
+private func previewCryptoRow() -> AssetHolding {
+  AssetHolding(
+    id: "ethereum",
+    kind: .cryptoToken,
+    name: "Ethereum",
+    displayLabel: "ETH",
+    decimals: 18,
+    currencyCode: nil,
+    chainId: nil,
+    exchange: nil,
+    quantity: Decimal(string: "12.95694") ?? 0,
+    unitPrice: previewAmount(4_000),
+    costBasis: previewAmount(35_000),
+    value: previewAmount(51_827),
+    contributingInstrumentIds: ["1:native", "10:native"],
+    contributingChainIds: [1, 10])
+}
+
+private func previewFiatRow() -> AssetHolding {
+  AssetHolding(
+    id: "AUD",
+    kind: .fiatCurrency,
+    name: "AUD",
+    displayLabel: "$",
+    decimals: 2,
+    currencyCode: "AUD",
+    chainId: nil,
+    exchange: nil,
+    quantity: 1_520,
+    unitPrice: nil,
+    costBasis: nil,
+    value: previewAmount(1_520),
+    contributingInstrumentIds: ["AUD"],
+    contributingChainIds: [])
+}
+
 private func previewRows() -> [AssetHolding] {
-  let aud = Instrument.AUD
-  func amount(_ value: Decimal) -> InstrumentAmount {
-    InstrumentAmount(quantity: value, instrument: aud)
-  }
-  return [
-    AssetHolding(
-      id: "ASX:BHP.AX", kind: .stock, name: "BHP", displayLabel: "BHP.AX", decimals: 0,
-      currencyCode: nil, chainId: nil, exchange: "ASX", quantity: 250, unitPrice: amount(45.30),
-      costBasis: amount(10_125), value: amount(11_325), contributingInstrumentIds: ["ASX:BHP.AX"],
-      contributingChainIds: []),
-    AssetHolding(
-      id: "ethereum", kind: .cryptoToken, name: "Ethereum", displayLabel: "ETH", decimals: 18,
-      currencyCode: nil, chainId: nil, exchange: nil, quantity: Decimal(string: "12.95694") ?? 0,
-      unitPrice: amount(4_000), costBasis: amount(35_000), value: amount(51_827),
-      contributingInstrumentIds: ["1:native", "10:native"], contributingChainIds: [1, 10]),
-    AssetHolding(
-      id: "AUD", kind: .fiatCurrency, name: "AUD", displayLabel: "$", decimals: 2,
-      currencyCode: "AUD", chainId: nil, exchange: nil, quantity: 1_520, unitPrice: nil,
-      costBasis: nil, value: amount(1_520), contributingInstrumentIds: ["AUD"],
-      contributingChainIds: []),
-  ]
+  [previewStockRow(), previewCryptoRow(), previewFiatRow()]
 }
 
 #Preview("rows") {

--- a/Shared/Views/Positions/PositionsChart.swift
+++ b/Shared/Views/Positions/PositionsChart.swift
@@ -1,10 +1,3 @@
-// Reason: Swift Charts mark APIs (`AreaMark`, `LineMark`,
-// `AxisMarks`, `AXDataSeriesDescriptor`, etc.) take long labelled
-// argument lists where SwiftLint's multi-line arguments rule fights
-// the natural call-site shape. Disabling at file scope rather than
-// reformatting every Charts call site to one-arg-per-line.
-// swiftlint:disable multiline_arguments
-
 import Accessibility
 import Charts
 import SwiftUI
@@ -125,7 +118,9 @@ struct PositionsChart: View {
       .accessibilityChartDescriptor(self)
 
       PositionsChartLegendRow(
-        rows: rows, mode: mode, gainLossOpacity: Self.gainLossOpacity,
+        rows: rows,
+        mode: mode,
+        gainLossOpacity: Self.gainLossOpacity,
         showBaseline: showBaseline)
     }
   }
@@ -261,41 +256,27 @@ extension PositionsChart: AXChartDescriptorRepresentable {
     // exposes a phantom zero baseline.
     let mode: PositionsChartMode = selection == nil ? .aggregate : .perInstrument
     let showBaseline = PositionsChartBaselineResolver.showsBaseline(points: points, mode: mode)
-
-    // Pair each point with its baseline (or nil); drop nil-baseline rows
-    // before they reach the AX descriptor so VoiceOver doesn't speak NaN.
-    let baselinePairs: [(label: String, value: Double)] =
-      showBaseline
-      ? points.compactMap { point in
-        let baseline: Decimal? =
-          selection == nil ? point.contributions : point.cost
-        guard let baseline else { return nil }
-        return (
-          point.date.formatted(.dateTime.month(.abbreviated).day().year()),
-          Double(truncating: baseline as NSDecimalNumber)
-        )
-      }
-      : []
+    let baselinePairs = baselinePairs(points: points, showBaseline: showBaseline)
 
     let allValues = valueDoubles + baselinePairs.map(\.value)
     let minVal = allValues.min() ?? 0
     let maxVal = allValues.max() ?? max(minVal + 1, 1)
 
     let valueSeries = AXDataSeriesDescriptor(
-      name: "Value", isContinuous: true,
+      name: "Value",
+      isContinuous: true,
       dataPoints: zip(dateLabels, valueDoubles).map { date, val in
         AXDataPoint(x: date, y: val)
       }
     )
-
     var series: [AXDataSeriesDescriptor] = [valueSeries]
     if showBaseline {
-      let baselineName = selection == nil ? "Invested amount" : "Cost basis"
-      let baselineSeries = AXDataSeriesDescriptor(
-        name: baselineName, isContinuous: true,
-        dataPoints: baselinePairs.map { AXDataPoint(x: $0.label, y: $0.value) }
-      )
-      series.append(baselineSeries)
+      series.append(
+        AXDataSeriesDescriptor(
+          name: selection == nil ? "Invested amount" : "Cost basis",
+          isContinuous: true,
+          dataPoints: baselinePairs.map { AXDataPoint(x: $0.label, y: $0.value) }
+        ))
     }
 
     let summary: String? =
@@ -312,6 +293,24 @@ extension PositionsChart: AXChartDescriptorRepresentable {
       yMax: max(minVal + 1, maxVal),
       series: series
     )
+  }
+
+  /// Pair each point with its baseline (or nil); drop nil-baseline rows
+  /// before they reach the AX descriptor so VoiceOver doesn't speak NaN.
+  @MainActor
+  private func baselinePairs(
+    points: [HistoricalValueSeries.Point], showBaseline: Bool
+  ) -> [(label: String, value: Double)] {
+    guard showBaseline else { return [] }
+    return points.compactMap { point in
+      let baseline: Decimal? =
+        selection == nil ? point.contributions : point.cost
+      guard let baseline else { return nil }
+      return (
+        point.date.formatted(.dateTime.month(.abbreviated).day().year()),
+        Double(truncating: baseline as NSDecimalNumber)
+      )
+    }
   }
 
   private struct ChartSnapshot: @unchecked Sendable {
@@ -337,16 +336,23 @@ private func previewChartInput(days: Int, base: Decimal, step: Decimal, cost: De
   let points: [HistoricalValueSeries.Point] = (0..<days).map { offset in
     let date = calendar.date(byAdding: .day, value: -(days - 1) + offset, to: now) ?? now
     return HistoricalValueSeries.Point(
-      date: date, value: base + Decimal(offset) * step, cost: cost,
+      date: date,
+      value: base + Decimal(offset) * step,
+      cost: cost,
       contributions: nil)
   }
   let series = HistoricalValueSeries(
-    hostCurrency: aud, total: points, perInstrument: [bhp.id: points])
+    hostCurrency: aud,
+    total: points,
+    perInstrument: [bhp.id: points])
   return PositionsViewInput(
-    title: "Brokerage", hostCurrency: aud,
+    title: "Brokerage",
+    hostCurrency: aud,
     positions: [
       ValuedPosition(
-        instrument: bhp, quantity: 100, unitPrice: nil,
+        instrument: bhp,
+        quantity: 100,
+        unitPrice: nil,
         costBasis: InstrumentAmount(quantity: cost, instrument: aud),
         value: InstrumentAmount(quantity: points.last?.value ?? 0, instrument: aud))
     ],
@@ -364,15 +370,15 @@ private func previewChartInput(days: Int, base: Decimal, step: Decimal, cost: De
 }
 
 #Preview("Chart - filtered to instrument") {
-  let bhp = AssetHolding(
-    id: "ASX:BHP.AX", kind: .stock, name: "BHP", displayLabel: "BHP.AX", decimals: 0,
-    currencyCode: nil, chainId: nil, exchange: "ASX", quantity: 100, unitPrice: nil,
-    costBasis: nil, value: nil, contributingInstrumentIds: ["ASX:BHP.AX"],
-    contributingChainIds: [])
+  let bhp = PositionSelection(
+    id: "ASX:BHP.AX",
+    kind: .stock,
+    displayLabel: "BHP.AX",
+    instrumentIds: ["ASX:BHP.AX"])
   return PositionsChart(
     input: previewChartInput(days: 30, base: 4_500, step: 25, cost: 4_000),
     range: .constant(.oneMonth),
-    selection: .constant(bhp.positionSelection)
+    selection: .constant(bhp)
   )
   .frame(width: 600, height: 320)
   .padding()

--- a/Shared/Views/Positions/PositionsTable.swift
+++ b/Shared/Views/Positions/PositionsTable.swift
@@ -1,8 +1,3 @@
-// Reason: AssetHolding preview literals and the Table column builders span
-// many labelled arguments; the multiline_arguments rule fires on every such
-// call site in this file.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 /// Responsive table of `AssetHolding`s. On wide layouts (macOS, regular iOS
@@ -271,40 +266,62 @@ private func mixedPositionsInput() -> PositionsViewInput {
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
   let cba = Instrument.stock(ticker: "CBA.AX", exchange: "ASX", name: "CBA")
   let eth = Instrument.crypto(
-    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    chainId: 1,
+    contractAddress: nil,
+    symbol: "ETH",
+    name: "Ethereum",
+    decimals: 18)
   let ethOptimism = Instrument.crypto(
-    chainId: 10, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    chainId: 10,
+    contractAddress: nil,
+    symbol: "ETH",
+    name: "Ethereum",
+    decimals: 18)
   let aud = Instrument.AUD
   return PositionsViewInput(
-    title: "Brokerage", hostCurrency: aud,
-    positions: [
-      ValuedPosition(
-        instrument: bhp, quantity: 250,
-        unitPrice: InstrumentAmount(quantity: 45.30, instrument: aud),
-        costBasis: InstrumentAmount(quantity: 10_125, instrument: aud),
-        value: InstrumentAmount(quantity: 11_325, instrument: aud)),
-      ValuedPosition(
-        instrument: cba, quantity: 80,
-        unitPrice: InstrumentAmount(quantity: 120, instrument: aud),
-        costBasis: InstrumentAmount(quantity: 9_000, instrument: aud),
-        value: InstrumentAmount(quantity: 9_600, instrument: aud)),
-      ValuedPosition(
-        instrument: eth, quantity: 2.45,
-        unitPrice: InstrumentAmount(quantity: 4_000, instrument: aud),
-        costBasis: InstrumentAmount(quantity: 7_500, instrument: aud),
-        value: InstrumentAmount(quantity: 9_800, instrument: aud)),
-      ValuedPosition(
-        instrument: ethOptimism, quantity: 1.10,
-        unitPrice: InstrumentAmount(quantity: 4_000, instrument: aud),
-        costBasis: InstrumentAmount(quantity: 3_500, instrument: aud),
-        value: InstrumentAmount(quantity: 4_400, instrument: aud)),
-      ValuedPosition(
-        instrument: aud, quantity: 2_480,
-        unitPrice: nil, costBasis: nil,
-        value: InstrumentAmount(quantity: 2_480, instrument: aud)),
-    ],
+    title: "Brokerage",
+    hostCurrency: aud,
+    positions: mixedPreviewPositions(
+      bhp: bhp, cba: cba, eth: eth, ethOptimism: ethOptimism, aud: aud),
     historicalValue: nil,
     assetKeysByInstrumentId: ["1:native": "ethereum", "10:native": "ethereum"])
+}
+
+private func mixedPreviewPositions(
+  bhp: Instrument, cba: Instrument, eth: Instrument, ethOptimism: Instrument, aud: Instrument
+) -> [ValuedPosition] {
+  [
+    ValuedPosition(
+      instrument: bhp,
+      quantity: 250,
+      unitPrice: InstrumentAmount(quantity: 45.30, instrument: aud),
+      costBasis: InstrumentAmount(quantity: 10_125, instrument: aud),
+      value: InstrumentAmount(quantity: 11_325, instrument: aud)),
+    ValuedPosition(
+      instrument: cba,
+      quantity: 80,
+      unitPrice: InstrumentAmount(quantity: 120, instrument: aud),
+      costBasis: InstrumentAmount(quantity: 9_000, instrument: aud),
+      value: InstrumentAmount(quantity: 9_600, instrument: aud)),
+    ValuedPosition(
+      instrument: eth,
+      quantity: 2.45,
+      unitPrice: InstrumentAmount(quantity: 4_000, instrument: aud),
+      costBasis: InstrumentAmount(quantity: 7_500, instrument: aud),
+      value: InstrumentAmount(quantity: 9_800, instrument: aud)),
+    ValuedPosition(
+      instrument: ethOptimism,
+      quantity: 1.10,
+      unitPrice: InstrumentAmount(quantity: 4_000, instrument: aud),
+      costBasis: InstrumentAmount(quantity: 3_500, instrument: aud),
+      value: InstrumentAmount(quantity: 4_400, instrument: aud)),
+    ValuedPosition(
+      instrument: aud,
+      quantity: 2_480,
+      unitPrice: nil,
+      costBasis: nil,
+      value: InstrumentAmount(quantity: 2_480, instrument: aud)),
+  ]
 }
 
 #Preview("PositionsTable - mixed wide") {
@@ -320,8 +337,11 @@ private func mixedPositionsInput() -> PositionsViewInput {
     hostCurrency: aud,
     positions: [
       ValuedPosition(
-        instrument: bhp, quantity: 250,
-        unitPrice: nil, costBasis: nil, value: nil)
+        instrument: bhp,
+        quantity: 250,
+        unitPrice: nil,
+        costBasis: nil,
+        value: nil)
     ],
     historicalValue: nil
   )

--- a/Shared/Views/Positions/PositionsView.swift
+++ b/Shared/Views/Positions/PositionsView.swift
@@ -1,9 +1,3 @@
-// swiftlint:disable multiline_arguments
-//
-// Previews and inline view-builder layouts construct PositionsViewInput
-// across multiple lines for readability; the rule fires on every such
-// call site in this file.
-
 import SwiftUI
 
 /// Unified container for displaying positions across the app. Composes a
@@ -60,18 +54,22 @@ private func defaultPreviewPositions() -> [ValuedPosition] {
   let aud = Instrument.AUD
   return [
     ValuedPosition(
-      instrument: bhp, quantity: 250,
+      instrument: bhp,
+      quantity: 250,
       unitPrice: InstrumentAmount(quantity: 45.30, instrument: aud),
       costBasis: InstrumentAmount(quantity: 10_125, instrument: aud),
       value: InstrumentAmount(quantity: 11_325, instrument: aud)),
     ValuedPosition(
-      instrument: cba, quantity: 80,
+      instrument: cba,
+      quantity: 80,
       unitPrice: InstrumentAmount(quantity: 120, instrument: aud),
       costBasis: InstrumentAmount(quantity: 9_000, instrument: aud),
       value: InstrumentAmount(quantity: 9_600, instrument: aud)),
     ValuedPosition(
-      instrument: aud, quantity: 2_480,
-      unitPrice: nil, costBasis: nil,
+      instrument: aud,
+      quantity: 2_480,
+      unitPrice: nil,
+      costBasis: nil,
       value: InstrumentAmount(quantity: 2_480, instrument: aud)),
   ]
 }
@@ -96,12 +94,16 @@ private func defaultPreviewPositions() -> [ValuedPosition] {
       hostCurrency: .AUD,
       positions: [
         ValuedPosition(
-          instrument: .USD, quantity: 100,
-          unitPrice: nil, costBasis: nil,
+          instrument: .USD,
+          quantity: 100,
+          unitPrice: nil,
+          costBasis: nil,
           value: InstrumentAmount(quantity: 152, instrument: .AUD)),
         ValuedPosition(
-          instrument: .AUD, quantity: 1_000,
-          unitPrice: nil, costBasis: nil,
+          instrument: .AUD,
+          quantity: 1_000,
+          unitPrice: nil,
+          costBasis: nil,
           value: InstrumentAmount(quantity: 1_000, instrument: .AUD)),
       ],
       historicalValue: nil
@@ -119,8 +121,11 @@ private func defaultPreviewPositions() -> [ValuedPosition] {
       hostCurrency: .AUD,
       positions: [
         ValuedPosition(
-          instrument: bhp, quantity: 250,
-          unitPrice: nil, costBasis: nil, value: nil)
+          instrument: bhp,
+          quantity: 250,
+          unitPrice: nil,
+          costBasis: nil,
+          value: nil)
       ],
       historicalValue: nil
     ),
@@ -150,16 +155,22 @@ private func withChartPreviewInput() -> PositionsViewInput {
   let points: [HistoricalValueSeries.Point] = (0..<60).map { offset in
     let date = calendar.date(byAdding: .day, value: -59 + offset, to: now) ?? now
     return HistoricalValueSeries.Point(
-      date: date, value: 10_000 + Decimal(offset) * 25, cost: 9_500,
+      date: date,
+      value: 10_000 + Decimal(offset) * 25,
+      cost: 9_500,
       contributions: nil)
   }
   let series = HistoricalValueSeries(
-    hostCurrency: aud, total: points, perInstrument: [bhp.id: points])
+    hostCurrency: aud,
+    total: points,
+    perInstrument: [bhp.id: points])
   return PositionsViewInput(
-    title: "Brokerage", hostCurrency: aud,
+    title: "Brokerage",
+    hostCurrency: aud,
     positions: [
       ValuedPosition(
-        instrument: bhp, quantity: 100,
+        instrument: bhp,
+        quantity: 100,
         unitPrice: InstrumentAmount(quantity: (points.last?.value ?? 0) / 100, instrument: aud),
         costBasis: InstrumentAmount(quantity: 9_500, instrument: aud),
         value: InstrumentAmount(quantity: points.last?.value ?? 0, instrument: aud))
@@ -172,35 +183,38 @@ private func withChartPreviewInput() -> PositionsViewInput {
     .frame(width: 720, height: 640)
 }
 
-#Preview("With performance tiles") {
+private func performanceTilesPreviewInput() -> PositionsViewInput {
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
   let aud = Instrument.AUD
-  return PositionsView(
-    input: PositionsViewInput(
-      title: "Brokerage",
-      hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 250,
-          unitPrice: InstrumentAmount(quantity: 45.30, instrument: aud),
-          costBasis: InstrumentAmount(quantity: 10_125, instrument: aud),
-          value: InstrumentAmount(quantity: 11_325, instrument: aud)),
-        ValuedPosition(
-          instrument: aud, quantity: 2_480,
-          unitPrice: nil, costBasis: nil,
-          value: InstrumentAmount(quantity: 2_480, instrument: aud)),
-      ],
-      historicalValue: nil,
-      performance: AccountPerformance(
+  return PositionsViewInput(
+    title: "Brokerage",
+    hostCurrency: aud,
+    positions: [
+      ValuedPosition(
+        instrument: bhp,
+        quantity: 250,
+        unitPrice: InstrumentAmount(quantity: 45.30, instrument: aud),
+        costBasis: InstrumentAmount(quantity: 10_125, instrument: aud),
+        value: InstrumentAmount(quantity: 11_325, instrument: aud)),
+      ValuedPosition(
         instrument: aud,
-        currentValue: InstrumentAmount(quantity: 13_805, instrument: aud),
-        totalContributions: InstrumentAmount(quantity: 12_605, instrument: aud),
-        profitLoss: InstrumentAmount(quantity: 1_200, instrument: aud),
-        profitLossPercent: Decimal(string: "0.0952"),
-        annualisedReturn: Decimal(string: "0.0833"),
-        firstFlowDate: Calendar.current.date(byAdding: .year, value: -2, to: Date()))
-    ),
-    range: .constant(.threeMonths)
-  )
-  .frame(width: 720, height: 480)
+        quantity: 2_480,
+        unitPrice: nil,
+        costBasis: nil,
+        value: InstrumentAmount(quantity: 2_480, instrument: aud)),
+    ],
+    historicalValue: nil,
+    performance: AccountPerformance(
+      instrument: aud,
+      currentValue: InstrumentAmount(quantity: 13_805, instrument: aud),
+      totalContributions: InstrumentAmount(quantity: 12_605, instrument: aud),
+      profitLoss: InstrumentAmount(quantity: 1_200, instrument: aud),
+      profitLossPercent: Decimal(string: "0.0952"),
+      annualisedReturn: Decimal(string: "0.0833"),
+      firstFlowDate: Calendar.current.date(byAdding: .year, value: -2, to: Date())))
+}
+
+#Preview("With performance tiles") {
+  PositionsView(input: performanceTilesPreviewInput(), range: .constant(.threeMonths))
+    .frame(width: 720, height: 480)
 }


### PR DESCRIPTION
Graduates every remaining production file off the file-level `// swiftlint:disable multiline_arguments` suppression, making each genuinely comply with the rule. Follows the pattern set by #1153 (which graduated the history-chart/assembler files).

## What & why

`multiline_arguments` requires a call's arguments to be all on one line **or** one-per-line — never the compact "2-per-line" wrapping `swift-format` emits by default. `swift-format` tolerates hand-written one-per-line and won't repack it, so each file complies by expanding its wrapped calls one-arg-per-line, then deleting the disable. `.swiftlint.yml` documented these disables as transitional; this clears the backlog.

27 files across 5 areas (Positions views, Import, Transactions views, Shared helpers, Accounts/Earmarks/Reports). Almost entirely pure formatting — no behaviour change.

## Cascades (expansion grew bodies past length limits)

Each was resolved by **semantic extraction**, never a threshold bump or re-added disable (`.swiftlint.yml` is unchanged):

- `DataExporter.downloadAllStages` → extracted `downloadEarmarksWithBudgets()` (the only production-logic extraction).
- `PositionRow` preview → `previewStockRow/previewCryptoRow/previewFiatRow/previewAmount`.
- `PositionsTable` preview → `mixedPreviewPositions(...)`.
- `PositionsView` preview → `performanceTilesPreviewInput()`.
- `PositionsChart` → `baselinePairs(points:showBaseline:)`; plus replaced a 15-line preview `AssetHolding` (built only to read `.positionSelection`) with a direct `PositionSelection` literal.
- `TransactionListView+Preview` → `previewAccounts(checkingId:savingsId:)`.
- `TransactionDetailView+Previews` → `customTransaction(accountId1:accountId2:)`.

## Verification

- `just format-check` — clean ("All Swift files are correctly formatted").
- `just build-mac` — **BUILD SUCCEEDED** (warnings-as-errors on, so warning-free).
- `just test-mac DataExporterTests ExportImportIntegrationTests ExportImportIntegrationTestsMore` — all pass (covers the one production extraction's earmarks+budgets path).
- `git diff .swiftlint.yml` — empty.
- No `swiftlint:disable multiline_arguments` remains anywhere under `Shared/` or `Features/`.
- `code-review` agent pass on all extractions: all good seams; one Minor (present-tense docstring) fixed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)