### PR TITLE
feat(analysis): drill into a month's transactions from the income/expense table

### DIFF
--- a/Domain/Models/MonthlyIncomeExpense.swift
+++ b/Domain/Models/MonthlyIncomeExpense.swift
@@ -131,6 +131,15 @@ extension MonthlyIncomeExpense: Codable {
 }
 
 extension MonthlyIncomeExpense {
+  /// Filter selecting this financial month's transactions, for drilling
+  /// into a row of the Monthly Income & Expense table. Spans the month's
+  /// actual transaction-date range (`start...end`) — the same instants
+  /// that produced the row's totals — so it captures exactly those
+  /// transactions without re-deriving the financial-month boundary.
+  var transactionsFilter: TransactionFilter {
+    TransactionFilter(dateRange: start...end)
+  }
+
   /// Total income including the investment layer (cash + investments).
   var totalIncome: InstrumentAmount {
     income + investmentIncome

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -16,6 +16,10 @@ struct AnalysisView: View {
   /// cycle (focus write → focus-dependent body invalidation → rewrite → …).
   var onNavigate: (SidebarSelection) -> Void = { _ in }
   @State private var selectedUpcomingTransaction: Transaction?
+  /// The month whose transactions are being drilled into from the
+  /// Monthly Income & Expense table. Non-nil pushes the month's
+  /// transaction list onto the navigation stack.
+  @State private var selectedMonth: MonthlyIncomeExpense?
 
   var body: some View {
     ScrollView {
@@ -46,6 +50,9 @@ struct AnalysisView: View {
       transactionStore: transactionStore,
       showRecurrence: true
     )
+    .navigationDestination(item: $selectedMonth) { month in
+      monthTransactionsList(month)
+    }
     .profileNavigationTitle("Analysis")
     .focusedSceneValue(\.newTransactionAction, createNewScheduledTransaction)
     .focusedSceneValue(
@@ -154,6 +161,19 @@ struct AnalysisView: View {
     }
   }
 
+  /// Transaction list for a single financial month, pushed when a row of
+  /// the Monthly Income & Expense table is tapped.
+  private func monthTransactionsList(_ month: MonthlyIncomeExpense) -> some View {
+    TransactionListView(
+      title: month.start.formatted(.dateTime.month(.wide).year()),
+      filter: month.transactionsFilter,
+      accounts: accountStore.accounts,
+      categories: categoryStore.categories,
+      earmarks: earmarkStore.earmarks,
+      transactionStore: transactionStore
+    )
+  }
+
   @ViewBuilder
   private func contentView(store: AnalysisStore) -> some View {
     VStack(spacing: 20) {
@@ -193,7 +213,9 @@ struct AnalysisView: View {
           transactionStore: transactionStore,
           selectedTransaction: $selectedUpcomingTransaction
         )
-        IncomeExpenseTableCard(data: store.displayedIncomeAndExpense)
+        IncomeExpenseTableCard(
+          data: store.displayedIncomeAndExpense,
+          onSelectMonth: { selectedMonth = $0 })
       }
     #else
       UpcomingTransactionsCard(

--- a/Features/Analysis/Views/IncomeExpenseTableCard.swift
+++ b/Features/Analysis/Views/IncomeExpenseTableCard.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct IncomeExpenseTableCard: View {
   let data: [MonthlyIncomeExpense]
+  /// Invoked when a month row is tapped, to drill into that month's
+  /// transactions. Defaults to a no-op so previews and any non-navigating
+  /// host render without wiring it.
+  var onSelectMonth: (MonthlyIncomeExpense) -> Void = { _ in }
 
   private static let initialVisibleCount = 6
   private static let loadMoreCount = 6
@@ -88,36 +92,14 @@ struct IncomeExpenseTableCard: View {
 
   private func dataRow(for item: MonthlyIncomeExpense) -> some View {
     VStack(spacing: 0) {
-      HStack(spacing: 12) {
-        VStack(alignment: .leading, spacing: 2) {
-          HStack(spacing: 4) {
-            Text(Self.monthLabel(for: item))
-              .font(.body)
-              .monospacedDigit()
-            if item.hasUnavailableData {
-              // Visual hint that the row's prices are still loading. The row's
-              // combined a11y label already announces this, so hide it here.
-              Image(systemName: "clock")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-            }
-          }
-          Text(monthsAgoLabel(for: item))
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .monospacedDigit()
-        }
-        .frame(minWidth: monthColumnMinWidth, alignment: .leading)
-        amountColumns(for: item)
-        cumulativeCell(for: item)
-          .frame(minWidth: totalColumnMinWidth, alignment: .trailing)
+      Button {
+        onSelectMonth(item)
+      } label: {
+        rowContent(for: item)
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 8)
-      .accessibilityElement(children: .combine)
-      .accessibilityLabel(
-        Self.accessibilityLabel(for: item, in: data, includeInvestments: includeInvestments))
+      .buttonStyle(.plain)
+      .accessibilityIdentifier(UITestIdentifiers.IncomeExpenseTable.row(item.month))
+      .accessibilityHint("Shows this month's transactions")
       Divider()
     }
     .onAppear {
@@ -125,6 +107,40 @@ struct IncomeExpenseTableCard: View {
         visibleCount += Self.loadMoreCount
       }
     }
+  }
+
+  private func rowContent(for item: MonthlyIncomeExpense) -> some View {
+    HStack(spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 4) {
+          Text(Self.monthLabel(for: item))
+            .font(.body)
+            .monospacedDigit()
+          if item.hasUnavailableData {
+            // Visual hint that the row's prices are still loading. The row's
+            // combined a11y label already announces this, so hide it here.
+            Image(systemName: "clock")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+              .accessibilityHidden(true)
+          }
+        }
+        Text(monthsAgoLabel(for: item))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+      }
+      .frame(minWidth: monthColumnMinWidth, alignment: .leading)
+      amountColumns(for: item)
+      cumulativeCell(for: item)
+        .frame(minWidth: totalColumnMinWidth, alignment: .trailing)
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .contentShape(Rectangle())
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      Self.accessibilityLabel(for: item, in: data, includeInvestments: includeInvestments))
   }
 
   /// Income, expense, and savings columns. When the month's prices are still

--- a/MoolahTests/Domain/MonthlyIncomeExpenseFilterTests.swift
+++ b/MoolahTests/Domain/MonthlyIncomeExpenseFilterTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests the filter used to drill from a Monthly Income & Expense row into
+/// that month's transactions.
+@Suite("MonthlyIncomeExpense transactions filter")
+struct MonthlyIncomeExpenseFilterTests {
+  private func month(start: Date, end: Date) -> MonthlyIncomeExpense {
+    MonthlyIncomeExpense(
+      month: "202604",
+      start: start,
+      end: end,
+      income: .zero(instrument: .AUD),
+      expense: .zero(instrument: .AUD),
+      profit: .zero(instrument: .AUD),
+      investmentIncome: .zero(instrument: .AUD),
+      investmentExpense: .zero(instrument: .AUD),
+      investmentProfit: .zero(instrument: .AUD))
+  }
+
+  @Test("filter spans the month's transaction-date range")
+  func filterSpansTransactionDateRange() {
+    let start = Date(timeIntervalSince1970: 1_700_000_000)
+    let end = Date(timeIntervalSince1970: 1_702_000_000)
+
+    let filter = month(start: start, end: end).transactionsFilter
+
+    #expect(filter.dateRange == start...end)
+    // Only the date range is constrained — no account/earmark/category scoping.
+    #expect(filter.accountId == nil)
+    #expect(filter.earmarkId == nil)
+    #expect(filter.categoryIds.isEmpty)
+    #expect(filter.scheduled == .all)
+  }
+
+  @Test("filter handles a single-day month (start == end)")
+  func filterHandlesSingleDayMonth() {
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+
+    let filter = month(start: day, end: day).transactionsFilter
+
+    #expect(filter.dateRange == day...day)
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -36,6 +36,17 @@ public enum UITestIdentifiers {
     public static let spamToggleButton = "transactionlist.toolbar.spamToggle"
   }
 
+  // MARK: - IncomeExpenseTable
+
+  public enum IncomeExpenseTable {
+    /// Tappable row of the Monthly Income & Expense table, keyed by the
+    /// financial-month "YYYYMM" string. Tapping drills into that month's
+    /// transactions.
+    public static func row(_ month: String) -> String {
+      "incomeexpensetable.row.\(month)"
+    }
+  }
+
   // MARK: - RecentlyAdded
 
   public enum RecentlyAdded {


### PR DESCRIPTION
## Summary

Makes each row of the **Monthly Income & Expense** table tappable: tapping a month pushes a transaction list filtered to that financial month onto the Analysis navigation stack.

- `MonthlyIncomeExpense.transactionsFilter` builds a `TransactionFilter(dateRange: start...end)` over the month's actual transaction-date span — the same instants that produced the row's totals — so it captures exactly that month's transactions without re-deriving the financial-month boundary.
- `IncomeExpenseTableCard` gains an `onSelectMonth` callback; each row is now a `.plain` `Button` with a full-row tap target, the existing combined VoiceOver label preserved, a "Shows this month's transactions" hint, and a per-row UI-test identifier (`UITestIdentifiers.IncomeExpenseTable.row(month)`).
- `AnalysisView` presents the month's `TransactionListView` via `.navigationDestination(item:)`, titled with the month (e.g. "April 2026").

Builds on #1155 (available-funds + investments rework).

## Testing
- Unit tests for the filter mapping (`MonthlyIncomeExpenseFilterTests`): date-range span and single-day month.
- Full suite green on **iOS Simulator and macOS**; `just format-check` clean.
- The navigation itself is standard SwiftUI (`Button` + `navigationDestination(item:)`); not covered by a committed XCUITest because the rows live in a `LazyVStack` below the fold (would need brittle outer-scroll handling). Verified manually in the running macOS app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)