### PR TITLE
fix(analysis): label income/expense rows with both months they span

### DIFF
--- a/Domain/Models/MonthlyIncomeExpense.swift
+++ b/Domain/Models/MonthlyIncomeExpense.swift
@@ -155,3 +155,39 @@ extension MonthlyIncomeExpense {
     profit + investmentProfit
   }
 }
+
+extension MonthlyIncomeExpense {
+  /// Display label naming the calendar month(s) the row's transactions
+  /// span. A financial month with a non-month-end cutoff straddles two
+  /// calendar months, so when `start` and `end` fall in different months
+  /// the label names both — "Apr – May 2026", or "Dec 2025 – Jan 2026"
+  /// across a year boundary; a single-month span is just "May 2026".
+  ///
+  /// UTC-anchored: `start`/`end` are midnight-UTC day tokens, so a local
+  /// formatter would drift a day-1 date into the previous month in
+  /// negative-UTC zones. Component extraction and month-name formatting
+  /// both pin to UTC.
+  var monthLabel: String {
+    let calendar = Calendar.utc
+    let startMonth = calendar.component(.month, from: start)
+    let startYear = calendar.component(.year, from: start)
+    let endMonth = calendar.component(.month, from: end)
+    let endYear = calendar.component(.year, from: end)
+
+    if startYear == endYear, startMonth == endMonth {
+      return "\(Self.monthName(start)) \(startYear)"
+    }
+    if startYear == endYear {
+      return "\(Self.monthName(start)) – \(Self.monthName(end)) \(endYear)"
+    }
+    return "\(Self.monthName(start)) \(startYear) – \(Self.monthName(end)) \(endYear)"
+  }
+
+  /// Localized abbreviated month name for `date`, pinned to UTC so a
+  /// midnight-UTC day token names the correct month in every zone.
+  private static func monthName(_ date: Date) -> String {
+    var style = Date.FormatStyle.dateTime.month(.abbreviated)
+    style.timeZone = .gmt
+    return date.formatted(style)
+  }
+}

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -165,7 +165,7 @@ struct AnalysisView: View {
   /// the Monthly Income & Expense table is tapped.
   private func monthTransactionsList(_ month: MonthlyIncomeExpense) -> some View {
     TransactionListView(
-      title: month.start.formatted(.dateTime.month(.wide).year()),
+      title: month.monthLabel,
       filter: month.transactionsFilter,
       accounts: accountStore.accounts,
       categories: categoryStore.categories,

--- a/Features/Analysis/Views/IncomeExpenseTableCard.swift
+++ b/Features/Analysis/Views/IncomeExpenseTableCard.swift
@@ -251,7 +251,7 @@ struct IncomeExpenseTableCard: View {
   }
 
   nonisolated static func monthLabel(for item: MonthlyIncomeExpense) -> String {
-    item.start.formatted(.dateTime.month(.abbreviated).year())
+    item.monthLabel
   }
 
   private func monthsAgoLabel(for item: MonthlyIncomeExpense) -> String {

--- a/MoolahTests/Domain/MonthlyIncomeExpenseMonthLabelTests.swift
+++ b/MoolahTests/Domain/MonthlyIncomeExpenseMonthLabelTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests the label shown for a Monthly Income & Expense row. A financial
+/// month with a non-month-end cutoff spans two calendar months, so when the
+/// row's transactions straddle a month boundary the label names both.
+@Suite("MonthlyIncomeExpense month label")
+struct MonthlyIncomeExpenseMonthLabelTests {
+  private func month(start: Date, end: Date) -> MonthlyIncomeExpense {
+    MonthlyIncomeExpense(
+      month: "202605",
+      start: start,
+      end: end,
+      income: .zero(instrument: .AUD),
+      expense: .zero(instrument: .AUD),
+      profit: .zero(instrument: .AUD),
+      investmentIncome: .zero(instrument: .AUD),
+      investmentExpense: .zero(instrument: .AUD),
+      investmentProfit: .zero(instrument: .AUD))
+  }
+
+  /// UTC-pinned abbreviated month name — the same anchoring the label must
+  /// use, so assertions stay locale-agnostic (no hard-coded "Apr"/"May").
+  private func utcMonthAbbrev(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    formatter.setLocalizedDateFormatFromTemplate("MMM")
+    return formatter.string(from: date)
+  }
+
+  private func utcDate(_ year: Int, _ monthValue: Int, _ day: Int) throws -> Date {
+    try #require(
+      Calendar.utc.date(from: DateComponents(year: year, month: monthValue, day: day)))
+  }
+
+  @Test("single calendar month shows one name and no range separator")
+  func singleMonth() throws {
+    let start = try utcDate(2026, 5, 3)
+    let end = try utcDate(2026, 5, 20)
+
+    let label = month(start: start, end: end).monthLabel
+
+    #expect(!label.contains("–"))
+    #expect(label.contains(utcMonthAbbrev(start)))
+    #expect(label.contains("2026"))
+  }
+
+  @Test("transactions spanning two months in the same year name both months once")
+  func twoMonthsSameYear() throws {
+    let start = try utcDate(2026, 4, 22)
+    let end = try utcDate(2026, 5, 10)
+
+    let label = month(start: start, end: end).monthLabel
+
+    #expect(label.contains("–"), "range label should join the two month names")
+    #expect(label.contains(utcMonthAbbrev(start)))  // April
+    #expect(label.contains(utcMonthAbbrev(end)))  // May
+    // Same year → year appears once.
+    #expect(label.components(separatedBy: "2026").count - 1 == 1)
+  }
+
+  @Test("transactions spanning a year boundary name both months and both years")
+  func twoMonthsAcrossYears() throws {
+    let start = try utcDate(2025, 12, 25)
+    let end = try utcDate(2026, 1, 10)
+
+    let label = month(start: start, end: end).monthLabel
+
+    #expect(label.contains("–"))
+    #expect(label.contains("2025"))
+    #expect(label.contains("2026"))
+  }
+
+  @Test("label uses UTC: a day-1 boundary date does not drift to the previous month")
+  func dayOneBoundaryDoesNotDrift() throws {
+    // Midnight-UTC May 1 must read as May, not April (which a local-zone
+    // formatter would show in a negative-UTC zone).
+    let mayFirst = try utcDate(2026, 5, 1)
+
+    let label = month(start: mayFirst, end: mayFirst).monthLabel
+
+    #expect(label.contains(utcMonthAbbrev(mayFirst)))
+    #expect(!label.contains("–"))
+  }
+}


### PR DESCRIPTION
## Summary

A financial month with a non-month-end cutoff (`monthEnd ≠` end of month) straddles **two calendar months** — e.g. with `monthEnd = 21`, the "May" financial month spans Apr 22 – May 21. The row was labelled from the first transaction's date alone, so it read "Apr 2026" and hid the second month.

`MonthlyIncomeExpense.monthLabel` now names **both** calendar months when the row's transaction span (`start...end`) crosses a boundary:
- same month → `May 2026`
- two months, same year → `Apr – May 2026`
- across a year → `Dec 2025 – Jan 2026`

Component extraction and month-name formatting both pin to **UTC**, since `start`/`end` are midnight-UTC day tokens that a local formatter would drift into the previous month in negative-UTC zones (the timezoneless-date seam in `guides/DATE_TIME_GUIDE.md`).

Both the table row label and the month's transaction-list title (from the row drill-down, #1156) use it.

## Testing
- `MonthlyIncomeExpenseMonthLabelTests`: single month, two-months-same-year (year named once), across-year (both years), and a day-1 UTC boundary that must not drift to the previous month. Assertions are locale-agnostic (compare against UTC-formatted month names, not hard-coded English).
- Full suite green on iOS + macOS; `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)