### PR TITLE
fix(analysis): classify crypto/exchange accounts as investment-like in daily-balance loaders

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -12,13 +12,16 @@ extension GRDBAnalysisRepository {
 
   // MARK: - SQL fetches
 
-  /// Loads every account id whose `type = 'investment'` AND whose
-  /// `valuation_mode = 'recordedValue'`. The Swift assembly walks
-  /// per-day deltas and folds in snapshot values for these accounts;
-  /// trades-mode investment accounts are intentionally excluded
-  /// because their per-day value comes from a different path and they
-  /// have no snapshot fold to apply — including them here would
-  /// overwrite their daily balance with a stale or missing snapshot.
+  /// Loads every account id of an investment-like `type`
+  /// (`investmentLikeTypesSQLList`) whose `valuation_mode =
+  /// 'recordedValue'`. The Swift assembly walks per-day deltas and
+  /// folds in snapshot values for these accounts; trades-mode
+  /// investment accounts are intentionally excluded because their
+  /// per-day value comes from a different path and they have no
+  /// snapshot fold to apply — including them here would overwrite their
+  /// daily balance with a stale or missing snapshot. Classifying by the
+  /// investment-like type set (not the literal `type = 'investment'`)
+  /// keeps crypto/exchange accounts out of the bank-balance sum.
   /// Reading the column directly off the `account` table avoids
   /// redundantly carrying the full account row across the snapshot
   /// boundary.
@@ -27,7 +30,8 @@ extension GRDBAnalysisRepository {
       database,
       sql: """
         SELECT id FROM account
-        WHERE type = 'investment' AND valuation_mode = 'recordedValue'
+        WHERE type IN (\(GRDBAnalysisRepository.investmentLikeTypesSQLList))
+          AND valuation_mode = 'recordedValue'
         """)
     var ids = Set<UUID>()
     ids.reserveCapacity(rows.count)
@@ -39,15 +43,21 @@ extension GRDBAnalysisRepository {
     return ids
   }
 
-  /// Loads every account id whose `type = 'investment'` AND whose
-  /// `valuation_mode = 'calculatedFromTrades'`. The trades-mode fold
+  /// Loads every account id of an investment-like `type`
+  /// (`investmentLikeTypesSQLList`) whose `valuation_mode =
+  /// 'calculatedFromTrades'` — the manual investment accounts the
+  /// migration flipped, plus crypto wallets and exchange accounts,
+  /// which are created in trades mode. The trades-mode fold
   /// (`applyTradesModePositionValuations`) walks per-day position
   /// deltas for these accounts and valuates the cumulative positions
   /// against the conversion service on the day's date. Recorded-value
   /// investment accounts are intentionally excluded — they contribute
-  /// via the snapshot fold instead. Reading the column directly off
-  /// the `account` table avoids carrying the full account row across
-  /// the position-row boundary.
+  /// via the snapshot fold instead. Classifying by the investment-like
+  /// type set (not the literal `type = 'investment'`) is what keeps
+  /// crypto/exchange market value out of the bank-balance sum and in
+  /// the investments total. Reading the column directly off the
+  /// `account` table avoids carrying the full account row across the
+  /// position-row boundary.
   static func fetchTradesModeInvestmentAccountIds(
     database: Database
   ) throws -> Set<UUID> {
@@ -55,7 +65,8 @@ extension GRDBAnalysisRepository {
       database,
       sql: """
         SELECT id FROM account
-        WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+        WHERE type IN (\(GRDBAnalysisRepository.investmentLikeTypesSQLList))
+          AND valuation_mode = 'calculatedFromTrades'
         """)
     var ids = Set<UUID>()
     ids.reserveCapacity(rows.count)

--- a/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
@@ -195,19 +195,21 @@ struct DailyBalancesPlanPinningTests {
     let database = try makeDatabase()
     // Mirrors the per-account id loader driven by
     // `GRDBAnalysisRepository.fetchInvestmentAccountIds`. The
-    // production SQL filters on `type = 'investment'` AND
-    // `valuation_mode = 'recordedValue'` so the snapshot fold only
-    // applies to recorded-value investment accounts. The
-    // `account_by_type` index keys on `(type)` and serves the
-    // selective `type = 'investment'` predicate; the
-    // `valuation_mode` predicate filters the candidate rows post-seek.
-    // SQLite emits `SEARCH account USING INDEX account_by_type` for
-    // this shape, which is *not* a full table scan.
+    // production SQL filters on an investment-like `type`
+    // (`investmentLikeTypesSQLList`) AND `valuation_mode =
+    // 'recordedValue'` so the snapshot fold only applies to
+    // recorded-value investment-like accounts. The `account_by_type`
+    // index keys on `(type)` and serves the selective type `IN` list
+    // via per-value index seeks; the `valuation_mode` predicate filters
+    // the candidate rows post-seek. SQLite emits `SEARCH account USING
+    // INDEX account_by_type` for this shape, which is *not* a full
+    // table scan.
     let detail = try planDetail(
       database,
       query: """
         SELECT id FROM account
-        WHERE type = 'investment' AND valuation_mode = 'recordedValue'
+        WHERE type IN (\(GRDBAnalysisRepository.investmentLikeTypesSQLList))
+          AND valuation_mode = 'recordedValue'
         """)
     #expect(detail.contains("SEARCH account USING INDEX account_by_type"))
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
@@ -218,18 +220,20 @@ struct DailyBalancesPlanPinningTests {
     let database = try makeDatabase()
     // Mirrors the per-account id loader driven by
     // `GRDBAnalysisRepository.fetchTradesModeInvestmentAccountIds`. The
-    // production SQL filters on `type = 'investment'` AND
-    // `valuation_mode = 'calculatedFromTrades'`. The `account_by_type`
-    // index keys on `(type)` and serves the selective `type =
-    // 'investment'` predicate; the `valuation_mode` predicate filters
-    // the candidate rows post-seek. SQLite emits `SEARCH account USING
-    // INDEX account_by_type` for this shape, which is *not* a full
-    // table scan.
+    // production SQL filters on an investment-like `type`
+    // (`investmentLikeTypesSQLList`) AND `valuation_mode =
+    // 'calculatedFromTrades'`. The `account_by_type` index keys on
+    // `(type)` and serves the selective type `IN` list via per-value
+    // index seeks; the `valuation_mode` predicate filters the candidate
+    // rows post-seek. SQLite emits `SEARCH account USING INDEX
+    // account_by_type` for this shape, which is *not* a full table
+    // scan.
     let detail = try planDetail(
       database,
       query: """
         SELECT id FROM account
-        WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+        WHERE type IN (\(GRDBAnalysisRepository.investmentLikeTypesSQLList))
+          AND valuation_mode = 'calculatedFromTrades'
         """)
     #expect(detail.contains("SEARCH account USING INDEX account_by_type"))
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))

--- a/MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
+++ b/MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
@@ -1,32 +1,49 @@
-// MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
 import Foundation
 import GRDB
 import Testing
 
 @testable import Moolah
 
-/// `fetchInvestmentAccountIds` must not surface trades-mode investment
-/// accounts. The daily-balance snapshot fold owns recorded-value
-/// accounts only; trades-mode accounts get their per-day value from a
-/// different (planned) path. Pinning this filter at the SQL boundary
-/// keeps the snapshot loader from leaking trades-mode ids into the
-/// fold, which would overwrite the calculated value with a stale or
-/// missing snapshot.
-@Suite("fetchInvestmentAccountIds filters by mode")
+/// The daily-balance investment-account loaders split accounts by
+/// valuation mode — `fetchInvestmentAccountIds` owns the recorded-value
+/// snapshot fold, `fetchTradesModeInvestmentAccountIds` owns the
+/// trades-mode position valuation. Both must classify by the
+/// *investment-like* account types (`investment`, `crypto`, `exchange`),
+/// not the literal `type = 'investment'`. A crypto or exchange account
+/// missing from these sets leaks into the bank-balance (`.balance`) sum,
+/// overstating current funds and understating investments.
+@Suite("Investment-account id loaders filter by investment-like type and mode")
 struct InvestmentAccountIdsModeFilterTests {
-  @Test("only recordedValue investment accounts are returned")
-  func filtersByMode() throws {
+  @Test("recorded-value loader returns every investment-like recordedValue account")
+  func recordedValueLoaderCoversInvestmentLikeTypes() throws {
+    let queue = try makeAccountsQueue()
+    let ids = try queue.read { database in
+      try GRDBAnalysisRepository.fetchInvestmentAccountIds(database: database)
+    }
+    #expect(ids == Set(Self.recordedInvestmentLikeIds))
+  }
+
+  @Test("trades-mode loader returns every investment-like calculatedFromTrades account")
+  func tradesModeLoaderCoversInvestmentLikeTypes() throws {
+    let queue = try makeAccountsQueue()
+    let ids = try queue.read { database in
+      try GRDBAnalysisRepository.fetchTradesModeInvestmentAccountIds(database: database)
+    }
+    #expect(ids == Set(Self.tradesInvestmentLikeIds))
+  }
+
+  // The investment-like ids expected from each loader: one investment,
+  // one crypto, one exchange account per valuation mode. The bank
+  // control must never appear in either set.
+  private static let recordedInvestmentLikeIds = [UUID(), UUID(), UUID()]
+  private static let tradesInvestmentLikeIds = [UUID(), UUID(), UUID()]
+  private static let bankId = UUID()
+
+  private func makeAccountsQueue() throws -> DatabaseQueue {
     let queue = try DatabaseQueue()
     try ProfileSchema.migrator.migrate(queue)
-    let recordedId = UUID()
-    let tradesId = UUID()
-    let bankId = UUID()
     try queue.write { database in
-      for (id, type, mode) in [
-        (recordedId, "investment", "recordedValue"),
-        (tradesId, "investment", "calculatedFromTrades"),
-        (bankId, "bank", "recordedValue"),
-      ] {
+      for seed in Self.seeds {
         try database.execute(
           sql: """
             INSERT INTO account
@@ -34,12 +51,29 @@ struct InvestmentAccountIdsModeFilterTests {
                is_hidden, valuation_mode)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-          arguments: [id, "AccountRecord|\(id)", "n", type, "AUD", 0, 0, mode])
+          arguments: [
+            seed.id, "AccountRecord|\(seed.id)", "n", seed.type, "AUD", 0, 0, seed.mode,
+          ])
       }
     }
-    let ids = try queue.read { database in
-      try GRDBAnalysisRepository.fetchInvestmentAccountIds(database: database)
-    }
-    #expect(ids == [recordedId])
+    return queue
   }
+
+  /// One account per (type, mode) combination that matters, plus a bank
+  /// control that must never appear in either set.
+  private struct Seed {
+    let id: UUID
+    let type: String
+    let mode: String
+  }
+
+  private static let seeds: [Seed] = [
+    Seed(id: recordedInvestmentLikeIds[0], type: "investment", mode: "recordedValue"),
+    Seed(id: recordedInvestmentLikeIds[1], type: "crypto", mode: "recordedValue"),
+    Seed(id: recordedInvestmentLikeIds[2], type: "exchange", mode: "recordedValue"),
+    Seed(id: tradesInvestmentLikeIds[0], type: "investment", mode: "calculatedFromTrades"),
+    Seed(id: tradesInvestmentLikeIds[1], type: "crypto", mode: "calculatedFromTrades"),
+    Seed(id: tradesInvestmentLikeIds[2], type: "exchange", mode: "calculatedFromTrades"),
+    Seed(id: bankId, type: "bank", mode: "recordedValue"),
+  ]
 }


### PR DESCRIPTION
## Problem

The daily-balance investment-account loaders (`fetchInvestmentAccountIds`, `fetchTradesModeInvestmentAccountIds`) classified accounts by the literal `type = 'investment'`. Crypto wallets (`type = 'crypto'`) and exchange accounts (`type = 'exchange'`) — both created in `calculatedFromTrades` mode — fell through the filter, so their converted market value was summed into the bank-balance (`.balance` / **Current Funds**) series instead of the investments total.

### Symptoms
- The **liquidity insight** reported "Liquid cash" far above the account list's current-accounts total (observed on a real profile: **$341,385.56 vs $204,956.13**, the ~$136k gap being crypto/exchange market value), then compared that inflated figure against the spending buffer.
- The **Net Worth chart** mis-split Current Funds (overstated) vs Investments (understated) for any profile with crypto/exchange accounts.
- **Net worth totals were correct** — every account was still counted exactly once; only the cash-vs-investment split was wrong.

## Fix

Route both loaders through the existing `GRDBAnalysisRepository.investmentLikeTypesSQLList` constant (`'investment', 'crypto', 'exchange'`, derived from `AccountType.isInvestmentLike`) — the same classifier the income/expense aggregation already uses. Crypto/exchange accounts now:
- valuate via the trades-mode position fold (`applyTradesModePositionValuations`), and
- are excluded from the bank-balance sum.

The `backfillValuationMode` migration was intentionally left unchanged (per review — crypto/exchange are already created in trades mode, so it's a no-op for them).

## Scope

This is the daily-balance/Net-Worth-chart classification only. The mislabeled "Liquid cash" insight figure is corrected as a consequence. A separate, still-open design question (whether the liquidity insight should use Available Funds — net of earmarks — as its input) is **not** addressed here.

## Tests
- `InvestmentAccountIdsModeFilterTests` — expanded to pin both loaders across investment/crypto/exchange × both valuation modes, with a bank control. Written failing first (RED), then GREEN.
- `DailyBalancesPlanPinningTests` — updated to mirror the new `type IN (...)` SQL; the `account_by_type` index still serves it via per-value seeks (no full scan).
- Full macOS suite: **4308 tests / 756 suites pass**. `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)