### PR TITLE
docs(claude-md): prefer EnterWorktree(name)/wt over raw git worktree add

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,24 @@
 
 **`main` is protected and does not accept direct pushes.** All changes must land via a pull request.
 
-- **Default to a worktree.** Never make changes directly on the `main` checkout. At the start of any task that modifies files, create a git worktree on a feature branch (see the `superpowers:using-git-worktrees` skill). `.worktrees/` is gitignored.
+- **Default to a worktree, created with `EnterWorktree(name: <branch>)`.** Never make changes directly on the `main` checkout. At the start of any task that modifies files, create a worktree with **`EnterWorktree(name: <branch>)`**. The `worktrunk` plugin's `WorktreeCreate` hook routes this through the `wt` CLI, whose `pre-start` hooks **copy the gitignored `.env` from the main checkout** and **rebase the new worktree onto `origin`'s default branch** automatically. **Do not** create worktrees with raw `git worktree add`, and **do not** hand-copy `.env` — both bypass `wt` and its hooks (and its path convention). Clean up a finished worktree (PR on automerge) with **`ExitWorktree(action: "remove")`**, which routes through `wt remove`; pass `discard_changes: true` if it balks at the gitignored `.env`.
 - **Ship via PR.** Push the feature branch and open a pull request with `gh pr create`. Do not attempt `git push origin main` — it will be rejected by branch protection.
 - **Exceptions:** Read-only inspection and investigation can happen on the `main` checkout without a worktree. If you're unsure whether a task will require edits, create the worktree up front.
 
-### `EnterWorktree` refuses to nest — `ExitWorktree` first
+### Already in a worktree? `EnterWorktree` refuses to nest — `ExitWorktree` first
 
-`EnterWorktree` fails with "Already in a worktree session" if the session is **already** inside a worktree (common when a previous task's worktree is still active, or a new task arrives in an existing worktree). It refuses to create or enter a nested worktree.
+`EnterWorktree` fails with "Already in a worktree session" if the session is **already** inside a worktree (common when a previous task's worktree is still active, or a new task arrives in an existing worktree). To start a *different* worktree, return to the `main` checkout first, then create the new one through `wt`:
 
-`ExitWorktree` is **not** limited to worktrees created by `EnterWorktree` in the current session — calling it returns the session to the original `main` checkout regardless, leaving the old worktree's branch and files intact on disk. So the reliable sequence when you need a *different* worktree than the one you're in:
+1. `ExitWorktree` — `action: "keep"` to preserve the current worktree (its branch and files stay on disk), or `action: "remove"` if its work is done. Either way the session returns to the `main` checkout.
+2. `EnterWorktree(name: <branch>)` — creates the new worktree through `wt` (running the `.env`-copy and rebase hooks) and switches the session into it.
 
-1. Create the new worktree up front with `git -C <repo> worktree add --no-track .claude/worktrees/<name> -b <branch> origin/main` (the manual fallback; do this *before* exiting so the old worktree's context is still available while you set up).
-2. `ExitWorktree` with `action: "keep"` — returns the session to the `main` checkout without disturbing the old worktree.
-3. `EnterWorktree` with `path:` pointing at the worktree you just created — the session switches into it cleanly.
-
-Do **not** try to operate on a second worktree purely via absolute paths while the session CWD is stuck in the first one: skill, plan, and memory resolution all key off the session CWD, so they will silently target the wrong tree.
+Do **not** dodge the nesting restriction with a raw `git -C <repo> worktree add` + `EnterWorktree(path:)` — entering a pre-made worktree does **not** fire the `WorktreeCreate` hook, so it bypasses `wt`, its hooks, and its path convention (this mistake has happened). And do **not** operate on a second worktree purely via absolute paths while the session CWD is stuck in the first one: skill, plan, and memory resolution all key off the session CWD, so they will silently target the wrong tree.
 
 ### Stacked-PR worktrees: don't accidentally push into the parent PR
 
-When you create a worktree branched off another PR's head (e.g. stacking a fix-up PR on top of an open PR), `git worktree add -b <new-local> <remote-tracking-branch>` silently sets the new local branch to **track the parent's remote branch**. A subsequent `git push -u origin <new-local>` then pushes your commits *into the parent PR's branch* — overwriting or extending the wrong PR. This has happened; recovery requires a force-push to restore the parent.
+The default `EnterWorktree(name:)` flow branches off `origin`'s default branch, and the `landing-prs` skill handles stacking by retargeting a child PR to `main` once its parent merges — prefer that over hand-picking a base. The footgun below applies only if you deliberately bypass `wt` with a raw `git worktree add` off another PR's head.
+
+When you create such a worktree (e.g. stacking a fix-up PR on top of an open PR), `git worktree add -b <new-local> <remote-tracking-branch>` silently sets the new local branch to **track the parent's remote branch**. A subsequent `git push -u origin <new-local>` then pushes your commits *into the parent PR's branch* — overwriting or extending the wrong PR. This has happened; recovery requires a force-push to restore the parent.
 
 To prevent it:
 


### PR DESCRIPTION
The project `CLAUDE.md` Git Workflow section steered toward creating worktrees with raw `git worktree add` + `EnterWorktree(path:)` and hand-copying `.env` — which bypasses the `worktrunk` plugin entirely.

The plugin's `hooks.json` wires `WorktreeCreate` → `wt switch --create --no-cd` and `WorktreeRemove` → `wt remove`. So **`EnterWorktree(name:)` already routes through `wt`**, running the user's `pre-start` hooks (copy `.env` from the main checkout, rebase onto `origin`'s default branch), and **`ExitWorktree(action: "remove")`** cleans up through `wt`. Entering a *pre-made* worktree via `path:` does **not** fire `WorktreeCreate`, which is exactly how the old guidance silently bypassed `wt` (verified empirically — a probe `EnterWorktree(name:)` landed at the `wt` path with `.env` copied and rebased onto `origin/main`).

### Changes
- **Default-worktree bullet:** use `EnterWorktree(name: <branch>)`; note the auto `.env` copy + rebase; clean up with `ExitWorktree(action: "remove")`. Don't use raw `git worktree add` or hand-copy `.env`.
- **"Refuses to nest" section:** corrected sequence is `ExitWorktree` → `EnterWorktree(name:)`, not the manual `git worktree add` + `EnterWorktree(path:)` fallback (which bypasses the hook).
- **Stacked-PR section:** scoped to the deliberate raw-`git worktree add` bypass; points at the `landing-prs` retarget-after-merge flow as the default.

Docs-only change to `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)