### PR TITLE
fix(analysis): single-flight all loads to bound the reload storm (#1163)

### DIFF
--- a/Features/Analysis/AnalysisStore+Observation.swift
+++ b/Features/Analysis/AnalysisStore+Observation.swift
@@ -43,19 +43,12 @@ extension AnalysisStore {
   }
 
   /// Force a reload in response to a price-cache rate tick (a background
-  /// warm landed new crypto prices). Coalesces bursts: if a reload is
-  /// already running, run exactly one more when it finishes. See #1075.
+  /// warm landed new crypto prices). Routes through `loadAll(force:)`,
+  /// which single-flights and coalesces: if a load is already running
+  /// (including the view's initial load), this becomes one trailing
+  /// reconcile pass rather than a concurrent recompute. See #1163, #1075.
   func reloadForRateTick() async {
-    if rateTickReloadInFlight {
-      rateTickReloadPending = true
-      return
-    }
-    rateTickReloadInFlight = true
-    defer { rateTickReloadInFlight = false }
-    repeat {
-      rateTickReloadPending = false
-      await loadAll(force: true)
-    } while rateTickReloadPending
+    await loadAll(force: true)
   }
 
   /// Test-only: yields a tick after every consumed rate-stream emission

--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -59,15 +59,21 @@ final class AnalysisStore {
   private let defaults: UserDefaults
   private let logger = Logger(subsystem: "com.moolah.app", category: "AnalysisStore")
 
-  // MARK: - Rate-tick reload coalescing
+  // MARK: - Load coalescing
 
-  /// True while a `reloadForRateTick()`-driven `loadAll(force:)` is in
-  /// flight. Bursts of rate ticks that arrive during a reload coalesce
-  /// into exactly one trailing re-run (see `reloadForRateTick`).
-  /// Non-private so the sibling `+Observation.swift` extension's
-  /// `reloadForRateTick` can read/write them.
-  var rateTickReloadInFlight = false
-  var rateTickReloadPending = false
+  /// True while a `loadAll(...)` pass is running. A single gate over ALL
+  /// loads — the view's initial load, filter-change reloads, and rate-tick
+  /// reloads alike — so a load requested while another is in flight never
+  /// runs concurrently; it coalesces into exactly one trailing reconcile
+  /// pass. This bounds the reload storm: the initial load's own price
+  /// fetches write the cache `observeRates()` watches, firing ticks
+  /// mid-load; without the gate each such tick spawns a fresh full
+  /// recompute (a populated profile cascades ~4–5 times). See #1163, #1075.
+  private var loadInFlight = false
+  private var pendingReload = false
+  /// Whether the coalesced trailing pass must bypass the cache guard
+  /// (a rate tick was among the coalesced requests). See `loadAll(force:)`.
+  private var pendingReloadForce = false
 
   /// The single observation `Task` draining `conversionService.observeRates()`
   /// / `observeErrors()`. Spawned from `init`, torn down by `stopObserving()`
@@ -133,7 +139,37 @@ final class AnalysisStore {
 
   // MARK: - Data Loading
 
+  /// Single-flight entry point for every load. A load requested while
+  /// another is running does not start concurrently — it coalesces into
+  /// exactly one trailing reconcile pass that re-reads the current filters.
+  /// A rate tick (`force`) makes that pass bypass the cache guard. This is
+  /// what tames the reload storm; see the `loadInFlight` doc and #1163.
   func loadAll(force: Bool = false) async {
+    if loadInFlight {
+      pendingReload = true
+      if force { pendingReloadForce = true }
+      return
+    }
+    loadInFlight = true
+    defer { loadInFlight = false }
+    var passForce = force
+    repeat {
+      // If the owning task (e.g. the view's `.task`) was cancelled while a
+      // pass ran, stop here rather than running the coalesced reconcile on
+      // a torn-down view — `performLoad` swallows `CancellationError`, so it
+      // would otherwise issue a wasted fetch and restamp `lastLoadedAt`.
+      guard !Task.isCancelled else { break }
+      pendingReload = false
+      pendingReloadForce = false
+      await performLoad(force: passForce)
+      // Any load requested during `performLoad` above set `pendingReload`
+      // (and `pendingReloadForce` if it was a rate tick); carry that force
+      // into the single trailing reconcile pass.
+      passForce = pendingReloadForce
+    } while pendingReload
+  }
+
+  private func performLoad(force: Bool) async {
     monthEnd = Calendar.current.component(.day, from: Date())
     error = nil
 

--- a/MoolahTests/Features/AnalysisStoreLoadCancellationTests.swift
+++ b/MoolahTests/Features/AnalysisStoreLoadCancellationTests.swift
@@ -39,4 +39,33 @@ struct AnalysisStoreLoadCancellationTests {
     #expect(store.error == nil)
     #expect(!store.isLoading)
   }
+
+  /// A rate tick that coalesces into a pending reconcile while the initial
+  /// load is in flight must NOT run after the owning task is cancelled.
+  /// Without the `Task.isCancelled` guard in `loadAll`'s coalescing loop,
+  /// the trailing reconcile would issue a second wasted fetch on a
+  /// torn-down view and restamp `lastLoadedAt`. See #1163.
+  @Test
+  func cancellationDuringInitialLoadSkipsCoalescedReconcile() async throws {
+    let repository = GatedCountingAnalysisRepository()
+    let store = AnalysisStore(
+      repository: repository, conversionService: StubConversionService(),
+      defaults: try makeDefaults())
+
+    let task = Task { @MainActor in await store.loadAll() }
+    await repository.waitUntilFetchStarted()
+    // A rate tick lands during the in-flight initial load → coalesced into
+    // a single pending reconcile pass.
+    await store.reloadForRateTick()
+    // The view tears down before the initial load completes.
+    task.cancel()
+    await repository.releaseAll()
+    await task.value
+
+    // Only the initial fetch ran; the coalesced reconcile was skipped.
+    let count = await repository.loadAllCount
+    #expect(count == 1)
+    #expect(store.error == nil)
+    #expect(!store.isLoading)
+  }
 }

--- a/MoolahTests/Features/AnalysisStoreRateTickTests.swift
+++ b/MoolahTests/Features/AnalysisStoreRateTickTests.swift
@@ -40,14 +40,38 @@ struct AnalysisStoreRateTickTests {
     await repository.waitUntilFetchStarted()
     // These three observe the in-flight reload and coalesce to a single
     // pending re-run. Each returns synchronously (no suspension) because
-    // `reloadForRateTick` short-circuits on `rateTickReloadInFlight`,
-    // so awaiting them sequentially is deterministic.
+    // the in-flight load gate short-circuits a concurrent reload, so
+    // awaiting them sequentially is deterministic.
     await store.reloadForRateTick()
     await store.reloadForRateTick()
     await store.reloadForRateTick()
     await repository.releaseAll()
     await first.value
     // Exactly one in-flight reload + one coalesced re-run.
+    let count = await repository.loadAllCount
+    #expect(count == 2)
+  }
+
+  @Test("rate ticks during the view's initial load coalesce to one reconcile")
+  func ticksDuringInitialLoadCoalesce() async throws {
+    let repository = GatedCountingAnalysisRepository()
+    let store = AnalysisStore(
+      repository: repository, conversionService: StubConversionService(),
+      defaults: try makeDefaults())
+    // The view-initiated initial load is held at the gate, unambiguously
+    // in flight. Rate ticks that land during it (the load fetching prices
+    // writes the very cache `observeRates()` watches — the reload storm)
+    // must coalesce into exactly ONE trailing reconcile, not spawn a fresh
+    // full reload each. See #1163.
+    let initial = Task { @MainActor in await store.loadAll() }
+    await repository.waitUntilFetchStarted()
+    await store.reloadForRateTick()
+    await store.reloadForRateTick()
+    await store.reloadForRateTick()
+    await repository.releaseAll()
+    await initial.value
+    // Initial load (1) + one coalesced reconcile from the 3 ticks (1) = 2,
+    // not 4 (which is what spawning a fresh reload per tick would give).
     let count = await repository.loadAllCount
     #expect(count == 2)
   }


### PR DESCRIPTION
**PR 1 of 2 for #1163** — Analysis page slow on first open.

## Problem

Opening the app (Analysis is the default view) churns for a long time on the first load per session/day. Live measurement on a prod-copy profile showed **~25,819 conversions across ~5 full recompute passes**.

Root cause of the *multiplier*: the initial load lazily fetches crypto prices; each price-cache write trips `conversionService.observeRates()` → `reloadForRateTick()` → `loadAll(force: true)`, which recomputes the entire history and fetches more prices → more ticks → cascade. The prior coalescing (#1075) only gated rate-tick reloads against *each other*, never against the view's own initial `loadAll()`, so ticks during the initial load each spawned a fresh concurrent recompute.

## Fix

Unify **every** load — the view's initial load, filter-change reloads, and rate-tick reloads — under one single-flight gate in `AnalysisStore.loadAll(force:)`. A load requested while another is in flight coalesces into **exactly one** trailing reconcile pass instead of a concurrent/cascading reload. A `Task.isCancelled` guard skips that reconcile when the owning view task has torn down.

This bounds the cascade to ≤2 passes deterministically (no timers). Conversion *results* are unchanged — this only governs *when* reloads fire. PR 2 makes each individual pass fast (concurrent conversion pre-warm).

## Tests

- `ticksDuringInitialLoadCoalesce` — 3 ticks during a gated initial load → 2 total fetches (initial + one reconcile), not 4.
- `cancellationDuringInitialLoadSkipsCoalescedReconcile` — cancel mid-load → coalesced reconcile is skipped, no error/loading leak.
- Existing rate-tick, cache-gate, clip, refresh-if-stale, and load-cancellation suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4LphNRBYdAZSbgHNmmCg6