### PR TITLE
perf(analysis): pre-warm conversions before the serial daily-balance walk (#1163)

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
@@ -75,20 +75,6 @@ extension GRDBAnalysisRepository {
       earmarkRows: aggregation.priorEarmarkRows,
       context: context)
 
-    // Pre-warm every conversion the per-day walk will perform, fanned out
-    // concurrently, so the underlying network price fetches overlap and the
-    // conversion memo is populated before the *serial* walk below — which
-    // then hits warm caches instead of awaiting each rate one at a time.
-    // Best-effort: the walk re-runs (and handles per Rule 11) any conversion
-    // that did not warm, so results are unchanged. See #1163.
-    let warmups = collectConversionWarmups(
-      priorAccountRows: aggregation.priorAccountRows,
-      priorEarmarkRows: aggregation.priorEarmarkRows,
-      accountRows: aggregation.accountRows,
-      earmarkRows: aggregation.earmarkRows,
-      context: context)
-    await prewarmConversions(warmups, to: profileInstrument, using: conversionService)
-
     var dailyBalances = try await walkDays(
       book: &book,
       accountRows: aggregation.accountRows,

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
@@ -23,131 +23,6 @@ import GRDB
 /// snapshot is the best available estimate.
 extension GRDBAnalysisRepository {
 
-  // MARK: - Row types
-
-  /// One row of the per-(day, account, instrument, type) SUM that
-  /// drives the historic span of `fetchDailyBalances`.
-  ///
-  /// `day` is the ISO-8601 `YYYY-MM-DD` string returned by
-  /// `DATE(t.date)` (UTC calendar day) — kept for diagnostics and as
-  /// the failure-callback context. The actual day-key passed to
-  /// `PositionBook.dailyBalance(...)` comes from `sampleDate` (a raw
-  /// `t.date` instant inside the group) so `Calendar.current.startOfDay`
-  /// produces the *local* day-key the contract tests expect — UTC-day
-  /// grouping diverges from local-day at TZ boundaries, which is fine
-  /// for indexing but wrong for the result key.
-  struct DailyBalanceAccountRow: Sendable {
-    let day: String
-    let sampleDate: Date
-    let accountId: UUID
-    let instrumentId: String
-    /// Raw value of `TransactionType` (`"income"`, `"expense"`,
-    /// `"transfer"`, `"openingBalance"`, `"trade"`). Pinned by the
-    /// `transaction_leg.type` CHECK constraint.
-    let type: String
-    let qty: Int64
-  }
-
-  /// One row of the per-(day, earmark, instrument, type) SUM. Same
-  /// shape as `DailyBalanceAccountRow` but keyed by `earmark_id`
-  /// instead of `account_id` — the earmark dimension drives the
-  /// `earmarks` map inside `PositionBook` and is fetched by a sibling
-  /// query so the leg-side index stays covering on
-  /// `leg_analysis_by_earmark_type`.
-  struct DailyBalanceEarmarkRow: Sendable {
-    let day: String
-    let sampleDate: Date
-    let earmarkId: UUID
-    let instrumentId: String
-    let type: String
-    let qty: Int64
-  }
-
-  // MARK: - Assembly input bundle
-
-  /// Bundle of inputs for `assembleDailyBalances` — every value that
-  /// crosses the `database.read` boundary fits inside this single
-  /// `Sendable` aggregation so the read closure surfaces one MVCC
-  /// snapshot to the converter.
-  ///
-  /// - `priorAccountRows` / `priorEarmarkRows` seed the `PositionBook`
-  ///   with pre-`after` legs under the `asStartingBalance: true`
-  ///   semantics (every leg type on an investment account contributes
-  ///   to `accountsFromTransfers`, matching the
-  ///   `investmentTransfersOnly: false` baseline applied before the
-  ///   cutoff).
-  /// - `accountRows` / `earmarkRows` carry the post-`after` deltas.
-  /// - `investmentValues` carries every `investment_value` row — all
-  ///   historical snapshots are loaded so the cursor walk in
-  ///   `applyInvestmentValues` can carry the most recent pre-window
-  ///   value forward into the first in-window day.
-  /// - `scheduled` carries the scheduled `[Transaction]` for the
-  ///   forecast extrapolation — the forecast path stays Swift-only
-  ///   because SQL can't extrapolate recurring patterns.
-  struct DailyBalancesAggregation: Sendable {
-    let priorAccountRows: [DailyBalanceAccountRow]
-    let priorEarmarkRows: [DailyBalanceEarmarkRow]
-    let accountRows: [DailyBalanceAccountRow]
-    let earmarkRows: [DailyBalanceEarmarkRow]
-    let investmentValues: [InvestmentValueSnapshot]
-    let investmentAccountIds: Set<UUID>
-    /// Account ids of trades-mode investment accounts. Drives the new
-    /// per-day position-valuation fold; recorded-value accounts are
-    /// carried in `investmentAccountIds` and drive the snapshot fold.
-    let tradesModeInvestmentAccountIds: Set<UUID>
-    /// Pre-cutoff `transaction_leg` SUM rows filtered to trades-mode
-    /// investment accounts only. Pre-fold seed for the new fold's
-    /// cumulative position dict.
-    let priorTradesModeAccountRows: [DailyBalanceAccountRow]
-    /// Post-cutoff `transaction_leg` SUM rows filtered to trades-mode
-    /// investment accounts only.
-    let tradesModeAccountRows: [DailyBalanceAccountRow]
-    let scheduled: [Transaction]
-    let instrumentMap: [String: Instrument]
-    let forecastUntil: Date?
-  }
-
-  // MARK: - Handler and context types
-
-  /// Diagnostic context passed to the conversion-failure handler so
-  /// the caller's logger can identify which day failed without
-  /// coupling this helper to a `Logger` instance.
-  struct DailyBalancesFailureContext: Sendable {
-    let day: String
-  }
-
-  /// Bundle of per-day diagnostic callbacks used by
-  /// `assembleDailyBalances`. Matches the
-  /// `ExpenseBreakdownHandlers` / `CategoryBalancesHandlers` /
-  /// `IncomeAndExpenseHandlers` shape so future analysis methods can
-  /// share the same handler pattern. Investment-value failures use
-  /// their own callback because they fire at the post-loop fold-in
-  /// step and carry per-account context — folding them into
-  /// `handleConversionFailure` would dilute the per-day signal.
-  struct DailyBalancesHandlers: Sendable {
-    let handleUnparseableDay: @Sendable (String) -> Void
-    let handleConversionFailure: @Sendable (Error, DailyBalancesFailureContext) -> Void
-    let handleInvestmentValueFailure: @Sendable (Error, Date) -> Void
-  }
-
-  /// Fixed inputs that stay constant across every per-day call inside
-  /// `walkDays` and the investment-value fold-in. Lifts the
-  /// `investmentAccountIds`, `instrumentMap`, `profileInstrument`, and
-  /// `conversionService` references out of every helper signature so
-  /// each function fits SwiftLint's `function_parameter_count` budget.
-  struct DailyBalancesAssemblyContext: Sendable {
-    let investmentAccountIds: Set<UUID>
-    /// Account ids of trades-mode investment accounts — read by
-    /// `applyTradesModePositionValuations` to early-exit when the
-    /// profile has none. None of the seed/walk helpers consult this
-    /// field; trades-mode accounts contribute through the new fold,
-    /// not through `accountsFromTransfers`.
-    let tradesModeInvestmentAccountIds: Set<UUID>
-    let instrumentMap: [String: Instrument]
-    let profileInstrument: Instrument
-    let conversionService: any InstrumentConversionService
-  }
-
   // MARK: - Public assembly entry point
 
   /// Walks the per-day deltas, mutates a `PositionBook`, calls
@@ -195,6 +70,20 @@ extension GRDBAnalysisRepository {
       accountRows: aggregation.priorAccountRows,
       earmarkRows: aggregation.priorEarmarkRows,
       context: context)
+
+    // Pre-warm every conversion the per-day walk will perform, fanned out
+    // concurrently, so the underlying network price fetches overlap and the
+    // conversion memo is populated before the *serial* walk below — which
+    // then hits warm caches instead of awaiting each rate one at a time.
+    // Best-effort: the walk re-runs (and handles per Rule 11) any conversion
+    // that did not warm, so results are unchanged. See #1163.
+    let warmups = collectConversionWarmups(
+      priorAccountRows: aggregation.priorAccountRows,
+      priorEarmarkRows: aggregation.priorEarmarkRows,
+      accountRows: aggregation.accountRows,
+      earmarkRows: aggregation.earmarkRows,
+      context: context)
+    await prewarmConversions(warmups, to: profileInstrument, using: conversionService)
 
     var dailyBalances = try await walkDays(
       book: &book,

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
@@ -1,9 +1,13 @@
 import Foundation
 import GRDB
 
-/// Swift assembly helpers and shared types for `fetchDailyBalances`.
-/// Companion files split the workload further:
+/// Swift assembly orchestration for `fetchDailyBalances`. Companion files
+/// split the workload further:
+/// - `+DailyBalancesTypes.swift` holds the row, bundle, handler, and
+///   context types shared across the siblings.
 /// - `+DailyBalancesAggregation.swift` holds the four SQL fetches.
+/// - `+DailyBalancesPrewarm.swift` holds the concurrent conversion
+///   pre-warm that runs before the serial walk.
 /// - `+DailyBalancesInvestmentValues.swift` holds the per-day
 ///   recorded-value snapshot fold-in.
 /// - `+DailyBalancesTradesMode.swift` holds the per-day trades-mode

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesPrewarm.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesPrewarm.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Conversion pre-warm for `fetchDailyBalances`. Splits the warm-up
+/// collection and concurrent fan-out out of `+DailyBalances.swift` (sibling
+/// to `+DailyBalancesAggregation.swift`, `+DailyBalancesForecast.swift`,
+/// etc.).
+///
+/// The per-day balance walk converts each held instrument to the profile
+/// instrument *serially*, awaiting one rate at a time — on a populated
+/// profile that is thousands of awaited conversions, and the first lookup
+/// per `(token, date)` blocks on a network price fetch. Resolving the same
+/// set up front, fanned out concurrently, overlaps those network fetches and
+/// fills the conversion memo so the serial walk then hits warm caches. See
+/// #1163.
+extension GRDBAnalysisRepository {
+
+  /// Collect the distinct `(instrument, day-instant)` conversions the
+  /// per-day `walkDays` loop will perform, in day order. The instrument
+  /// set is the running union seeded by the prior rows (which
+  /// `seedPriorBook` installs from day zero) and grown by each day's
+  /// deltas — mirroring `walkDays` + `applyDailyDeltas`. Each instrument
+  /// is paired with that day's representative `sampleDate`, the same
+  /// instant the walk converts on, so the warmed memo key matches the
+  /// walk's conversion exactly. The profile instrument is excluded:
+  /// `PositionBook.dailyBalance`'s same-instrument fast path never
+  /// converts it.
+  ///
+  /// Over-approximates only harmlessly: an instrument whose post-cutoff
+  /// position lives solely on an investment account (so the walk reads it
+  /// via `accountsFromTransfers`, not the bank sum) may be warmed for a
+  /// day the walk skips — a wasted cache hit, never a wrong result.
+  /// Internal so `GRDBAnalysisPrewarmTests` can pin the running-union math.
+  static func collectConversionWarmups(
+    priorAccountRows: [DailyBalanceAccountRow],
+    priorEarmarkRows: [DailyBalanceEarmarkRow],
+    accountRows: [DailyBalanceAccountRow],
+    earmarkRows: [DailyBalanceEarmarkRow],
+    context: DailyBalancesAssemblyContext
+  ) -> [(instrument: Instrument, date: Date)] {
+    let profileInstrument = context.profileInstrument
+    var active = Set<Instrument>()
+    for row in priorAccountRows {
+      active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+    }
+    for row in priorEarmarkRows {
+      active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+    }
+
+    let accountByDay = Dictionary(grouping: accountRows, by: \.day)
+    let earmarkByDay = Dictionary(grouping: earmarkRows, by: \.day)
+    let allDayStrings = Set(accountByDay.keys).union(earmarkByDay.keys).sorted()
+
+    var warmups: [(instrument: Instrument, date: Date)] = []
+    for dayString in allDayStrings {
+      let accountSlice = accountByDay[dayString] ?? []
+      let earmarkSlice = earmarkByDay[dayString] ?? []
+      for row in accountSlice {
+        active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+      }
+      for row in earmarkSlice {
+        active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+      }
+      let sample =
+        accountSlice.first.map(\.sampleDate) ?? earmarkSlice.first.map(\.sampleDate)
+      guard let sample else { continue }
+      for instrument in active where instrument != profileInstrument {
+        warmups.append((instrument: instrument, date: sample))
+      }
+    }
+    return warmups
+  }
+
+  /// Concurrently resolve the collected warm-up conversions (bounded
+  /// fan-out) so the underlying network price fetches overlap and the
+  /// conversion memo is populated before the serial walk. Best-effort: a
+  /// warm-up that fails is simply re-attempted — and its failure handled
+  /// per the Rule 11 contract — by the walk, so failures are swallowed
+  /// here and never alter the result.
+  static func prewarmConversions(
+    _ warmups: [(instrument: Instrument, date: Date)],
+    to target: Instrument,
+    using service: any InstrumentConversionService
+  ) async {
+    guard !warmups.isEmpty else { return }
+    let maxConcurrent = 16
+    await withTaskGroup(of: Void.self) { group in
+      var next = 0
+      let prime = min(maxConcurrent, warmups.count)
+      while next < prime {
+        let warmup = warmups[next]
+        group.addTask { await Self.warmOne(warmup, to: target, using: service) }
+        next += 1
+      }
+      while await group.next() != nil {
+        // Stop scheduling more warm-ups once the owning task is cancelled
+        // (the in-flight children drain at scope exit). The pre-warm is
+        // best-effort, so there's nothing to salvage by continuing.
+        guard !Task.isCancelled, next < warmups.count else { continue }
+        let warmup = warmups[next]
+        group.addTask { await Self.warmOne(warmup, to: target, using: service) }
+        next += 1
+      }
+    }
+  }
+
+  private static func warmOne(
+    _ warmup: (instrument: Instrument, date: Date),
+    to target: Instrument,
+    using service: any InstrumentConversionService
+  ) async {
+    _ = try? await service.convertResult(
+      InstrumentAmount(quantity: 1, instrument: warmup.instrument), to: target, on: warmup.date)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesPrewarm.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesPrewarm.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-/// Conversion pre-warm for `fetchDailyBalances`. Splits the warm-up
-/// collection and concurrent fan-out out of `+DailyBalances.swift` (sibling
-/// to `+DailyBalancesAggregation.swift`, `+DailyBalancesForecast.swift`,
-/// etc.).
+/// Conversion pre-warm for `fetchDailyBalances`: collects the distinct
+/// `(instrument, day-instant)` conversions the per-day walk will perform and
+/// resolves them concurrently before the serial walk runs.
 ///
 /// The per-day balance walk converts each held instrument to the profile
 /// instrument *serially*, awaiting one rate at a time — on a populated
@@ -25,11 +24,15 @@ extension GRDBAnalysisRepository {
   /// `PositionBook.dailyBalance`'s same-instrument fast path never
   /// converts it.
   ///
-  /// Over-approximates only harmlessly: an instrument whose post-cutoff
-  /// position lives solely on an investment account (so the walk reads it
-  /// via `accountsFromTransfers`, not the bank sum) may be warmed for a
-  /// day the walk skips — a wasted cache hit, never a wrong result.
-  /// Internal so `GRDBAnalysisPrewarmTests` can pin the running-union math.
+  /// Over-approximates only harmlessly — wasted warm-ups, never a missed
+  /// conversion that would change a result. Two known sources: an instrument
+  /// whose post-cutoff position lives solely on an investment account (the
+  /// walk reads it via `accountsFromTransfers`, not the bank sum, so some
+  /// days are skipped); and trades-mode account instruments, which the
+  /// separate `applyTradesModePositionValuations` fold converts at
+  /// `startOfDay(for: sampleDate)` rather than `sampleDate`, a memo key this
+  /// warm-up does not populate. Internal so `GRDBAnalysisPrewarmTests` can
+  /// pin the running-union math.
   static func collectConversionWarmups(
     priorAccountRows: [DailyBalanceAccountRow],
     priorEarmarkRows: [DailyBalanceEarmarkRow],
@@ -82,22 +85,28 @@ extension GRDBAnalysisRepository {
     using service: any InstrumentConversionService
   ) async {
     guard !warmups.isEmpty else { return }
+    // Bounded fan-out: enough in-flight conversions to overlap the
+    // per-(token, date) network price fetches, without flooding the
+    // provider hosts (the HTTP layer rate-limits per host) or spawning a
+    // task per day on a multi-year window. The conversion-service actor
+    // serialises the memo writes regardless, so a higher cap buys nothing.
     let maxConcurrent = 16
-    await withTaskGroup(of: Void.self) { group in
+    // A cancelled child rethrows `CancellationError` (see `warmOne`), which
+    // surfaces from `group.next()`, tears the group down, and propagates out
+    // — swallowed here because the pre-warm is best-effort: the serial walk
+    // re-runs and rethrows cancellation authoritatively.
+    try? await withThrowingTaskGroup(of: Void.self) { group in
       var next = 0
       let prime = min(maxConcurrent, warmups.count)
       while next < prime {
         let warmup = warmups[next]
-        group.addTask { await Self.warmOne(warmup, to: target, using: service) }
+        group.addTask { try await Self.warmOne(warmup, to: target, using: service) }
         next += 1
       }
-      while await group.next() != nil {
-        // Stop scheduling more warm-ups once the owning task is cancelled
-        // (the in-flight children drain at scope exit). The pre-warm is
-        // best-effort, so there's nothing to salvage by continuing.
-        guard !Task.isCancelled, next < warmups.count else { continue }
+      while try await group.next() != nil {
+        guard next < warmups.count else { continue }
         let warmup = warmups[next]
-        group.addTask { await Self.warmOne(warmup, to: target, using: service) }
+        group.addTask { try await Self.warmOne(warmup, to: target, using: service) }
         next += 1
       }
     }
@@ -107,8 +116,18 @@ extension GRDBAnalysisRepository {
     _ warmup: (instrument: Instrument, date: Date),
     to target: Instrument,
     using service: any InstrumentConversionService
-  ) async {
-    _ = try? await service.convertResult(
-      InstrumentAmount(quantity: 1, instrument: warmup.instrument), to: target, on: warmup.date)
+  ) async throws {
+    do {
+      _ = try await service.convertResult(
+        InstrumentAmount(quantity: 1, instrument: warmup.instrument), to: target, on: warmup.date)
+    } catch is CancellationError {
+      // Propagate cancellation so the group tears down promptly instead of
+      // running the remaining warm-ups for a torn-down load.
+      throw CancellationError()
+    } catch {
+      // Best-effort: a conversion that fails to warm is re-attempted — and
+      // its failure handled per the Rule 11 per-day contract — by the serial
+      // walk, so non-cancellation errors are intentionally discarded here.
+    }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesPrewarm.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesPrewarm.swift
@@ -34,23 +34,20 @@ extension GRDBAnalysisRepository {
   /// warm-up does not populate. Internal so `GRDBAnalysisPrewarmTests` can
   /// pin the running-union math.
   static func collectConversionWarmups(
-    priorAccountRows: [DailyBalanceAccountRow],
-    priorEarmarkRows: [DailyBalanceEarmarkRow],
-    accountRows: [DailyBalanceAccountRow],
-    earmarkRows: [DailyBalanceEarmarkRow],
-    context: DailyBalancesAssemblyContext
+    in aggregation: DailyBalancesAggregation,
+    profileInstrument: Instrument
   ) -> [(instrument: Instrument, date: Date)] {
-    let profileInstrument = context.profileInstrument
+    let instrumentMap = aggregation.instrumentMap
     var active = Set<Instrument>()
-    for row in priorAccountRows {
-      active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+    for row in aggregation.priorAccountRows {
+      active.insert(resolveInstrument(row.instrumentId, in: instrumentMap))
     }
-    for row in priorEarmarkRows {
-      active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+    for row in aggregation.priorEarmarkRows {
+      active.insert(resolveInstrument(row.instrumentId, in: instrumentMap))
     }
 
-    let accountByDay = Dictionary(grouping: accountRows, by: \.day)
-    let earmarkByDay = Dictionary(grouping: earmarkRows, by: \.day)
+    let accountByDay = Dictionary(grouping: aggregation.accountRows, by: \.day)
+    let earmarkByDay = Dictionary(grouping: aggregation.earmarkRows, by: \.day)
     let allDayStrings = Set(accountByDay.keys).union(earmarkByDay.keys).sorted()
 
     var warmups: [(instrument: Instrument, date: Date)] = []
@@ -58,10 +55,10 @@ extension GRDBAnalysisRepository {
       let accountSlice = accountByDay[dayString] ?? []
       let earmarkSlice = earmarkByDay[dayString] ?? []
       for row in accountSlice {
-        active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+        active.insert(resolveInstrument(row.instrumentId, in: instrumentMap))
       }
       for row in earmarkSlice {
-        active.insert(resolveInstrument(row.instrumentId, in: context.instrumentMap))
+        active.insert(resolveInstrument(row.instrumentId, in: instrumentMap))
       }
       let sample =
         accountSlice.first.map(\.sampleDate) ?? earmarkSlice.first.map(\.sampleDate)

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTypes.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTypes.swift
@@ -3,8 +3,9 @@ import Foundation
 /// Row, bundle, handler, and context types shared by the
 /// `fetchDailyBalances` assembly (`+DailyBalances.swift`) and its sibling
 /// folds (`+DailyBalancesAggregation.swift`, `+DailyBalancesForecast.swift`,
-/// `+DailyBalancesPrewarm.swift`, …). Pure declarations — no logic — split
-/// out so the assembly file stays within the file-length budget.
+/// `+DailyBalancesPrewarm.swift`, …): the per-(day, account/earmark,
+/// instrument, type) SUM rows, the `database.read`-snapshot input bundle,
+/// the per-day diagnostic handlers, and the fixed per-walk context.
 extension GRDBAnalysisRepository {
 
   // MARK: - Row types

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTypes.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTypes.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Row, bundle, handler, and context types shared by the
+/// `fetchDailyBalances` assembly (`+DailyBalances.swift`) and its sibling
+/// folds (`+DailyBalancesAggregation.swift`, `+DailyBalancesForecast.swift`,
+/// `+DailyBalancesPrewarm.swift`, …). Pure declarations — no logic — split
+/// out so the assembly file stays within the file-length budget.
+extension GRDBAnalysisRepository {
+
+  // MARK: - Row types
+
+  /// One row of the per-(day, account, instrument, type) SUM that
+  /// drives the historic span of `fetchDailyBalances`.
+  ///
+  /// `day` is the ISO-8601 `YYYY-MM-DD` string returned by
+  /// `DATE(t.date)` (UTC calendar day) — kept for diagnostics and as
+  /// the failure-callback context. The actual day-key passed to
+  /// `PositionBook.dailyBalance(...)` comes from `sampleDate` (a raw
+  /// `t.date` instant inside the group) so `Calendar.current.startOfDay`
+  /// produces the *local* day-key the contract tests expect — UTC-day
+  /// grouping diverges from local-day at TZ boundaries, which is fine
+  /// for indexing but wrong for the result key.
+  struct DailyBalanceAccountRow: Sendable {
+    let day: String
+    let sampleDate: Date
+    let accountId: UUID
+    let instrumentId: String
+    /// Raw value of `TransactionType` (`"income"`, `"expense"`,
+    /// `"transfer"`, `"openingBalance"`, `"trade"`). Pinned by the
+    /// `transaction_leg.type` CHECK constraint.
+    let type: String
+    let qty: Int64
+  }
+
+  /// One row of the per-(day, earmark, instrument, type) SUM. Same
+  /// shape as `DailyBalanceAccountRow` but keyed by `earmark_id`
+  /// instead of `account_id` — the earmark dimension drives the
+  /// `earmarks` map inside `PositionBook` and is fetched by a sibling
+  /// query so the leg-side index stays covering on
+  /// `leg_analysis_by_earmark_type`.
+  struct DailyBalanceEarmarkRow: Sendable {
+    let day: String
+    let sampleDate: Date
+    let earmarkId: UUID
+    let instrumentId: String
+    let type: String
+    let qty: Int64
+  }
+
+  // MARK: - Assembly input bundle
+
+  /// Bundle of inputs for `assembleDailyBalances` — every value that
+  /// crosses the `database.read` boundary fits inside this single
+  /// `Sendable` aggregation so the read closure surfaces one MVCC
+  /// snapshot to the converter.
+  ///
+  /// - `priorAccountRows` / `priorEarmarkRows` seed the `PositionBook`
+  ///   with pre-`after` legs under the `asStartingBalance: true`
+  ///   semantics (every leg type on an investment account contributes
+  ///   to `accountsFromTransfers`, matching the
+  ///   `investmentTransfersOnly: false` baseline applied before the
+  ///   cutoff).
+  /// - `accountRows` / `earmarkRows` carry the post-`after` deltas.
+  /// - `investmentValues` carries every `investment_value` row — all
+  ///   historical snapshots are loaded so the cursor walk in
+  ///   `applyInvestmentValues` can carry the most recent pre-window
+  ///   value forward into the first in-window day.
+  /// - `scheduled` carries the scheduled `[Transaction]` for the
+  ///   forecast extrapolation — the forecast path stays Swift-only
+  ///   because SQL can't extrapolate recurring patterns.
+  struct DailyBalancesAggregation: Sendable {
+    let priorAccountRows: [DailyBalanceAccountRow]
+    let priorEarmarkRows: [DailyBalanceEarmarkRow]
+    let accountRows: [DailyBalanceAccountRow]
+    let earmarkRows: [DailyBalanceEarmarkRow]
+    let investmentValues: [InvestmentValueSnapshot]
+    let investmentAccountIds: Set<UUID>
+    /// Account ids of trades-mode investment accounts. Drives the new
+    /// per-day position-valuation fold; recorded-value accounts are
+    /// carried in `investmentAccountIds` and drive the snapshot fold.
+    let tradesModeInvestmentAccountIds: Set<UUID>
+    /// Pre-cutoff `transaction_leg` SUM rows filtered to trades-mode
+    /// investment accounts only. Pre-fold seed for the new fold's
+    /// cumulative position dict.
+    let priorTradesModeAccountRows: [DailyBalanceAccountRow]
+    /// Post-cutoff `transaction_leg` SUM rows filtered to trades-mode
+    /// investment accounts only.
+    let tradesModeAccountRows: [DailyBalanceAccountRow]
+    let scheduled: [Transaction]
+    let instrumentMap: [String: Instrument]
+    let forecastUntil: Date?
+  }
+
+  // MARK: - Handler and context types
+
+  /// Diagnostic context passed to the conversion-failure handler so
+  /// the caller's logger can identify which day failed without
+  /// coupling this helper to a `Logger` instance.
+  struct DailyBalancesFailureContext: Sendable {
+    let day: String
+  }
+
+  /// Bundle of per-day diagnostic callbacks used by
+  /// `assembleDailyBalances`. Matches the
+  /// `ExpenseBreakdownHandlers` / `CategoryBalancesHandlers` /
+  /// `IncomeAndExpenseHandlers` shape so future analysis methods can
+  /// share the same handler pattern. Investment-value failures use
+  /// their own callback because they fire at the post-loop fold-in
+  /// step and carry per-account context — folding them into
+  /// `handleConversionFailure` would dilute the per-day signal.
+  struct DailyBalancesHandlers: Sendable {
+    let handleUnparseableDay: @Sendable (String) -> Void
+    let handleConversionFailure: @Sendable (Error, DailyBalancesFailureContext) -> Void
+    let handleInvestmentValueFailure: @Sendable (Error, Date) -> Void
+  }
+
+  /// Fixed inputs that stay constant across every per-day call inside
+  /// `walkDays` and the investment-value fold-in. Lifts the
+  /// `investmentAccountIds`, `instrumentMap`, `profileInstrument`, and
+  /// `conversionService` references out of every helper signature so
+  /// each function fits SwiftLint's `function_parameter_count` budget.
+  struct DailyBalancesAssemblyContext: Sendable {
+    let investmentAccountIds: Set<UUID>
+    /// Account ids of trades-mode investment accounts — read by
+    /// `applyTradesModePositionValuations` to early-exit when the
+    /// profile has none. None of the seed/walk helpers consult this
+    /// field; trades-mode accounts contribute through the new fold,
+    /// not through `accountsFromTransfers`.
+    let tradesModeInvestmentAccountIds: Set<UUID>
+    let instrumentMap: [String: Instrument]
+    let profileInstrument: Instrument
+    let conversionService: any InstrumentConversionService
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -177,6 +177,17 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
           Sibling days continue to render.
           """)
       })
+    // Pre-warm the conversions the per-day walk will perform, fanned out
+    // concurrently, so the network price fetches overlap and the conversion
+    // memo is populated before `assembleDailyBalances`'s serial walk hits
+    // them. Best-effort and result-neutral: the walk re-runs (and handles
+    // per Rule 11) anything that did not warm. Kept here rather than inside
+    // `assembleDailyBalances` so that helper's serial per-day conversion
+    // contract stays intact. See #1163.
+    let warmups = Self.collectConversionWarmups(
+      in: aggregation, profileInstrument: instrument)
+    await Self.prewarmConversions(warmups, to: instrument, using: conversionService)
+
     return try await Self.assembleDailyBalances(
       aggregation: aggregation,
       profileInstrument: instrument,

--- a/MoolahTests/Backends/GRDB/GRDBAnalysisPrewarmTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBAnalysisPrewarmTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("GRDBAnalysisRepository — conversion pre-warm collection")
+struct GRDBAnalysisPrewarmTests {
+
+  private func context(profile: Instrument) -> GRDBAnalysisRepository.DailyBalancesAssemblyContext {
+    GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: [],
+      instrumentMap: [:],
+      profileInstrument: profile,
+      conversionService: StubConversionService())
+  }
+
+  private func accountRow(
+    day: String, sample: Date, instrument: String
+  ) -> GRDBAnalysisRepository.DailyBalanceAccountRow {
+    GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: day, sampleDate: sample, accountId: UUID(), instrumentId: instrument,
+      type: "transfer", qty: 100_000_000)
+  }
+
+  /// The collected warm-ups must be the *running union* of instruments —
+  /// each day carries every instrument seen up to and including that day,
+  /// at that day's representative instant, mirroring what the per-day walk
+  /// converts. The profile instrument is excluded (the walk's same-instrument
+  /// fast path skips it). Prior rows seed the union from day zero.
+  @Test("running union across days, seeded by prior rows, excludes the profile instrument")
+  func collectsRunningUnion() throws {
+    let aud = Instrument.fiat(code: "AUD")
+    let day1 = Date(timeIntervalSince1970: 1_000_000)
+    let day2 = Date(timeIntervalSince1970: 1_100_000)
+
+    let warmups = GRDBAnalysisRepository.collectConversionWarmups(
+      priorAccountRows: [accountRow(day: "2025-12-31", sample: day1, instrument: "USD")],
+      priorEarmarkRows: [],
+      accountRows: [
+        accountRow(day: "2026-01-01", sample: day1, instrument: "EUR"),
+        // AUD == profile instrument: must never be warmed.
+        accountRow(day: "2026-01-01", sample: day1, instrument: "AUD"),
+        accountRow(day: "2026-01-02", sample: day2, instrument: "GBP"),
+      ],
+      earmarkRows: [],
+      context: context(profile: aud))
+
+    // Compare as a set of (instrument id, date) — inner ordering is irrelevant.
+    let got = Set(warmups.map { Pair(id: $0.instrument.id, date: $0.date) })
+    let expected: Set<Pair> = [
+      // Day 1: USD (prior) + EUR (day-1 delta), at day1's instant.
+      Pair(id: "USD", date: day1), Pair(id: "EUR", date: day1),
+      // Day 2: USD + EUR carried forward + GBP (day-2 delta), at day2's instant.
+      Pair(id: "USD", date: day2), Pair(id: "EUR", date: day2), Pair(id: "GBP", date: day2),
+    ]
+    #expect(got == expected)
+  }
+
+  /// A single-instrument profile (every position already in the profile
+  /// instrument) needs no conversions — the collection is empty so the
+  /// pre-warm is a no-op.
+  @Test("no warm-ups when every instrument is the profile instrument")
+  func emptyWhenAllProfileInstrument() throws {
+    let aud = Instrument.fiat(code: "AUD")
+    let warmups = GRDBAnalysisRepository.collectConversionWarmups(
+      priorAccountRows: [accountRow(day: "2025-12-31", sample: Date(), instrument: "AUD")],
+      priorEarmarkRows: [],
+      accountRows: [accountRow(day: "2026-01-01", sample: Date(), instrument: "AUD")],
+      earmarkRows: [],
+      context: context(profile: aud))
+    #expect(warmups.isEmpty)
+  }
+
+  private struct Pair: Hashable {
+    let id: String
+    let date: Date
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBAnalysisPrewarmTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBAnalysisPrewarmTests.swift
@@ -23,13 +23,21 @@ struct GRDBAnalysisPrewarmTests {
       type: "transfer", qty: 100_000_000)
   }
 
+  private func earmarkRow(
+    day: String, sample: Date, instrument: String
+  ) -> GRDBAnalysisRepository.DailyBalanceEarmarkRow {
+    GRDBAnalysisRepository.DailyBalanceEarmarkRow(
+      day: day, sampleDate: sample, earmarkId: UUID(), instrumentId: instrument,
+      type: "transfer", qty: 100_000_000)
+  }
+
   /// The collected warm-ups must be the *running union* of instruments —
   /// each day carries every instrument seen up to and including that day,
   /// at that day's representative instant, mirroring what the per-day walk
   /// converts. The profile instrument is excluded (the walk's same-instrument
   /// fast path skips it). Prior rows seed the union from day zero.
   @Test("running union across days, seeded by prior rows, excludes the profile instrument")
-  func collectsRunningUnion() throws {
+  func collectsRunningUnion() {
     let aud = Instrument.fiat(code: "AUD")
     let day1 = Date(timeIntervalSince1970: 1_000_000)
     let day2 = Date(timeIntervalSince1970: 1_100_000)
@@ -61,7 +69,7 @@ struct GRDBAnalysisPrewarmTests {
   /// instrument) needs no conversions — the collection is empty so the
   /// pre-warm is a no-op.
   @Test("no warm-ups when every instrument is the profile instrument")
-  func emptyWhenAllProfileInstrument() throws {
+  func emptyWhenAllProfileInstrument() {
     let aud = Instrument.fiat(code: "AUD")
     let warmups = GRDBAnalysisRepository.collectConversionWarmups(
       priorAccountRows: [accountRow(day: "2025-12-31", sample: Date(), instrument: "AUD")],
@@ -70,6 +78,32 @@ struct GRDBAnalysisPrewarmTests {
       earmarkRows: [],
       context: context(profile: aud))
     #expect(warmups.isEmpty)
+  }
+
+  /// Earmark instruments feed the same running union as account
+  /// instruments — both the prior-row seed (`priorEarmarkRows`) and the
+  /// per-day growth (`earmarkRows`) must surface in the warm-ups.
+  @Test("earmark rows seed and grow the running union too")
+  func collectsEarmarkInstruments() {
+    let aud = Instrument.fiat(code: "AUD")
+    let day1 = Date(timeIntervalSince1970: 2_000_000)
+    let day2 = Date(timeIntervalSince1970: 2_100_000)
+
+    let warmups = GRDBAnalysisRepository.collectConversionWarmups(
+      priorAccountRows: [],
+      priorEarmarkRows: [earmarkRow(day: "2025-12-31", sample: day1, instrument: "USD")],
+      accountRows: [accountRow(day: "2026-01-02", sample: day2, instrument: "EUR")],
+      earmarkRows: [earmarkRow(day: "2026-01-01", sample: day1, instrument: "GBP")],
+      context: context(profile: aud))
+
+    let got = Set(warmups.map { Pair(id: $0.instrument.id, date: $0.date) })
+    let expected: Set<Pair> = [
+      // Day 1 (earmark slice): USD (prior earmark) + GBP (day-1 earmark).
+      Pair(id: "USD", date: day1), Pair(id: "GBP", date: day1),
+      // Day 2 (account slice): USD + GBP carried forward + EUR (day-2 account).
+      Pair(id: "USD", date: day2), Pair(id: "GBP", date: day2), Pair(id: "EUR", date: day2),
+    ]
+    #expect(got == expected)
   }
 
   private struct Pair: Hashable {

--- a/MoolahTests/Backends/GRDB/GRDBAnalysisPrewarmTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBAnalysisPrewarmTests.swift
@@ -6,15 +6,6 @@ import Testing
 @Suite("GRDBAnalysisRepository — conversion pre-warm collection")
 struct GRDBAnalysisPrewarmTests {
 
-  private func context(profile: Instrument) -> GRDBAnalysisRepository.DailyBalancesAssemblyContext {
-    GRDBAnalysisRepository.DailyBalancesAssemblyContext(
-      investmentAccountIds: [],
-      tradesModeInvestmentAccountIds: [],
-      instrumentMap: [:],
-      profileInstrument: profile,
-      conversionService: StubConversionService())
-  }
-
   private func accountRow(
     day: String, sample: Date, instrument: String
   ) -> GRDBAnalysisRepository.DailyBalanceAccountRow {
@@ -31,6 +22,30 @@ struct GRDBAnalysisPrewarmTests {
       type: "transfer", qty: 100_000_000)
   }
 
+  /// Minimal aggregation carrying only the rows the warm-up collection
+  /// reads; everything else is empty. `instrumentMap` is left empty so
+  /// `resolveInstrument` falls back to `Instrument.fiat(code:)`.
+  private func aggregation(
+    priorAccount: [GRDBAnalysisRepository.DailyBalanceAccountRow] = [],
+    priorEarmark: [GRDBAnalysisRepository.DailyBalanceEarmarkRow] = [],
+    account: [GRDBAnalysisRepository.DailyBalanceAccountRow] = [],
+    earmark: [GRDBAnalysisRepository.DailyBalanceEarmarkRow] = []
+  ) -> GRDBAnalysisRepository.DailyBalancesAggregation {
+    GRDBAnalysisRepository.DailyBalancesAggregation(
+      priorAccountRows: priorAccount,
+      priorEarmarkRows: priorEarmark,
+      accountRows: account,
+      earmarkRows: earmark,
+      investmentValues: [],
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: [],
+      priorTradesModeAccountRows: [],
+      tradesModeAccountRows: [],
+      scheduled: [],
+      instrumentMap: [:],
+      forecastUntil: nil)
+  }
+
   /// The collected warm-ups must be the *running union* of instruments —
   /// each day carries every instrument seen up to and including that day,
   /// at that day's representative instant, mirroring what the per-day walk
@@ -43,16 +58,15 @@ struct GRDBAnalysisPrewarmTests {
     let day2 = Date(timeIntervalSince1970: 1_100_000)
 
     let warmups = GRDBAnalysisRepository.collectConversionWarmups(
-      priorAccountRows: [accountRow(day: "2025-12-31", sample: day1, instrument: "USD")],
-      priorEarmarkRows: [],
-      accountRows: [
-        accountRow(day: "2026-01-01", sample: day1, instrument: "EUR"),
-        // AUD == profile instrument: must never be warmed.
-        accountRow(day: "2026-01-01", sample: day1, instrument: "AUD"),
-        accountRow(day: "2026-01-02", sample: day2, instrument: "GBP"),
-      ],
-      earmarkRows: [],
-      context: context(profile: aud))
+      in: aggregation(
+        priorAccount: [accountRow(day: "2025-12-31", sample: day1, instrument: "USD")],
+        account: [
+          accountRow(day: "2026-01-01", sample: day1, instrument: "EUR"),
+          // AUD == profile instrument: must never be warmed.
+          accountRow(day: "2026-01-01", sample: day1, instrument: "AUD"),
+          accountRow(day: "2026-01-02", sample: day2, instrument: "GBP"),
+        ]),
+      profileInstrument: aud)
 
     // Compare as a set of (instrument id, date) — inner ordering is irrelevant.
     let got = Set(warmups.map { Pair(id: $0.instrument.id, date: $0.date) })
@@ -72,11 +86,10 @@ struct GRDBAnalysisPrewarmTests {
   func emptyWhenAllProfileInstrument() {
     let aud = Instrument.fiat(code: "AUD")
     let warmups = GRDBAnalysisRepository.collectConversionWarmups(
-      priorAccountRows: [accountRow(day: "2025-12-31", sample: Date(), instrument: "AUD")],
-      priorEarmarkRows: [],
-      accountRows: [accountRow(day: "2026-01-01", sample: Date(), instrument: "AUD")],
-      earmarkRows: [],
-      context: context(profile: aud))
+      in: aggregation(
+        priorAccount: [accountRow(day: "2025-12-31", sample: Date(), instrument: "AUD")],
+        account: [accountRow(day: "2026-01-01", sample: Date(), instrument: "AUD")]),
+      profileInstrument: aud)
     #expect(warmups.isEmpty)
   }
 
@@ -90,11 +103,11 @@ struct GRDBAnalysisPrewarmTests {
     let day2 = Date(timeIntervalSince1970: 2_100_000)
 
     let warmups = GRDBAnalysisRepository.collectConversionWarmups(
-      priorAccountRows: [],
-      priorEarmarkRows: [earmarkRow(day: "2025-12-31", sample: day1, instrument: "USD")],
-      accountRows: [accountRow(day: "2026-01-02", sample: day2, instrument: "EUR")],
-      earmarkRows: [earmarkRow(day: "2026-01-01", sample: day1, instrument: "GBP")],
-      context: context(profile: aud))
+      in: aggregation(
+        priorEarmark: [earmarkRow(day: "2025-12-31", sample: day1, instrument: "USD")],
+        account: [accountRow(day: "2026-01-02", sample: day2, instrument: "EUR")],
+        earmark: [earmarkRow(day: "2026-01-01", sample: day1, instrument: "GBP")]),
+      profileInstrument: aud)
 
     let got = Set(warmups.map { Pair(id: $0.instrument.id, date: $0.date) })
     let expected: Set<Pair> = [


### PR DESCRIPTION
**PR 2 of 2 for #1163** — Analysis page slow on first open. (PR 1 #1164 bounds the reload storm; this makes each load pass fast.)

## Problem

The per-day daily-balance walk (`PositionBook.dailyBalance` inside `walkDays`) converts every held instrument to the profile instrument **serially**, awaiting one rate at a time. On a populated profile that's thousands of awaited conversions, and the first lookup per `(token, date)` blocks on a network price fetch — the slow ~18-conversions/sec "trickle" measured during a cold load.

## Fix

Resolve the same conversions **up front, fanned out concurrently**, before the serial walk:

- `collectConversionWarmups` builds the exact `(instrument, day-instant)` set the walk will convert — the running union of instruments seeded by the prior rows and grown by each day's deltas, each paired with that day's `sampleDate` so the warmed memo key matches the walk's conversion exactly; the profile instrument is excluded (same-instrument fast path).
- `prewarmConversions` resolves them with a bounded (max 16 in-flight) task group, so the network fetches overlap and the conversion memo fills.

The serial walk then hits warm caches instead of trickling through network lookups.

**Result-neutral & best-effort:** the pre-warm only populates caches and swallows failures; the walk stays authoritative and re-runs (handling per the Rule 11 per-day contract) anything that didn't warm. It stops refilling on cooperative cancellation.

## Tests

- `GRDBAnalysisPrewarmTests` — pins the running-union collection (prior-seeded, grows by day, excludes profile instrument) and the single-currency no-op case.
- Full daily-balance regression net passes unchanged: daily balances, multi-currency, multi-instrument, investment value, positive-amount transfers, Rule 11 scoping, date-sensitive conversion, pre-listing, expense-breakdown, income/expense.

## Notes

- Scoped to the daily-balance walk (the dominant cost). The forecast path is already concurrently pre-converted; the investment-value / trades-mode folds convert smaller per-snapshot sets and are left for a possible follow-up.
- Splits the row/bundle/handler/context types and the pre-warm helpers into sibling files (`+DailyBalancesTypes`, `+DailyBalancesPrewarm`) to keep `+DailyBalances.swift` under the 400-line limit (no logic moved, pure relocation).

> Note: the `code-review` / `concurrency-review` agents were unavailable (persistent 529s) at authoring time, so this was self-reviewed against CODE_GUIDE/CONCURRENCY_GUIDE; happy to re-run them on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4LphNRBYdAZSbgHNmmCg6