### PR TITLE
perf(conversion): batch the investment-value and trades-mode daily-balance folds

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -136,22 +136,44 @@ extension GRDBAnalysisRepository {
   }
 
   // MARK: - Per-day fold-in
+
+  /// One day's accumulated investment-value plan: the day key (also the
+  /// failure context), the synchronous fast-path subtotal (every snapshot
+  /// already in the profile instrument), and the number of foreign-value
+  /// conversion requests this day contributed to the flat batch. The
+  /// assemble pass slices `requestCount` outcomes back out per day in order.
+  private struct InvestmentValuePlan {
+    let date: Date
+    let fastPathTotal: Decimal
+    let requestCount: Int
+  }
+
   /// Per-day investment-value override: for each recorded-value
   /// investment account, carries the latest snapshot forward to each
   /// day and replaces the bank-balance-derived `investmentValue`
   /// with the converted total.
   ///
+  /// Batched in three phases (same shape as `walkDays`): (1) walk the
+  /// days, advancing the snapshot cursor, and snapshot each day's
+  /// foreign-value conversion requests *at that day's cumulative
+  /// `latestByAccount` state* while accumulating the synchronous
+  /// profile-instrument subtotal; (2) resolve every day's requests in a
+  /// single `convertResultBatch(...)`; (3) assemble each day from its
+  /// outcome slice. The cursor walk MUST snapshot inside phase 1 — the
+  /// carried-forward map mutates per day, so deriving requests afterwards
+  /// would value every day at the final day's positions.
+  ///
   /// Rule 11 contract (same as `walkDays`): a conversion failure on a
   /// single day drops that day from `dailyBalances` via
   /// `removeValue(forKey:)` so the chart shows a gap rather than an
   /// incorrect partial total. Sibling days are unaffected.
-  /// `CancellationError` rethrows immediately and is never routed
-  /// through the failure callback.
+  /// `CancellationError` rethrows immediately (surfaced from inside the
+  /// single batch) and is never routed through the failure callback.
   ///
-  /// `Task.checkCancellation()` at the top of the per-day loop covers
-  /// the all-fast-path case (every snapshot already in the profile
-  /// instrument): no `await` would otherwise occur, so the runtime
-  /// would never get a chance to surface cancellation.
+  /// `Task.checkCancellation()` before the batch covers the all-fast-path
+  /// case (every snapshot already in the profile instrument): the batch
+  /// would be empty, so no `await` inside it would otherwise occur and the
+  /// runtime would never get a chance to surface cancellation.
   static func applyInvestmentValues(
     _ investmentValues: [InvestmentValueSnapshot],
     to dailyBalances: inout [Date: DailyBalance],
@@ -159,39 +181,109 @@ extension GRDBAnalysisRepository {
     handlers: DailyBalancesHandlers
   ) async throws {
     guard !investmentValues.isEmpty, !dailyBalances.isEmpty else { return }
+
+    let (plans, requests) = accumulateInvestmentValueDays(
+      investmentValues: investmentValues,
+      days: dailyBalances.keys.sorted(),
+      profileInstrument: context.profileInstrument)
+
+    // The all-fast-path case produces an empty batch (no `await` inside),
+    // so check cancellation explicitly before resolving.
+    try Task.checkCancellation()
+    let outcomes = try await context.conversionService.convertResultBatch(requests)
+
+    assembleInvestmentValueDays(
+      plans: plans,
+      outcomes: outcomes,
+      into: &dailyBalances,
+      profileInstrument: context.profileInstrument,
+      handlers: handlers)
+  }
+
+  /// Phase 1: walk the days in order, advancing the snapshot cursor and
+  /// snapshotting each day's foreign-value conversion requests at that
+  /// day's cumulative `latestByAccount` state. Profile-instrument values
+  /// fold into the day's `fastPathTotal` synchronously (Rule 8 fast path);
+  /// foreign values append one request to the flat batch. `.knownZero`
+  /// stays a per-element outcome resolved in phase 3. Days with no carried
+  /// snapshot produce no plan (matching the old `latestByAccount.isEmpty`
+  /// `continue`).
+  private static func accumulateInvestmentValueDays(
+    investmentValues: [InvestmentValueSnapshot],
+    days: [Date],
+    profileInstrument: Instrument
+  ) -> (plans: [InvestmentValuePlan], requests: [BatchConversionRequest]) {
     var latestByAccount: [UUID: InstrumentAmount] = [:]
     var valueIndex = 0
-    for date in dailyBalances.keys.sorted() {
-      // The Rule 8 fast path can let the loop run synchronously when
-      // every snapshot is in the profile instrument; an explicit
-      // cancellation check ensures the outer task can be torn down
-      // promptly even in that case.
-      try Task.checkCancellation()
+    var plans: [InvestmentValuePlan] = []
+    var requests: [BatchConversionRequest] = []
+    for date in days {
       valueIndex = advanceInvestmentCursor(
         values: investmentValues,
         latestByAccount: &latestByAccount,
         from: valueIndex,
         upTo: date)
       if latestByAccount.isEmpty { continue }
-      let totalValue: InstrumentAmount
-      do {
-        totalValue = try await sumInvestmentValues(
-          latestByAccount: latestByAccount,
-          on: date,
-          profileInstrument: context.profileInstrument,
-          conversionService: context.conversionService)
-      } catch let cancel as CancellationError {
-        throw cancel
-      } catch {
-        // Rule 11: drop the day from dailyBalances so the chart shows
-        // a gap rather than rendering a partial total. Matches the
-        // walkDays per-day error contract.
-        handlers.handleInvestmentValueFailure(error, date)
-        dailyBalances.removeValue(forKey: date)
+      var fastPathTotal: Decimal = 0
+      var requestCount = 0
+      for value in latestByAccount.values {
+        if value.instrument.id == profileInstrument.id {
+          fastPathTotal += value.quantity
+          continue
+        }
+        requests.append(
+          BatchConversionRequest(amount: value, target: profileInstrument, date: date))
+        requestCount += 1
+      }
+      plans.append(
+        InvestmentValuePlan(
+          date: date, fastPathTotal: fastPathTotal, requestCount: requestCount))
+    }
+    return (plans, requests)
+  }
+
+  /// Phase 3: slice the flat `outcomes` back out per day in the same order
+  /// the requests were appended, folding each day's foreign-value outcomes
+  /// into its `fastPathTotal` and overwriting that day's `DailyBalance`.
+  ///
+  /// Rule 11: a `.failure` in a day's slice drops that day from
+  /// `dailyBalances` and logs once via `handleInvestmentValueFailure`.
+  /// `.knownZero` (e.g. an `.unpriced` / `.spam` crypto investment value)
+  /// contributes zero rather than failing the day — issue #790.
+  private static func assembleInvestmentValueDays(
+    plans: [InvestmentValuePlan],
+    outcomes: [BatchConversionOutcome],
+    into dailyBalances: inout [Date: DailyBalance],
+    profileInstrument: Instrument,
+    handlers: DailyBalancesHandlers
+  ) {
+    var cursor = 0
+    for plan in plans {
+      let slice = outcomes[cursor..<cursor + plan.requestCount]
+      cursor += plan.requestCount
+      var total = plan.fastPathTotal
+      var failure: (any Error)?
+      for outcome in slice {
+        switch outcome {
+        case .value(let converted):
+          total += converted.quantity
+        case .knownZero:
+          break  // contributes zero
+        case .failure(let error):
+          failure = error
+        }
+      }
+      if let failure {
+        // Rule 11: drop the day from dailyBalances so the chart shows a
+        // gap rather than rendering a partial total. Matches the walkDays
+        // per-day error contract.
+        handlers.handleInvestmentValueFailure(failure, plan.date)
+        dailyBalances.removeValue(forKey: plan.date)
         continue
       }
-      guard let balance = dailyBalances[date] else { continue }
-      dailyBalances[date] = DailyBalance(
+      guard let balance = dailyBalances[plan.date] else { continue }
+      let totalValue = InstrumentAmount(quantity: total, instrument: profileInstrument)
+      dailyBalances[plan.date] = DailyBalance(
         date: balance.date,
         balance: balance.balance,
         earmarked: balance.earmarked,
@@ -225,34 +317,5 @@ extension GRDBAnalysisRepository {
       }
     }
     return valueIndex
-  }
-
-  /// Sum the per-account investment values, converting foreign
-  /// instruments to the profile instrument on `date`. Throws on any
-  /// conversion failure so the caller can drop the day from the
-  /// `dailyBalances` dict per Rule 11. The return is non-optional —
-  /// the function either throws or returns the converted total.
-  private static func sumInvestmentValues(
-    latestByAccount: [UUID: InstrumentAmount],
-    on date: Date,
-    profileInstrument: Instrument,
-    conversionService: any InstrumentConversionService
-  ) async throws -> InstrumentAmount {
-    var total: Decimal = 0
-    for value in latestByAccount.values {
-      if value.instrument.id == profileInstrument.id {
-        total += value.quantity
-        continue
-      }
-      // `.knownZero` (e.g. an `.unpriced` / `.spam` crypto investment
-      // value) contributes zero rather than failing the day —
-      // issue #790.
-      let result = try await conversionService.convertResult(
-        value, to: profileInstrument, on: date)
-      if case .value(let converted) = result {
-        total += converted.quantity
-      }
-    }
-    return InstrumentAmount(quantity: total, instrument: profileInstrument)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
@@ -3,9 +3,11 @@ import Foundation
 /// Per-day position-valuation fold for trades-mode investment
 /// accounts. Sister of `applyInvestmentValues` in
 /// `+DailyBalancesInvestmentValues.swift` — same per-day Rule 11
-/// error contract: `CancellationError` rethrows immediately; any
-/// other thrown error drops the day from `dailyBalances` and logs
-/// through `handleInvestmentValueFailure`.
+/// error contract: only `CancellationError` throws from
+/// `convertResultBatch` and rethrows immediately; a per-position
+/// conversion failure arrives as a `.failure` outcome in the assemble
+/// phase, which drops that day from `dailyBalances` and logs through
+/// `handleInvestmentValueFailure`.
 ///
 /// Paired with the recorded-value (snapshot) fold in
 /// `+DailyBalancesInvestmentValues.swift`.
@@ -23,18 +25,38 @@ extension GRDBAnalysisRepository {
     let quantity: Decimal
   }
 
+  /// One day's accumulated trades-mode plan: the day key (also the failure
+  /// context), the synchronous fast-path subtotal (profile-instrument
+  /// positions plus skipped zeros), and the number of foreign-position
+  /// conversion requests this day contributed to the flat batch. The
+  /// assemble pass slices `requestCount` outcomes back out per day in order.
+  private struct TradesModeDayPlan {
+    let dayKey: Date
+    let fastPathTotal: Decimal
+    let requestCount: Int
+  }
+
   /// Per-day position-valuation fold for trades-mode investment
   /// accounts. Sister of `applyInvestmentValues` — same per-day error
-  /// contract: `CancellationError` rethrows immediately; any other
-  /// thrown error drops the day from `dailyBalances` and logs through
-  /// `handleInvestmentValueFailure`.
+  /// contract: only `CancellationError` throws from `convertResultBatch`
+  /// and rethrows immediately; a per-position conversion failure arrives
+  /// as a `.failure` outcome in the assemble phase, which drops that day
+  /// from `dailyBalances` and logs through `handleInvestmentValueFailure`.
   ///
-  /// The fold builds a sorted cursor over trades-mode rows
-  /// (`(dayKey, accountId, instrument, quantity)` entries), then
-  /// walks `dailyBalances.keys.sorted()`. For each output `dayKey`,
-  /// the cursor advances through every entry with `entry.dayKey <=
-  /// dayKey` — including entries for days absent from
-  /// `dailyBalances` (e.g. dropped by an earlier snapshot-fold
+  /// Batched in three phases (same shape as `walkDays` and
+  /// `applyInvestmentValues`): (1) walk `dailyBalances.keys.sorted()`,
+  /// advancing the position cursor, and snapshot each day's
+  /// foreign-position conversion requests *at that day's cumulative
+  /// `positions` state* while accumulating the synchronous
+  /// profile-instrument subtotal; (2) resolve every day's requests in a
+  /// single `convertResultBatch(...)`; (3) merge each day's outcome slice
+  /// into `dailyBalances`. The cursor walk MUST snapshot inside phase 1 —
+  /// `positions` mutates cumulatively per day, so deriving requests
+  /// afterwards would value every day at the final day's positions.
+  ///
+  /// For each output `dayKey`, the cursor advances through every entry
+  /// with `entry.dayKey <= dayKey` — including entries for days absent
+  /// from `dailyBalances` (e.g. dropped by an earlier snapshot-fold
   /// failure) — so cumulative position state stays correct on every
   /// following day.
   ///
@@ -53,18 +75,50 @@ extension GRDBAnalysisRepository {
       !dailyBalances.isEmpty
     else { return }
 
+    let (plans, requests) = accumulateTradesModeDays(
+      priorRows: priorRows,
+      postRows: postRows,
+      days: dailyBalances.keys.sorted(),
+      context: context)
+
+    // The all-fast-path case produces an empty batch (no `await` inside),
+    // so check cancellation explicitly before resolving.
+    try Task.checkCancellation()
+    let outcomes = try await context.conversionService.convertResultBatch(requests)
+
+    assembleTradesModeDays(
+      plans: plans,
+      outcomes: outcomes,
+      into: &dailyBalances,
+      profileInstrument: context.profileInstrument,
+      handlers: handlers)
+  }
+
+  /// Phase 1: walk the days in order, advancing the position cursor and
+  /// snapshotting each day's foreign-position conversion requests at that
+  /// day's cumulative `positions` state. Profile-instrument positions fold
+  /// into the day's `fastPathTotal` synchronously (Rule 8 fast path);
+  /// zero-quantity positions are skipped (a lingering instrument key after
+  /// a same-day BUY+SELL nets out — there is no value in a `0 * rate` hop);
+  /// foreign positions append one request to the flat batch. Days where
+  /// `positions` is empty produce no plan (matching the old
+  /// `positions.isEmpty` `continue`).
+  private static func accumulateTradesModeDays(
+    priorRows: [DailyBalanceAccountRow],
+    postRows: [DailyBalanceAccountRow],
+    days: [Date],
+    context: DailyBalancesAssemblyContext
+  ) -> (plans: [TradesModeDayPlan], requests: [BatchConversionRequest]) {
     var positions = seedTradesModePriorPositions(
       priorRows: priorRows, instrumentMap: context.instrumentMap)
     let entries = buildTradesModeEntries(
       postRows: postRows, instrumentMap: context.instrumentMap)
+    let profileInstrument = context.profileInstrument
 
     var valueIndex = 0
-    for dayKey in dailyBalances.keys.sorted() {
-      // The Rule 8 fast path inside `sumTradesModePositions` can let
-      // the loop run synchronously when every position is in the
-      // profile instrument; an explicit cancellation check ensures
-      // the outer task can be torn down promptly even in that case.
-      try Task.checkCancellation()
+    var plans: [TradesModeDayPlan] = []
+    var requests: [BatchConversionRequest] = []
+    for dayKey in days {
       // Advance the cursor: apply every entry on-or-before dayKey,
       // including those for days absent from dailyBalances.
       while valueIndex < entries.count, entries[valueIndex].dayKey <= dayKey {
@@ -74,30 +128,76 @@ extension GRDBAnalysisRepository {
         valueIndex += 1
       }
       if positions.isEmpty { continue }
-      do {
-        // dayKey is `Calendar.current.startOfDay(for: row.sampleDate)`
-        // — same normalization as walkDays and the conversion-service
-        // lookup.
-        let total = try await sumTradesModePositions(
-          positions: positions,
-          on: dayKey,
-          profileInstrument: context.profileInstrument,
-          conversionService: context.conversionService)
-        mergeTradesModeTotal(
-          total,
-          into: &dailyBalances,
-          on: dayKey,
-          profileInstrument: context.profileInstrument)
-      } catch let cancel as CancellationError {
-        throw cancel
-      } catch {
+      var fastPathTotal: Decimal = 0
+      var requestCount = 0
+      for (_, perInstrument) in positions {
+        for (instrument, quantity) in perInstrument {
+          if quantity == 0 { continue }
+          if instrument.id == profileInstrument.id {
+            fastPathTotal += quantity
+            continue
+          }
+          // dayKey is `Calendar.current.startOfDay(for: row.sampleDate)`
+          // — same normalization as walkDays and the conversion-service
+          // lookup.
+          let amount = InstrumentAmount(quantity: quantity, instrument: instrument)
+          requests.append(
+            BatchConversionRequest(amount: amount, target: profileInstrument, date: dayKey))
+          requestCount += 1
+        }
+      }
+      plans.append(
+        TradesModeDayPlan(
+          dayKey: dayKey, fastPathTotal: fastPathTotal, requestCount: requestCount))
+    }
+    return (plans, requests)
+  }
+
+  /// Phase 3: slice the flat `outcomes` back out per day in the same order
+  /// the requests were appended, folding each day's foreign-position
+  /// outcomes into its `fastPathTotal` and merging the result into
+  /// `dailyBalances`.
+  ///
+  /// Rule 11: a `.failure` in a day's slice drops that day from
+  /// `dailyBalances` and logs once via `handleInvestmentValueFailure`.
+  /// `.knownZero` (e.g. an `.unpriced` / `.spam` crypto position)
+  /// contributes zero rather than failing the day — issue #790.
+  private static func assembleTradesModeDays(
+    plans: [TradesModeDayPlan],
+    outcomes: [BatchConversionOutcome],
+    into dailyBalances: inout [Date: DailyBalance],
+    profileInstrument: Instrument,
+    handlers: DailyBalancesHandlers
+  ) {
+    var cursor = 0
+    for plan in plans {
+      let slice = outcomes[cursor..<cursor + plan.requestCount]
+      cursor += plan.requestCount
+      var total = plan.fastPathTotal
+      var failure: (any Error)?
+      for outcome in slice {
+        switch outcome {
+        case .value(let converted):
+          total += converted.quantity
+        case .knownZero:
+          break  // contributes zero
+        case .failure(let error):
+          failure = error
+        }
+      }
+      if let failure {
         // Rule 11: drop the day from dailyBalances so the chart shows
         // a gap. Matches the walkDays / applyInvestmentValues
         // per-day error contract.
-        handlers.handleInvestmentValueFailure(error, dayKey)
-        dailyBalances.removeValue(forKey: dayKey)
+        handlers.handleInvestmentValueFailure(failure, plan.dayKey)
+        dailyBalances.removeValue(forKey: plan.dayKey)
         continue
       }
+      mergeTradesModeTotal(
+        InstrumentAmount(quantity: total, instrument: profileInstrument),
+        into: &dailyBalances,
+        on: plan.dayKey,
+        profileInstrument: profileInstrument)
     }
   }
 
@@ -173,46 +273,5 @@ extension GRDBAnalysisRepository {
       netWorth: existing.balance + combined,
       bestFit: existing.bestFit,
       isForecast: existing.isForecast)
-  }
-
-  /// Sum per-account, per-instrument trades-mode positions on `date`,
-  /// converting foreign instruments to the profile instrument via the
-  /// conversion service. Rule 8 fast path applies at the leaf level
-  /// so an account holding both profile-instrument and foreign-
-  /// instrument positions still routes only the foreign positions
-  /// through the service. Zero-quantity positions are skipped (a
-  /// lingering instrument key after a same-day BUY+SELL nets out)
-  /// to honour Rule 8's spirit — there is no value in a `0 * rate`
-  /// async hop, and the answer is identically zero. When every
-  /// position is in the profile instrument the function returns
-  /// synchronously — the outer `applyTradesModePositionValuations`
-  /// loop is responsible for the `try Task.checkCancellation()`
-  /// that keeps the all-fast-path case promptly cancellable.
-  private static func sumTradesModePositions(
-    positions: [UUID: [Instrument: Decimal]],
-    on date: Date,
-    profileInstrument: Instrument,
-    conversionService: any InstrumentConversionService
-  ) async throws -> InstrumentAmount {
-    var total: Decimal = 0
-    for (_, perInstrument) in positions {
-      for (instrument, quantity) in perInstrument {
-        if quantity == 0 { continue }
-        if instrument.id == profileInstrument.id {
-          total += quantity
-          continue
-        }
-        // `.knownZero` (e.g. an `.unpriced` / `.spam` crypto position)
-        // contributes zero rather than failing the day's investment
-        // aggregation — issue #790.
-        let amount = InstrumentAmount(quantity: quantity, instrument: instrument)
-        let result = try await conversionService.convertResult(
-          amount, to: profileInstrument, on: date)
-        if case .value(let converted) = result {
-          total += converted.quantity
-        }
-      }
-    }
-    return InstrumentAmount(quantity: total, instrument: profileInstrument)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -62,16 +62,20 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   // `decodeEarmarkDeltaRows`).
   //
   // `+DailyBalancesInvestmentValues.swift` — `applyInvestmentValues`
-  // plus its private cursor helpers (`advanceInvestmentCursor`,
-  // `sumInvestmentValues`); also owns the SQL fetches that produce
+  // plus its two-phase helpers (`accumulateInvestmentValueDays` /
+  // `assembleInvestmentValueDays`, around the `InvestmentValuePlan`
+  // plan type) and the private cursor helper
+  // (`advanceInvestmentCursor`); also owns the SQL fetches that produce
   // its inputs (`fetchInvestmentAccountIds`,
   // `fetchInvestmentValueSnapshots`,
   // `fetchTradesModeInvestmentAccountIds`).
   //
   // `+DailyBalancesTradesMode.swift` — `applyTradesModePositionValuations`
-  // fold + private helpers (`seedTradesModePriorPositions`,
+  // fold + its two-phase helpers (`accumulateTradesModeDays` /
+  // `assembleTradesModeDays`, around the `TradesModeDayPlan` plan type)
+  // and private helpers (`seedTradesModePriorPositions`,
   // `buildTradesModeEntries`, `mergeTradesModeTotal`,
-  // `sumTradesModePositions`, `TradesModePositionEntry`).
+  // `TradesModePositionEntry`).
   // Pre-filtered trades-mode rows arrive via the aggregation; the fold
   // computes per-day position valuations and adds them onto
   // `DailyBalance.investmentValue`.

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
@@ -226,12 +226,13 @@ struct GRDBDailyBalancesTradesModeRule11Tests {
 
   @Test("CancellationError from Task.checkCancellation rethrows immediately")
   func cancellationRethrown() async throws {
-    // All-fast-path scenario: a profile-instrument position means
-    // `sumTradesModePositions` never `await`s, so without an explicit
-    // `try Task.checkCancellation()` at the top of the per-day loop
-    // the runtime would never get a chance to surface cancellation.
-    // This test pins that the cancellation check is wired and rethrows
-    // directly (Rule 11 contract: never via the failure callback).
+    // All-fast-path scenario: `Task.checkCancellation()` fires before
+    // `convertResultBatch`. With an all-profile-instrument accumulate
+    // the batch is empty, so no `await` happens inside it and without
+    // the explicit check the runtime would never get a chance to
+    // surface cancellation. This test pins that the cancellation check
+    // is wired and rethrows directly (Rule 11 contract: never via the
+    // failure callback).
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
     let dayKey = Calendar.current.startOfDay(for: day)
     let aud = Instrument.defaultTestInstrument

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
@@ -302,10 +302,9 @@ struct GRDBDailyBalancesTradesModeTests {
 
     // After the cursor advance, positions[accountId][USD] = 0 — the
     // outer dict key is still present, so positions.isEmpty is false
-    // and `sumTradesModePositions` is invoked. The new
-    // `quantity == 0` guard inside the helper skips the zero
-    // position before the Rule 8 fast-path / convert decision —
-    // total stays 0. existing.investmentValue is nil, so
+    // and `accumulateTradesModeDays` is called. Its `quantity == 0`
+    // guard skips the zero position before the Rule 8 fast-path /
+    // convert decision — total stays 0. existing.investmentValue is nil, so
     // `(nil ?? .zero(AUD)) + .zero(AUD) == .zero(AUD)`. The day's
     // investmentValue is .zero(AUD) — non-nil, but quantity == 0.
     let value = try #require(balances[dayKey]?.investmentValue)


### PR DESCRIPTION
**PR-A.2 of the batch-conversion-API initiative** (follow-on to #1163; completes the daily-balance migration started in #1167).

## What

The two remaining per-day serial-conversion folds in the daily-balance assembly now use one `convertResultBatch` each, same accumulate → batch → assemble shape as the main walk:

- `applyInvestmentValues` → `accumulateInvestmentValueDays` (cursor walk, per-day request snapshot) → one batch → `assembleInvestmentValueDays`.
- `applyTradesModePositionValuations` → `accumulateTradesModeDays` → one batch → `assembleTradesModeDays`; removes the now-dead `sumTradesModePositions`.

## Safety

Conversion **results unchanged** — per-day dates, `.knownZero`→0 (#790), sign convention, profile-instrument fast path, and the per-day Rule 11 drop (a `.failure` outcome drops that day + logs once via `handleInvestmentValueFailure`; `CancellationError` propagates, with an explicit `Task.checkCancellation()` covering the empty/all-fast-path batch) all preserved. The existing trades-mode / investment-value / Rule 11 contract suites pass **unchanged**.

`code-review` run; findings (all doc-accuracy) applied. **Full macOS suite 4345 tests green; format-check clean.**

## Initiative status

The daily-balance path (the dominant cost, ~25k conversions/load) is now fully on the batch API. Remaining: incremental migration of the other history sites (income/expense, expense breakdown, category balances, account/earmark/investment/positions totals, insight bills) + folding the existing forecast & transaction-page task-groups into the batch call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4LphNRBYdAZSbgHNmmCg6