### PR TITLE
perf(conversion): batch the income/expense, expense-breakdown, category-balances aggregations

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
@@ -186,6 +186,16 @@ extension GRDBAnalysisRepository {
     return SQLRequest<Row>(literal: literal)
   }
 
+  /// The batch plan for the category-balances walk: the rows that parsed
+  /// (retained so the index-aligned outcome can rebuild each bucket and
+  /// failure context), the flat request list, and the day-strings that
+  /// failed to parse so the caller surfaces them before the batch.
+  private struct CategoryBalancesPlan {
+    let parsedRows: [CategoryBalancesRow]
+    let requests: [BatchConversionRequest]
+    let unparseableDays: [String]
+  }
+
   /// Walks the SQL aggregation rows, converts each `(qty, instrument)`
   /// to the target instrument on its own day, and accumulates totals
   /// per `categoryId`. Conversion runs outside the `database.read`
@@ -195,13 +205,18 @@ extension GRDBAnalysisRepository {
   /// Mirrors `assembleExpenseBreakdown`'s per-row error contract:
   /// `handleUnparseableDay` and `handleConversionFailure` are invoked
   /// per failing row so each failure surfaces individually in
-  /// diagnostics; the loop continues processing remaining rows then
+  /// diagnostics; the walk continues processing remaining rows then
   /// re-throws the first conversion error after the walk so the
   /// function preserves its existing "throws on conversion error"
   /// contract while still delivering the per-row detail required by
   /// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11. A `CancellationError` is
-  /// rethrown immediately and never folded into the
-  /// conversion-failure path.
+  /// rethrown immediately (it propagates straight out of the batch call)
+  /// and never folded into the conversion-failure path.
+  ///
+  /// All rows' `(qty, instrument, day)` conversions resolve in a single
+  /// `convertResultBatch(_:)` — the row order of the request list is
+  /// preserved in the outcomes, so the per-row failure callbacks still
+  /// fire in row order before the rethrow.
   @concurrent
   static func assembleCategoryBalances(
     aggregation: CategoryBalancesAggregation,
@@ -209,29 +224,27 @@ extension GRDBAnalysisRepository {
     conversionService: any InstrumentConversionService,
     handlers: CategoryBalancesHandlers
   ) async throws -> [UUID: InstrumentAmount] {
+    let plan = Self.planCategoryBalances(
+      aggregation: aggregation, targetInstrument: targetInstrument)
+    for dayString in plan.unparseableDays {
+      handlers.handleUnparseableDay(dayString)
+    }
+    // One batched conversion for every parseable row; `CancellationError`
+    // propagates straight out (never reaching the per-row failure path).
+    let outcomes = try await conversionService.convertResultBatch(plan.requests)
+
     var balances: [UUID: InstrumentAmount] = [:]
     var firstConversionError: Error?
-    for row in aggregation.rows {
-      guard let day = Self.parseDayString(row.day) else {
-        handlers.handleUnparseableDay(row.day)
-        continue
-      }
-      let instrument =
-        aggregation.instrumentMap[row.instrumentId]
-        ?? Instrument.fiat(code: row.instrumentId)
+    for (row, outcome) in zip(plan.parsedRows, outcomes) {
       let amount: InstrumentAmount
-      do {
-        amount = try await Self.convertedQuantity(
-          storageValue: row.qty,
-          instrument: instrument,
-          to: targetInstrument,
-          on: day,
-          conversionService: conversionService)
-      } catch let cancel as CancellationError {
-        // Cooperative cancellation surfaces unchanged — never folded
-        // into the per-row conversion-failure log path.
-        throw cancel
-      } catch {
+      switch outcome {
+      case .value(let converted):
+        amount = converted
+      case .knownZero:
+        // Issue #790: an `.unpriced` / `.spam` source folds to zero in
+        // the target rather than failing the row.
+        amount = .zero(instrument: targetInstrument)
+      case .failure(let error):
         let context = CategoryBalancesFailureContext(
           day: row.day,
           categoryId: row.categoryId,
@@ -252,5 +265,37 @@ extension GRDBAnalysisRepository {
       throw firstConversionError
     }
     return balances
+  }
+
+  /// Parse every row's day, resolve its source instrument, and build the
+  /// flat batch request list. Same-instrument rows still contribute a
+  /// request so the outcome list stays index-aligned with the rows; the
+  /// batch's same-instrument fast path resolves them to `.value` without
+  /// a conversion-service hit, matching `convertedQuantity`'s short
+  /// circuit.
+  private static func planCategoryBalances(
+    aggregation: CategoryBalancesAggregation,
+    targetInstrument: Instrument
+  ) -> CategoryBalancesPlan {
+    var parsedRows: [CategoryBalancesRow] = []
+    var requests: [BatchConversionRequest] = []
+    var unparseableDays: [String] = []
+    for row in aggregation.rows {
+      guard let day = Self.parseDayString(row.day) else {
+        unparseableDays.append(row.day)
+        continue
+      }
+      let instrument =
+        aggregation.instrumentMap[row.instrumentId]
+        ?? Instrument.fiat(code: row.instrumentId)
+      parsedRows.append(row)
+      requests.append(
+        BatchConversionRequest(
+          amount: InstrumentAmount(storageValue: row.qty, instrument: instrument),
+          target: targetInstrument,
+          date: day))
+    }
+    return CategoryBalancesPlan(
+      parsedRows: parsedRows, requests: requests, unparseableDays: unparseableDays)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift
@@ -108,6 +108,23 @@ extension GRDBAnalysisRepository {
     }
   }
 
+  /// One parseable row paired with its parsed day, retained so the batch
+  /// outcome can rebuild its bucket (the day picks the financial month)
+  /// and failure context.
+  private struct ExpenseBreakdownParsedRow {
+    let row: ExpenseBreakdownRow
+    let day: Date
+  }
+
+  /// One parseable row's conversion plan: the parsed rows, the
+  /// index-aligned flat request list, and the day-strings that failed to
+  /// parse so the caller surfaces them before the batch.
+  private struct ExpenseBreakdownPlan {
+    let parsedRows: [ExpenseBreakdownParsedRow]
+    let requests: [BatchConversionRequest]
+    let unparseableDays: [String]
+  }
+
   /// Walks the SQL aggregation rows, converts each `(qty, instrument)`
   /// to the profile instrument on its own day, and buckets the results
   /// by `(financialMonth, categoryId)`. Conversion runs outside the
@@ -119,13 +136,17 @@ extension GRDBAnalysisRepository {
   /// specific `Logger` instance. `handlers.handleConversionFailure` is
   /// invoked once per failing row so each failure surfaces individually
   /// in diagnostics rather than being collapsed into the first failure
-  /// to escape — the loop continues processing remaining rows, then
+  /// to escape — the walk continues processing remaining rows, then
   /// re-throws the first failure after the walk so the function
   /// preserves its existing "throws on conversion error" contract while
   /// still delivering the per-row detail required by
   /// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11. A `CancellationError` is
-  /// rethrown immediately and never folded into the conversion-failure
-  /// path.
+  /// rethrown immediately (it propagates straight out of the batch call)
+  /// and never folded into the conversion-failure path.
+  ///
+  /// All rows' `(qty, instrument, day)` conversions resolve in a single
+  /// `convertResultBatch(_:)`; the outcomes stay index-aligned with the
+  /// rows so the per-row failure callbacks still fire in row order.
   @concurrent
   static func assembleExpenseBreakdown(
     aggregation: ExpenseBreakdownAggregation,
@@ -134,6 +155,15 @@ extension GRDBAnalysisRepository {
     monthEnd: Int,
     handlers: ExpenseBreakdownHandlers
   ) async throws -> [ExpenseBreakdown] {
+    let plan = Self.planExpenseBreakdown(
+      aggregation: aggregation, profileInstrument: profileInstrument)
+    for dayString in plan.unparseableDays {
+      handlers.handleUnparseableDay(dayString)
+    }
+    // One batched conversion for every parseable row; `CancellationError`
+    // propagates straight out (never reaching the per-row failure path).
+    let outcomes = try await conversionService.convertResultBatch(plan.requests)
+
     var buckets: [String: [UUID?: InstrumentAmount]] = [:]
     var firstConversionError: Error?
     // Strict Rule 11 (#1077): a financial month with ANY transient
@@ -143,27 +173,18 @@ extension GRDBAnalysisRepository {
     // the income/expense aggregation, `ExpenseBreakdown` carries no
     // start/end, so a plain month set suffices (no day-range tracking).
     var incompleteMonths: Set<String> = []
-    for row in aggregation.rows {
-      guard let day = Self.parseDayString(row.day) else {
-        handlers.handleUnparseableDay(row.day)
-        continue
-      }
-      let instrument =
-        aggregation.instrumentMap[row.instrumentId]
-        ?? Instrument.fiat(code: row.instrumentId)
+    for (planned, outcome) in zip(plan.parsedRows, outcomes) {
+      let row = planned.row
+      let day = planned.day
       let amount: InstrumentAmount
-      do {
-        amount = try await Self.convertedQuantity(
-          storageValue: row.qty,
-          instrument: instrument,
-          to: profileInstrument,
-          on: day,
-          conversionService: conversionService)
-      } catch let cancel as CancellationError {
-        // Cooperative cancellation surfaces unchanged — never folded
-        // into the per-row conversion-failure log path.
-        throw cancel
-      } catch {
+      switch outcome {
+      case .value(let converted):
+        amount = converted
+      case .knownZero:
+        // Issue #790: an `.unpriced` / `.spam` source folds to zero in
+        // the profile instrument rather than failing the row.
+        amount = .zero(instrument: profileInstrument)
+      case .failure(let error):
         let context = ConversionFailureContext(
           day: row.day, categoryId: row.categoryId, instrumentId: row.instrumentId)
         handlers.handleConversionFailure(error, context)
@@ -196,6 +217,38 @@ extension GRDBAnalysisRepository {
       buckets,
       incompleteMonths: incompleteMonths,
       profileInstrument: profileInstrument)
+  }
+
+  /// Parse every row's day, resolve its source instrument, and build the
+  /// flat batch request list. Same-instrument rows still contribute a
+  /// request so the outcome list stays index-aligned with the rows; the
+  /// batch's same-instrument fast path resolves them to `.value` without
+  /// a conversion-service hit, matching `convertedQuantity`'s short
+  /// circuit.
+  private static func planExpenseBreakdown(
+    aggregation: ExpenseBreakdownAggregation,
+    profileInstrument: Instrument
+  ) -> ExpenseBreakdownPlan {
+    var parsedRows: [ExpenseBreakdownParsedRow] = []
+    var requests: [BatchConversionRequest] = []
+    var unparseableDays: [String] = []
+    for row in aggregation.rows {
+      guard let day = Self.parseDayString(row.day) else {
+        unparseableDays.append(row.day)
+        continue
+      }
+      let instrument =
+        aggregation.instrumentMap[row.instrumentId]
+        ?? Instrument.fiat(code: row.instrumentId)
+      parsedRows.append(ExpenseBreakdownParsedRow(row: row, day: day))
+      requests.append(
+        BatchConversionRequest(
+          amount: InstrumentAmount(storageValue: row.qty, instrument: instrument),
+          target: profileInstrument,
+          date: day))
+    }
+    return ExpenseBreakdownPlan(
+      parsedRows: parsedRows, requests: requests, unparseableDays: unparseableDays)
   }
 
   /// Emits one `ExpenseBreakdown` per non-empty `(month, category)` bucket

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpense.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpense.swift
@@ -91,16 +91,6 @@ extension GRDBAnalysisRepository {
     var investmentProfit: InstrumentAmount
   }
 
-  /// Bundle of converted per-row sums fed into a month bucket, so the
-  /// bucket-update helper takes one parameter instead of many.
-  private struct ConvertedRowSums {
-    let day: Date
-    let income: InstrumentAmount
-    let expense: InstrumentAmount
-    let investmentIncome: InstrumentAmount
-    let investmentExpense: InstrumentAmount
-  }
-
   /// Walks the SQL aggregation rows, converts each row's four sums to
   /// the profile instrument on the row's own day, and accumulates
   /// into per-financial-month buckets. Conversion runs outside the
@@ -130,6 +120,16 @@ extension GRDBAnalysisRepository {
     monthEnd: Int,
     handlers: IncomeAndExpenseHandlers
   ) async throws -> [MonthlyIncomeExpense] {
+    let plan = Self.planIncomeAndExpense(
+      aggregation: aggregation, profileInstrument: profileInstrument)
+    for dayString in plan.unparseableDays {
+      handlers.handleUnparseableDay(dayString)
+    }
+    // One batched conversion for every parseable row's non-zero columns;
+    // `CancellationError` propagates straight out (never reaching the
+    // per-row failure path).
+    let outcomes = try await conversionService.convertResultBatch(plan.requests)
+
     var buckets: [String: MonthBucket] = [:]
     var firstConversionError: Error?
     // Strict Rule 11 (#1077): a financial month with ANY transient
@@ -137,26 +137,19 @@ extension GRDBAnalysisRepository {
     // rows in the month converted — and a month whose rows ALL skipped
     // still emits a zeroed placeholder bucket spanning the failing days.
     var unavailable = UnavailableMonthTracker()
-    for row in aggregation.rows {
-      guard let day = Self.parseDayString(row.day) else {
-        handlers.handleUnparseableDay(row.day)
-        continue
-      }
-      let instrument =
-        aggregation.instrumentMap[row.instrumentId]
-        ?? Instrument.fiat(code: row.instrumentId)
+    var cursor = 0
+    for planned in plan.parsedRows {
+      let row = planned.row
+      let day = planned.day
+      let slice = Array(outcomes[cursor..<cursor + planned.tags.count])
+      cursor += planned.tags.count
       let converted: ConvertedRowSums
       do {
-        converted = try await Self.convertRowSums(
-          row: row,
+        converted = try Self.assembleConvertedRowSums(
+          tags: planned.tags,
+          outcomes: slice,
           day: day,
-          instrument: instrument,
-          profileInstrument: profileInstrument,
-          conversionService: conversionService)
-      } catch let cancel as CancellationError {
-        // Cooperative cancellation surfaces unchanged — never folded
-        // into the per-row conversion-failure log path.
-        throw cancel
+          profileInstrument: profileInstrument)
       } catch {
         let context = IncomeAndExpenseFailureContext(
           day: row.day, instrumentId: row.instrumentId)
@@ -231,59 +224,6 @@ extension GRDBAnalysisRepository {
       }
       buckets[month] = bucket
     }
-  }
-
-  /// Converts each of the four per-row sums to the profile instrument
-  /// on the row's `day`. Same-instrument rows incur zero
-  /// conversion-service calls: zero-value columns short-circuit in
-  /// `convertedQuantityIfNonZero` before reaching the conversion
-  /// service, and non-zero same-instrument sums short-circuit in
-  /// `convertedQuantity` at the `instrument.id == target.id` guard.
-  private static func convertRowSums(
-    row: IncomeAndExpenseRow,
-    day: Date,
-    instrument: Instrument,
-    profileInstrument: Instrument,
-    conversionService: any InstrumentConversionService
-  ) async throws -> ConvertedRowSums {
-    func convert(_ value: Int64) async throws -> InstrumentAmount {
-      try await Self.convertedQuantityIfNonZero(
-        storageValue: value,
-        instrument: instrument,
-        profileInstrument: profileInstrument,
-        day: day,
-        conversionService: conversionService)
-    }
-    return ConvertedRowSums(
-      day: day,
-      income: try await convert(row.incomeQty),
-      expense: try await convert(row.expenseQty),
-      investmentIncome: try await convert(row.investmentIncomeQty),
-      investmentExpense: try await convert(row.investmentExpenseQty))
-  }
-
-  /// Skip the conversion call when the storage value is zero — every
-  /// CASE branch of the SQL emits `0` for non-matching legs, so most
-  /// rows have several zero-value columns. Skipping the call keeps
-  /// the conversion-service hit count tied to the row count rather
-  /// than four-times the row count, preserving the per-row counter
-  /// invariants asserted by `GRDBIncomeAndExpenseAssembleTests`.
-  private static func convertedQuantityIfNonZero(
-    storageValue: Int64,
-    instrument: Instrument,
-    profileInstrument: Instrument,
-    day: Date,
-    conversionService: any InstrumentConversionService
-  ) async throws -> InstrumentAmount {
-    if storageValue == 0 {
-      return .zero(instrument: profileInstrument)
-    }
-    return try await Self.convertedQuantity(
-      storageValue: storageValue,
-      instrument: instrument,
-      to: profileInstrument,
-      on: day,
-      conversionService: conversionService)
   }
 
   /// Build a fresh `MonthBucket` seeded with the row's day as both

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpenseBatch.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpenseBatch.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Batch-conversion planning and outcome-reassembly helpers for
+/// `assembleIncomeAndExpense`. Split from the main
+/// `+IncomeAndExpense.swift` assembly file: the per-row walk there
+/// drives `planIncomeAndExpense` once up front to flatten every row's
+/// non-zero columns into a single `convertResultBatch(_:)` request list,
+/// then `assembleConvertedRowSums` to rebuild each row's four-column
+/// `ConvertedRowSums` from its outcome slice.
+extension GRDBAnalysisRepository {
+  /// Bundle of converted per-row sums fed into a month bucket, so the
+  /// bucket-update helper takes one parameter instead of many.
+  struct ConvertedRowSums {
+    let day: Date
+    let income: InstrumentAmount
+    let expense: InstrumentAmount
+    let investmentIncome: InstrumentAmount
+    let investmentExpense: InstrumentAmount
+  }
+
+  /// Which of the four `ConvertedRowSums` columns a batch request fills.
+  /// Only non-zero columns produce a request (and therefore a tag), so a
+  /// row's tag list mirrors exactly the conversion-service hits the
+  /// pre-batch `convertRowSums` would have made — keeping the per-row
+  /// counter invariants asserted by `GRDBIncomeAndExpenseAssembleTests`.
+  enum IncomeExpenseColumn {
+    case income
+    case expense
+    case investmentIncome
+    case investmentExpense
+  }
+
+  /// One parseable row paired with its parsed day and the `(column)` tags
+  /// whose outcomes reassemble into a `ConvertedRowSums`. The tag count
+  /// equals the number of requests this row contributed to the flat list.
+  struct IncomeExpenseRowPlan {
+    let row: IncomeAndExpenseRow
+    let day: Date
+    let tags: [IncomeExpenseColumn]
+  }
+
+  /// Flat batch plan across every parseable row: per-row plans plus the
+  /// index-aligned flat request list and the day-strings that failed to
+  /// parse.
+  struct IncomeAndExpensePlan {
+    let parsedRows: [IncomeExpenseRowPlan]
+    let requests: [BatchConversionRequest]
+    let unparseableDays: [String]
+  }
+
+  /// Parse every row's day, resolve its source instrument, and build the
+  /// flat batch request list across all four columns of every row. A
+  /// zero-value column emits no request (it folds to `.zero` at assembly
+  /// time) so the conversion-service hit count stays tied to the non-zero
+  /// column count rather than four-times the row count. Same-instrument
+  /// non-zero columns still emit a request; the batch's same-instrument
+  /// fast path resolves them to `.value` without a service hit, matching
+  /// `convertedQuantity`'s short circuit.
+  static func planIncomeAndExpense(
+    aggregation: IncomeAndExpenseAggregation,
+    profileInstrument: Instrument
+  ) -> IncomeAndExpensePlan {
+    var parsedRows: [IncomeExpenseRowPlan] = []
+    var requests: [BatchConversionRequest] = []
+    var unparseableDays: [String] = []
+    for row in aggregation.rows {
+      guard let day = Self.parseDayString(row.day) else {
+        unparseableDays.append(row.day)
+        continue
+      }
+      let instrument =
+        aggregation.instrumentMap[row.instrumentId]
+        ?? Instrument.fiat(code: row.instrumentId)
+      let columns: [(IncomeExpenseColumn, Int64)] = [
+        (.income, row.incomeQty),
+        (.expense, row.expenseQty),
+        (.investmentIncome, row.investmentIncomeQty),
+        (.investmentExpense, row.investmentExpenseQty),
+      ]
+      var tags: [IncomeExpenseColumn] = []
+      for (column, value) in columns where value != 0 {
+        tags.append(column)
+        requests.append(
+          BatchConversionRequest(
+            amount: InstrumentAmount(storageValue: value, instrument: instrument),
+            target: profileInstrument,
+            date: day))
+      }
+      parsedRows.append(IncomeExpenseRowPlan(row: row, day: day, tags: tags))
+    }
+    return IncomeAndExpensePlan(
+      parsedRows: parsedRows, requests: requests, unparseableDays: unparseableDays)
+  }
+
+  /// Reassemble one row's `ConvertedRowSums` from its `(column, outcome)`
+  /// slice. Every column starts at `.zero(profileInstrument)` so the
+  /// zero-value columns the plan skipped contribute zero. The batch
+  /// resolves all of the row's non-zero columns up front; this walk
+  /// surfaces the first `.failure` in the slice so the row degrades as a
+  /// unit, throwing that column's error. `.knownZero` folds to zero
+  /// (issue #790).
+  static func assembleConvertedRowSums(
+    tags: [IncomeExpenseColumn],
+    outcomes: [BatchConversionOutcome],
+    day: Date,
+    profileInstrument: Instrument
+  ) throws -> ConvertedRowSums {
+    var income = InstrumentAmount.zero(instrument: profileInstrument)
+    var expense = InstrumentAmount.zero(instrument: profileInstrument)
+    var investmentIncome = InstrumentAmount.zero(instrument: profileInstrument)
+    var investmentExpense = InstrumentAmount.zero(instrument: profileInstrument)
+    for (column, outcome) in zip(tags, outcomes) {
+      let amount: InstrumentAmount
+      switch outcome {
+      case .value(let converted):
+        amount = converted
+      case .knownZero:
+        amount = .zero(instrument: profileInstrument)
+      case .failure(let error):
+        throw error
+      }
+      // Direct assignment (not accumulation) is safe: each column tag
+      // appears at most once per row, and the targets are zero-initialized.
+      switch column {
+      case .income: income = amount
+      case .expense: expense = amount
+      case .investmentIncome: investmentIncome = amount
+      case .investmentExpense: investmentExpense = amount
+      }
+    }
+    return ConvertedRowSums(
+      day: day,
+      income: income,
+      expense: expense,
+      investmentIncome: investmentIncome,
+      investmentExpense: investmentExpense)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBCategoryBalancesAssembleTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCategoryBalancesAssembleTests.swift
@@ -126,8 +126,8 @@ struct GRDBCategoryBalancesAssembleTests {
     }
 
     // CancellationError surfaced unchanged — the per-row failure log
-    // never fired, and the loop short-circuited on the first row
-    // (no further conversion calls beyond the cancelled one).
+    // never fired, and the batch rethrew CancellationError after the
+    // first element resolved; no further conversion calls issued.
     #expect(visited.snapshot().isEmpty)
     #expect(conversionService.callCount == 1)
   }

--- a/MoolahTests/Backends/GRDB/GRDBExpenseBreakdownAssembleTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBExpenseBreakdownAssembleTests.swift
@@ -230,8 +230,8 @@ struct GRDBExpenseBreakdownAssembleTests {
     }
 
     // CancellationError surfaced unchanged — the per-row failure log
-    // never fired, and the loop short-circuited on the first row
-    // (no further conversion calls beyond the cancelled one).
+    // never fired, and the batch rethrew CancellationError after the
+    // first element resolved; no further conversion calls issued.
     #expect(visited.snapshot().isEmpty)
     #expect(conversionService.callCount == 1)
   }

--- a/MoolahTests/Backends/GRDB/GRDBIncomeAndExpenseAssembleTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBIncomeAndExpenseAssembleTests.swift
@@ -122,6 +122,44 @@ struct GRDBIncomeAndExpenseAssembleTests {
     #expect(conversionService.callCount == 3)
   }
 
+  @Test("multi-column row surfaces the first failing column's error after batching both columns")
+  func multiColumnRowSurfacesFirstColumnError() async throws {
+    // A single row carrying BOTH a non-zero income and a non-zero expense
+    // pins the batch semantics: every non-zero column is converted up
+    // front in one batch, and the row's reassembly surfaces the FIRST
+    // `.failure` in column order (income, index 0) as the row's error.
+    let usd = "USD"
+    let aggregation = GRDBAnalysisRepository.IncomeAndExpenseAggregation(
+      rows: [
+        .init(
+          day: "2025-01-15", instrumentId: usd,
+          incomeQty: 100, expenseQty: 200,
+          investmentIncomeQty: 0, investmentExpenseQty: 0)
+      ],
+      instrumentMap: [usd: .fiat(code: usd)])
+    // Index 0 (income) fails; index 1 (expense) succeeds. The surfaced
+    // error must be the income column's, proving column-order precedence.
+    let conversionService = FakeConversionService.perCall { index in
+      index == 0 ? .failure(CallbackError(index: index)) : .success(0)
+    }
+    let handlers = GRDBAnalysisRepository.IncomeAndExpenseHandlers(
+      handleUnparseableDay: { _ in }, handleConversionFailure: { _, _ in })
+
+    let thrown = await #expect(throws: CallbackError.self) {
+      _ = try await GRDBAnalysisRepository.assembleIncomeAndExpense(
+        aggregation: aggregation,
+        profileInstrument: .defaultTestInstrument,
+        conversionService: conversionService,
+        monthEnd: 25,
+        handlers: handlers)
+    }
+    // The income column (index 0) is the one whose error surfaces.
+    #expect(thrown == CallbackError(index: 0))
+    // Both non-zero columns were flattened into a single batch — the row
+    // is converted as a unit, not aborted at the first failing column.
+    #expect(conversionService.recordedBatches.last?.count == 2)
+  }
+
   @Test("transient conversion failures degrade per-row — no rethrow")
   func transientFailuresDoNotRethrow() async throws {
     let aggregation = makeAggregation()
@@ -260,8 +298,8 @@ struct GRDBIncomeAndExpenseAssembleTests {
     }
 
     // CancellationError surfaced unchanged — the per-row failure log
-    // never fired, and the loop short-circuited on the first row
-    // (no further conversion calls beyond the cancelled one).
+    // never fired, and the batch rethrew CancellationError after the
+    // first element resolved; no further conversion calls issued.
     #expect(visited.snapshot().isEmpty)
     #expect(conversionService.callCount == 1)
   }


### PR DESCRIPTION
PR-C1 of the batch-conversion-API initiative (follow-on to #1163). Migrates the three analysis aggregation methods to one convertResultBatch each. Rethrow-first-failure contract, per-row dates, knownZero, and same-instrument fast path preserved; existing assemble + unavailable contract suites pass unchanged. instrument-conversion-review findings applied. 🤖 Generated with [Claude Code](https://claude.com/claude-code)