### PR TITLE
perf(conversion): batch account/earmark/investment/positions display-balance conversions

### DIFF
--- a/Features/Accounts/AccountBalanceCalculator.swift
+++ b/Features/Accounts/AccountBalanceCalculator.swift
@@ -105,6 +105,13 @@ struct AccountBalanceCalculator {
   ) async throws -> InstrumentAmount {
     var total = InstrumentAmount.zero(instrument: target)
     let date = Date()
+    // recordedValue snapshots keep their existing `convertAmount` semantics
+    // (throw on failure, throw on knownZero). Every other account's
+    // cross-instrument positions accumulate into one flat batch resolved by a
+    // single `convertResultBatch`. Same-instrument positions sum inline
+    // (Rule 8). A `.failure` outcome rethrows so the whole total is marked
+    // unavailable (Rule 11); `.knownZero` contributes zero (#790).
+    var requests: [BatchConversionRequest] = []
     for account in accounts {
       if account.type == .investment, account.valuationMode == .recordedValue {
         let snapshot =
@@ -123,13 +130,17 @@ struct AccountBalanceCalculator {
         if position.amount.instrument == target {
           total += position.amount
         } else {
-          let result = try await conversionService.convertResult(
-            position.amount, to: target, on: date)
-          if case .value(let converted) = result {
-            total += converted
-          }
+          requests.append(
+            BatchConversionRequest(amount: position.amount, target: target, date: date))
         }
-        try Task.checkCancellation()
+      }
+    }
+    let outcomes = try await conversionService.convertResultBatch(requests)
+    for outcome in outcomes {
+      switch outcome {
+      case .value(let converted): total += converted
+      case .knownZero: break
+      case .failure(let error): throw error
       }
     }
     return total
@@ -160,18 +171,28 @@ struct AccountBalanceCalculator {
     if account.type == .investment, account.valuationMode == .recordedValue {
       return investmentValue ?? .zero(instrument: account.instrument)
     }
-    var total = InstrumentAmount.zero(instrument: account.instrument)
+    let target = account.instrument
+    var total = InstrumentAmount.zero(instrument: target)
+    // Sum same-instrument positions inline (Rule 8 fast path); batch the
+    // rest into a single `convertResultBatch`. A `.failure` outcome rethrows
+    // so the caller marks the balance unavailable (Rule 11); `.knownZero`
+    // contributes nothing (#790).
+    var requests: [BatchConversionRequest] = []
     for position in account.positions {
-      if position.amount.instrument == account.instrument {
+      if position.amount.instrument == target {
         total += position.amount
       } else {
-        let result = try await conversionService.convertResult(
-          position.amount, to: account.instrument, on: date)
-        if case .value(let converted) = result {
-          total += converted
-        }
+        requests.append(
+          BatchConversionRequest(amount: position.amount, target: target, date: date))
       }
-      try Task.checkCancellation()
+    }
+    let outcomes = try await conversionService.convertResultBatch(requests)
+    for outcome in outcomes {
+      switch outcome {
+      case .value(let converted): total += converted
+      case .knownZero: break
+      case .failure(let error): throw error
+      }
     }
     return total
   }
@@ -186,16 +207,42 @@ struct AccountBalanceCalculator {
     balances: [UUID: InstrumentAmount],
     on date: Date
   ) async -> (InstrumentAmount, Bool) {
-    var total = InstrumentAmount.zero(instrument: targetInstrument)
+    // Collect one request per account, bailing if any account is missing
+    // from `balances` (same as the serial guard). Resolve all in one
+    // `convertResultBatch`; any `.failure` marks the whole aggregate
+    // unavailable — an inaccurate aggregate is worse than no aggregate.
+    var requests: [BatchConversionRequest] = []
+    requests.reserveCapacity(list.count)
     for account in list {
       guard let balance = balances[account.id] else {
         return (.zero(instrument: targetInstrument), false)
       }
-      do {
-        let converted = try await conversionService.convertAmount(
-          balance, to: targetInstrument, on: date)
-        total += converted
-      } catch {
+      requests.append(
+        BatchConversionRequest(amount: balance, target: targetInstrument, date: date))
+    }
+    let outcomes: [BatchConversionOutcome]
+    do {
+      outcomes = try await conversionService.convertResultBatch(requests)
+    } catch {
+      // Cancellation: caller re-checks `Task.isCancelled` and short-circuits.
+      return (.zero(instrument: targetInstrument), false)
+    }
+    var total = InstrumentAmount.zero(instrument: targetInstrument)
+    for (account, outcome) in zip(list, outcomes) {
+      switch outcome {
+      case .value(let converted): total += converted
+      case .knownZero:
+        // Unreachable today: each request converts a per-account display
+        // balance, which is always fiat / the profile currency and so can't
+        // resolve to a `.knownZero` (.unpriced / .spam) crypto source. Guard
+        // it anyway — a future account type with a crypto display instrument
+        // would land here, and silently folding it to zero would understate
+        // the aggregate. Mark the total unavailable instead (#790).
+        assertionFailure(
+          "Aggregate display balance resolved to .knownZero for \(account.name); "
+            + "display balances are expected to be fiat / profile currency.")
+        return (.zero(instrument: targetInstrument), false)
+      case .failure(let error):
         logger.warning(
           "Aggregate conversion failed for \(account.name): \(error.localizedDescription)")
         return (.zero(instrument: targetInstrument), false)

--- a/Features/Earmarks/EarmarkStore+Conversion.swift
+++ b/Features/Earmarks/EarmarkStore+Conversion.swift
@@ -24,35 +24,76 @@ extension EarmarkStore {
     -> ConvertedEarmarkTotals
   {
     let date = Date()
-    var balance = InstrumentAmount.zero(instrument: earmark.instrument)
-    var saved = InstrumentAmount.zero(instrument: earmark.instrument)
-    var spent = InstrumentAmount.zero(instrument: earmark.instrument)
-    for position in earmark.positions {
-      balance += try await convertPositionOrZero(
-        position.amount, to: earmark.instrument, on: date)
-    }
-    for position in earmark.savedPositions {
-      saved += try await convertPositionOrZero(
-        position.amount, to: earmark.instrument, on: date)
-    }
-    for position in earmark.spentPositions {
-      spent += try await convertPositionOrZero(
-        position.amount, to: earmark.instrument, on: date)
-    }
+    let target = earmark.instrument
+    // Same-instrument fast path (Rule 8): positions already in `target` are
+    // summed inline and never enter the batch. Each list keeps its inline
+    // total plus the count of cross-instrument requests it contributed, so
+    // its outcome slice sums back in the order Phase 1 appended them. A
+    // single `convertResultBatch` resolves all cross-instrument positions.
+    var requests: [BatchConversionRequest] = []
+    let (balanceInline, balanceCount) = accumulate(
+      earmark.positions, target: target, date: date, into: &requests)
+    let (savedInline, savedCount) = accumulate(
+      earmark.savedPositions, target: target, date: date, into: &requests)
+    let (spentInline, spentCount) = accumulate(
+      earmark.spentPositions, target: target, date: date, into: &requests)
+    let outcomes = try await conversionService.convertResultBatch(requests)
+
+    var cursor = 0
+    let balance = try sumOutcomes(
+      outcomes, range: &cursor, count: balanceCount, into: balanceInline)
+    let saved = try sumOutcomes(
+      outcomes, range: &cursor, count: savedCount, into: savedInline)
+    let spent = try sumOutcomes(
+      outcomes, range: &cursor, count: spentCount, into: spentInline)
     return ConvertedEarmarkTotals(balance: balance, saved: saved, spent: spent)
   }
 
-  /// Convert `amount` to `target` on `date`, folding `.knownZero` (an
-  /// `.unpriced` / `.spam` crypto source) to zero in `target`.
-  /// Issue #790.
-  func convertPositionOrZero(
-    _ amount: InstrumentAmount, to target: Instrument, on date: Date
-  ) async throws -> InstrumentAmount {
-    let result = try await conversionService.convertResult(
-      amount, to: target, on: date)
-    switch result {
-    case .value(let converted): return converted
-    case .knownZero: return .zero(instrument: target)
+  /// Split one position list into its same-instrument inline subtotal and the
+  /// cross-instrument requests appended to `requests`. Returns the inline
+  /// total (already in `target`) and the number of requests contributed, so
+  /// the caller can slice the matching outcomes back out in order.
+  private func accumulate(
+    _ positions: [Position],
+    target: Instrument,
+    date: Date,
+    into requests: inout [BatchConversionRequest]
+  ) -> (inline: InstrumentAmount, count: Int) {
+    var inline = InstrumentAmount.zero(instrument: target)
+    var count = 0
+    for position in positions {
+      if position.amount.instrument == target {
+        inline += position.amount
+      } else {
+        requests.append(
+          BatchConversionRequest(amount: position.amount, target: target, date: date))
+        count += 1
+      }
     }
+    return (inline, count)
+  }
+
+  /// Fold `count` outcomes starting at `cursor` (advanced in place) into
+  /// `inline` (the list's same-instrument subtotal, already in the target
+  /// instrument). Folds `.knownZero` (an `.unpriced` / `.spam` crypto source)
+  /// to zero (issue #790); rethrows the first `.failure` so a real provider
+  /// outage fails the whole earmark — we never display a partial earmark
+  /// balance under transient outage.
+  private func sumOutcomes(
+    _ outcomes: [BatchConversionOutcome],
+    range cursor: inout Int,
+    count: Int,
+    into inline: InstrumentAmount
+  ) throws -> InstrumentAmount {
+    var total = inline
+    for outcome in outcomes[cursor..<cursor + count] {
+      switch outcome {
+      case .value(let converted): total += converted
+      case .knownZero: break
+      case .failure(let error): throw error
+      }
+    }
+    cursor += count
+    return total
   }
 }

--- a/Features/Investments/InvestmentStore+Positions.swift
+++ b/Features/Investments/InvestmentStore+Positions.swift
@@ -77,13 +77,41 @@ extension InvestmentStore {
   /// values. `.knownZero` positions drop out of `valuedPositions`
   /// entirely (issue #790).
   func valuatePositions(profileCurrency: Instrument, on date: Date) async {
+    // Phase 1 — accumulate one batch request per cross-instrument position;
+    // host-currency positions resolve inline (Rule 8 fast path) and never
+    // contribute a request. Phase 2 — one batched conversion (cancellation
+    // surfaces as a thrown `CancellationError`). Phase 3 — assemble each
+    // position's row and fold its outcome into the total / first failure.
+    var requests: [BatchConversionRequest] = []
+    requests.reserveCapacity(positions.count)
+    for position in positions where position.instrument.id != profileCurrency.id {
+      requests.append(
+        BatchConversionRequest(
+          amount: InstrumentAmount(
+            quantity: position.quantity, instrument: position.instrument),
+          target: profileCurrency,
+          date: date))
+    }
+
+    let outcomes: [BatchConversionOutcome]
+    do {
+      outcomes = try await conversionService.convertResultBatch(requests)
+    } catch {
+      // Cancellation is task-wide and not a failure: leave published state
+      // untouched so a re-run recomputes from scratch.
+      return
+    }
+
     var valued: [ValuedPosition] = []
     var total: Decimal = 0
     var firstFailure: Error?
-
+    var cursor = 0
     for position in positions {
-      let (entry, outcome) = await valuate(
-        position: position, profileCurrency: profileCurrency, on: date)
+      let isHostCurrency = position.instrument.id == profileCurrency.id
+      let resolved: BatchConversionOutcome? = isHostCurrency ? nil : outcomes[cursor]
+      if !isHostCurrency { cursor += 1 }
+      let (entry, outcome) = valuate(
+        position: position, profileCurrency: profileCurrency, outcome: resolved)
       if let entry { valued.append(entry) }
       switch outcome {
       case .success(let value):
@@ -157,10 +185,13 @@ extension InvestmentStore {
     case failure(Error)
   }
 
+  /// Assemble one position's `ValuedPosition` + `ValuationOutcome` from its
+  /// pre-resolved batch `outcome`. Pass `outcome: nil` for a host-currency
+  /// position (Rule 8 fast path) — it values 1:1 without a conversion.
   private func valuate(
-    position: Position, profileCurrency: Instrument, on date: Date
-  ) async -> (ValuedPosition?, ValuationOutcome) {
-    if position.instrument.id == profileCurrency.id {
+    position: Position, profileCurrency: Instrument, outcome: BatchConversionOutcome?
+  ) -> (ValuedPosition?, ValuationOutcome) {
+    guard let outcome else {
       let entry = ValuedPosition(
         instrument: position.instrument,
         quantity: position.quantity,
@@ -169,29 +200,23 @@ extension InvestmentStore {
         value: InstrumentAmount(quantity: position.quantity, instrument: profileCurrency))
       return (entry, .success(position.quantity))
     }
-    do {
-      let amount = InstrumentAmount(
-        quantity: position.quantity, instrument: position.instrument)
-      let result = try await conversionService.convertResult(
-        amount, to: profileCurrency, on: date)
-      switch result {
-      case .knownZero:
-        return (nil, .knownZero)
-      case .value(let converted):
-        let value = converted.quantity
-        let unit =
-          position.quantity == 0
-          ? nil
-          : InstrumentAmount(quantity: value / position.quantity, instrument: profileCurrency)
-        let entry = ValuedPosition(
-          instrument: position.instrument,
-          quantity: position.quantity,
-          unitPrice: unit,
-          costBasis: nil,
-          value: converted)
-        return (entry, .success(value))
-      }
-    } catch {
+    switch outcome {
+    case .knownZero:
+      return (nil, .knownZero)
+    case .value(let converted):
+      let value = converted.quantity
+      let unit =
+        position.quantity == 0
+        ? nil
+        : InstrumentAmount(quantity: value / position.quantity, instrument: profileCurrency)
+      let entry = ValuedPosition(
+        instrument: position.instrument,
+        quantity: position.quantity,
+        unitPrice: unit,
+        costBasis: nil,
+        value: converted)
+      return (entry, .success(value))
+    case .failure(let error):
       logger.warning(
         "Failed to valuate position \(position.instrument.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
       )

--- a/MoolahTests/Support/FakeConversionService.swift
+++ b/MoolahTests/Support/FakeConversionService.swift
@@ -276,6 +276,12 @@ final class FakeConversionService: InstrumentConversionService, Sendable {
         to: request.target, date: request.date)
       switch runOutcome(conversionRequest) {
       case .success(.value(let converted)):
+        // Mirror `convertResult`'s `.value` path: it also bumps
+        // `convertAmountCallCount` because the old doubles reached `.value`
+        // via `convertAmount`. Keeping the batch counting-equivalent to N
+        // serial `convertResult` calls is the invariant migrated sites rely
+        // on (e.g. the single-pass `convertAmountCallCount` delta assertion).
+        state.withLock { $0.convertAmountCallCount += 1 }
         outcomes.append(.value(converted))
       case .success(.knownZero(let targetInstrument)):
         outcomes.append(.knownZero(targetInstrument: targetInstrument))

--- a/MoolahTests/Support/FakeConversionServiceTests.swift
+++ b/MoolahTests/Support/FakeConversionServiceTests.swift
@@ -221,6 +221,11 @@ struct FakeConversionServiceTests {
     }
     #expect(second == InstrumentAmount(quantity: 7, instrument: aud))
 
+    // Only the `.value` element advances the counter; the `.failure` element
+    // does not. This pins the counting invariant migrated sites rely on (a
+    // failed element is not counted as a conversion).
+    #expect(failing.convertAmountCallCount == 1)
+
     // Cancellation is task-wide: it rethrows, never a per-element outcome.
     let cancelling = FakeConversionService.perCall { _ in .failure(CancellationError()) }
     await #expect(throws: CancellationError.self) {

--- a/Shared/PositionsValuator.swift
+++ b/Shared/PositionsValuator.swift
@@ -39,22 +39,55 @@ struct PositionsValuator: Sendable {
     costBasis: [String: Decimal],
     on date: Date
   ) async -> [ValuedPosition] {
+    // Phase 1 — accumulate one batch request per cross-instrument position;
+    // same-instrument positions resolve inline (Rule 8 fast path) and never
+    // contribute a request. Phase 2 — one batched conversion. Phase 3 —
+    // assemble each position's row from its outcome slot (Rule 11 / #790).
+    var requests: [BatchConversionRequest] = []
+    requests.reserveCapacity(positions.count)
+    for position in positions where position.instrument != hostCurrency {
+      requests.append(
+        BatchConversionRequest(
+          amount: InstrumentAmount(
+            quantity: position.quantity, instrument: position.instrument),
+          target: hostCurrency,
+          date: date))
+    }
+
+    // Cooperative cancellation now surfaces as a thrown `CancellationError`
+    // from the batch; the consuming `.task(id:)` is torn down (filter change
+    // / unmount) so we return what we have (nothing) and let the caller
+    // re-check `Task.isCancelled` before publishing.
+    let outcomes: [BatchConversionOutcome]
+    do {
+      outcomes = try await conversionService.convertResultBatch(requests)
+    } catch {
+      return []
+    }
+
     var rows: [ValuedPosition] = []
     rows.reserveCapacity(positions.count)
-    // Sequential await per row, not a TaskGroup: rows are independent, but the
-    // conversion service caches per (instrument, date), so warm-cache loads are
-    // O(1) per row. Cold-cache loads pay O(N * RTT) — acceptable for the dozens
-    // of positions per account this view targets. If profiling later shows cold
-    // loads are user-visible, switching to withTaskGroup is a self-contained change.
+    // Advances only for cross-instrument positions, so it indexes `outcomes`
+    // in the same order Phase 1 appended their requests; same-instrument
+    // positions take the fast path below and never consume an outcome.
+    var cursor = 0
     for position in positions {
-      // Cancellation cooperative: when the consuming `.task(id:)` is
-      // torn down (filter change / unmount) skip remaining positions
-      // and return what we have. The caller is expected to re-check
-      // `Task.isCancelled` before publishing the result so the partial
-      // list never lands on screen.
-      guard !Task.isCancelled else { break }
-      if let entry = await row(
-        for: position, hostCurrency: hostCurrency, costBasis: costBasis, on: date)
+      let cost: InstrumentAmount? = costBasis[position.instrument.id].map {
+        InstrumentAmount(quantity: $0, instrument: hostCurrency)
+      }
+      if position.instrument == hostCurrency {
+        rows.append(
+          ValuedPosition(
+            instrument: position.instrument,
+            quantity: position.quantity,
+            unitPrice: nil,
+            costBasis: cost,
+            value: InstrumentAmount(quantity: position.quantity, instrument: hostCurrency)))
+        continue
+      }
+      defer { cursor += 1 }
+      if let entry = row(
+        for: position, hostCurrency: hostCurrency, cost: cost, outcome: outcomes[cursor])
       {
         rows.append(entry)
       }
@@ -62,58 +95,41 @@ struct PositionsValuator: Sendable {
     return rows
   }
 
+  /// Assemble one cross-instrument position's row from its batch outcome.
+  /// `.knownZero` drops the row (returns `nil`, #790); `.value` builds the
+  /// valued row; `.failure` logs and emits a `value == nil` row (Rule 11).
   private func row(
     for position: Position,
     hostCurrency: Instrument,
-    costBasis: [String: Decimal],
-    on date: Date
-  ) async -> ValuedPosition? {
-    let cost: InstrumentAmount? = costBasis[position.instrument.id].map {
-      InstrumentAmount(quantity: $0, instrument: hostCurrency)
-    }
-
-    if position.instrument == hostCurrency {
+    cost: InstrumentAmount?,
+    outcome: BatchConversionOutcome
+  ) -> ValuedPosition? {
+    switch outcome {
+    case .knownZero:
+      // `.unpriced` / `.spam` crypto source — drop the row entirely
+      // so it stops appearing in the account's positions table.
+      // Issue #790.
+      return nil
+    case .value(let converted):
+      let total = converted.quantity
+      // For short positions (negative quantity), `total` and `position.quantity`
+      // share the negative sign, so the quotient yields a positive per-unit price
+      // — the natural reading of "what one share is worth right now". The zero
+      // guard prevents NaN from propagating into the rendered amount; we accept
+      // that a service returning total == 0 yields unitPrice == 0 (which is rare
+      // and visually obvious as "free", which is correct for the data we have).
+      let unit: InstrumentAmount? =
+        position.quantity == 0
+        ? nil
+        : InstrumentAmount(quantity: total / position.quantity, instrument: hostCurrency)
       return ValuedPosition(
         instrument: position.instrument,
         quantity: position.quantity,
-        unitPrice: nil,
+        unitPrice: unit,
         costBasis: cost,
-        value: InstrumentAmount(quantity: position.quantity, instrument: hostCurrency)
+        value: converted
       )
-    }
-
-    do {
-      let amount = InstrumentAmount(
-        quantity: position.quantity, instrument: position.instrument)
-      let result = try await conversionService.convertResult(
-        amount, to: hostCurrency, on: date)
-      switch result {
-      case .knownZero:
-        // `.unpriced` / `.spam` crypto source — drop the row entirely
-        // so it stops appearing in the account's positions table.
-        // Issue #790.
-        return nil
-      case .value(let converted):
-        let total = converted.quantity
-        // For short positions (negative quantity), `total` and `position.quantity`
-        // share the negative sign, so the quotient yields a positive per-unit price
-        // — the natural reading of "what one share is worth right now". The zero
-        // guard prevents NaN from propagating into the rendered amount; we accept
-        // that a service returning total == 0 yields unitPrice == 0 (which is rare
-        // and visually obvious as "free", which is correct for the data we have).
-        let unit: InstrumentAmount? =
-          position.quantity == 0
-          ? nil
-          : InstrumentAmount(quantity: total / position.quantity, instrument: hostCurrency)
-        return ValuedPosition(
-          instrument: position.instrument,
-          quantity: position.quantity,
-          unitPrice: unit,
-          costBasis: cost,
-          value: converted
-        )
-      }
-    } catch {
+    case .failure(let error):
       logger.warning(
         "Failed to valuate position \(position.instrument.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
       )


### PR DESCRIPTION
PR-C2 of the batch-conversion-API initiative (follow-on to #1163). Migrates the display-balance totals to convertResultBatch. The 'mark unavailable on failure' degradation rule, knownZero, same-instrument fast path, sign convention, and @MainActor isolation are preserved; existing suites pass unchanged. instrument-conversion-review findings applied. 🤖 Generated with [Claude Code](https://claude.com/claude-code)