### PR TITLE
perf(conversion): batch forecast/transaction-page conversions + insight bills

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
@@ -43,57 +43,140 @@ extension GRDBAnalysisRepository {
       context: context)
   }
 
-  /// Pre-convert all instances concurrently — each conversion is
-  /// independent. The accumulator that follows is inherently
-  /// sequential (each iteration depends on the previous running
-  /// totals), so it can't be parallelised.
+  /// One instance's slot in the flat batch request list: the range of
+  /// requests that belong to its foreign-instrument legs, index-aligned
+  /// to `legs` so the rebuild can stitch converted quantities back in.
+  /// Same-instrument legs carry no request (they pass through untouched),
+  /// so `legRequestIndices` maps each leg to its request index or `nil`.
+  private struct ForecastInstancePlan {
+    let instance: Transaction
+    /// For each leg, the index into the flat batch (and thus the flat
+    /// outcomes list) that converts it, or `nil` when the leg already
+    /// shares the profile instrument and needs no conversion.
+    let legRequestIndices: [Int?]
+    /// `true` when at least one leg needs conversion. Instances with no
+    /// foreign leg pass straight through, mirroring the same-instrument
+    /// fast-path guard the serial per-leg conversion used.
+    let needsConversion: Bool
+  }
+
+  /// Pre-convert all instances in a single batch — each leg conversion is
+  /// independent, so they collapse into one `convertResultBatch(...)` hop
+  /// over the profile instrument on `conversionDate`. The accumulator that
+  /// follows is inherently sequential (each iteration depends on the
+  /// previous running totals), so it can't be parallelised.
+  ///
+  /// Per-instance error tolerance (Rule 11,
+  /// `INSTRUMENT_CONVERSION_GUIDE.md`): a single instance's conversion
+  /// failure must not abort the whole forecast (that surfaced on the
+  /// Analysis page as a full-screen "WalletSyncError"). When ANY of an
+  /// instance's leg conversions resolves to `.failure`, the instance is
+  /// passed through *unconverted* and logged — the accumulator's per-day
+  /// `catch` then drops that day, and every later occurrence of an
+  /// unpriceable recurring leg drops the same way, so a day's total is
+  /// never partial. `.knownZero` legs fold to a zero-quantity leg (issue
+  /// #790).
+  ///
+  /// Cancellation propagates as a thrown `CancellationError`.
   private static func preConvertForecastInstances(
     _ instances: [Transaction],
     profileInstrument: Instrument,
     conversionService: any InstrumentConversionService,
     on conversionDate: Date
   ) async throws -> [Transaction] {
-    guard let firstInstance = instances.first else { return [] }
-    return try await withThrowingTaskGroup(of: (Int, Transaction).self) { group in
-      for (index, instance) in instances.enumerated() {
-        group.addTask {
-          do {
-            let txn = try await convertLegsToProfileInstrument(
-              instance,
-              to: profileInstrument,
-              on: conversionDate,
-              conversionService: conversionService)
-            return (index, txn)
-          } catch let cancel as CancellationError {
-            // Cooperative cancellation surfaces unchanged — never
-            // folded into the per-day degradation path.
-            throw cancel
-          } catch {
-            // Rule 11 (`INSTRUMENT_CONVERSION_GUIDE.md`): a single
-            // instance's conversion failure must not abort the whole
-            // forecast (that surfaced on the Analysis page as a
-            // full-screen "WalletSyncError"). Pass the instance through
-            // *unconverted* and log here — the accumulator's per-day
-            // `catch` then drops that day, and every later occurrence
-            // of an unpriceable recurring leg drops the same way, so a
-            // day's total is never partial. Logging at the point of
-            // failure is required: the accumulator only logs if
-            // `dailyBalance` itself subsequently throws, which is not
-            // guaranteed for every degraded instance.
-            forecastLogger.warning(
-              """
-              Forecast pre-conversion failed for instance \(index, privacy: .public) — \
-              \(error.localizedDescription, privacy: .public). Passing it through \
-              unconverted; affected forecast days drop (Rule 11).
-              """)
-            return (index, instance)
-          }
+    guard !instances.isEmpty else { return [] }
+
+    // Phase 1 — plan: collect every foreign leg's request across all
+    // instances into one flat list, recording per-leg request indices so
+    // the rebuild can stitch outcomes back in.
+    var requests: [BatchConversionRequest] = []
+    var plans: [ForecastInstancePlan] = []
+    plans.reserveCapacity(instances.count)
+    for instance in instances {
+      var legRequestIndices: [Int?] = []
+      legRequestIndices.reserveCapacity(instance.legs.count)
+      var needsConversion = false
+      for leg in instance.legs {
+        if leg.instrument.id == profileInstrument.id {
+          legRequestIndices.append(nil)
+        } else {
+          needsConversion = true
+          legRequestIndices.append(requests.count)
+          requests.append(
+            BatchConversionRequest(
+              amount: InstrumentAmount(quantity: leg.quantity, instrument: leg.instrument),
+              target: profileInstrument,
+              date: conversionDate))
         }
       }
-      var out = Array(repeating: firstInstance, count: instances.count)
-      for try await (index, txn) in group { out[index] = txn }
-      return out
+      plans.append(
+        ForecastInstancePlan(
+          instance: instance,
+          legRequestIndices: legRequestIndices,
+          needsConversion: needsConversion))
     }
+
+    // Phase 2 — one batched conversion. Cancellation throws here.
+    let outcomes = try await conversionService.convertResultBatch(requests)
+
+    // Phase 3 — rebuild each instance from its outcome slice, passing the
+    // instance through unconverted if any of its legs failed (Rule 11).
+    return plans.enumerated().map { index, plan in
+      rebuildForecastInstance(
+        plan,
+        outcomes: outcomes,
+        profileInstrument: profileInstrument,
+        instanceIndex: index)
+    }
+  }
+
+  /// Rebuild a single forecast instance from the flat `outcomes` list using
+  /// its `legRequestIndices`. Same-instrument legs (`nil` index) pass
+  /// through; `.value` legs adopt the converted quantity in the profile
+  /// instrument; `.knownZero` legs fold to a zero-quantity profile leg; a
+  /// `.failure` on any leg passes the WHOLE instance through unconverted and
+  /// logs once (per-instance error tolerance, Rule 11).
+  private static func rebuildForecastInstance(
+    _ plan: ForecastInstancePlan,
+    outcomes: [BatchConversionOutcome],
+    profileInstrument: Instrument,
+    instanceIndex: Int
+  ) -> Transaction {
+    guard plan.needsConversion else { return plan.instance }
+    var convertedLegs: [TransactionLeg] = []
+    convertedLegs.reserveCapacity(plan.instance.legs.count)
+    for (leg, requestIndex) in zip(plan.instance.legs, plan.legRequestIndices) {
+      guard let requestIndex else {
+        convertedLegs.append(leg)
+        continue
+      }
+      let convertedQty: Decimal
+      switch outcomes[requestIndex] {
+      case .value(let amount):
+        convertedQty = amount.quantity
+      case .knownZero:
+        convertedQty = 0
+      case .failure(let error):
+        forecastLogger.warning(
+          """
+          Forecast pre-conversion failed for instance \(instanceIndex, privacy: .public) — \
+          \(error.localizedDescription, privacy: .public). Passing it through \
+          unconverted; affected forecast days drop (Rule 11).
+          """)
+        return plan.instance
+      }
+      convertedLegs.append(
+        TransactionLeg(
+          accountId: leg.accountId,
+          instrument: profileInstrument,
+          quantity: convertedQty,
+          type: leg.type,
+          categoryId: leg.categoryId,
+          earmarkId: leg.earmarkId))
+    }
+    var result = plan.instance
+    result.legs = convertedLegs
+    return result
   }
 
   // MARK: - Scheduled-transaction extrapolation
@@ -153,64 +236,6 @@ extension GRDBAnalysisRepository {
     }
 
     return calendar.date(byAdding: components, to: date)
-  }
-
-  // MARK: - Per-instance leg conversion
-
-  /// Return a copy of the transaction with every leg's
-  /// quantity/instrument rewritten into the profile instrument. Used
-  /// before feeding scheduled-transaction instances into the forecast
-  /// accumulator so every leg already shares the profile instrument
-  /// when `PositionBook.dailyBalance` is queried (skipping the
-  /// multi-instrument conversion path on every forecast day).
-  ///
-  /// - Parameter date: date passed to the conversion service. For
-  ///   forecast use this is `Date()` — the current rate — because
-  ///   scheduled transactions have future dates and no exchange-rate
-  ///   source has future rates. Same-instrument legs are returned
-  ///   untouched.
-  static func convertLegsToProfileInstrument(
-    _ txn: Transaction,
-    to instrument: Instrument,
-    on date: Date,
-    conversionService: any InstrumentConversionService
-  ) async throws -> Transaction {
-    guard txn.legs.contains(where: { $0.instrument.id != instrument.id }) else {
-      return txn
-    }
-    var convertedLegs: [TransactionLeg] = []
-    convertedLegs.reserveCapacity(txn.legs.count)
-    for leg in txn.legs {
-      if leg.instrument.id == instrument.id {
-        convertedLegs.append(leg)
-        continue
-      }
-      // `.knownZero` source legs (`.unpriced` / `.spam` crypto) fold to
-      // a zero-quantity leg rather than aborting the forecast day —
-      // issue #790. Real provider errors still throw so a transient
-      // rate failure preserves Rule 11 (mark the day unavailable).
-      let conversionResult = try await conversionService.convertResult(
-        InstrumentAmount(quantity: leg.quantity, instrument: leg.instrument),
-        to: instrument,
-        on: date)
-      let convertedQty: Decimal
-      switch conversionResult {
-      case .value(let amount): convertedQty = amount.quantity
-      case .knownZero: convertedQty = 0
-      }
-      convertedLegs.append(
-        TransactionLeg(
-          accountId: leg.accountId,
-          instrument: instrument,
-          quantity: convertedQty,
-          type: leg.type,
-          categoryId: leg.categoryId,
-          earmarkId: leg.earmarkId
-        ))
-    }
-    var result = txn
-    result.legs = convertedLegs
-    return result
   }
 
   /// Walk the pre-converted instances and emit one `DailyBalance` per

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -78,6 +78,7 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   //
   // `+DailyBalancesForecast.swift` — `generateForecast` plus its
   // private helpers (`preConvertForecastInstances`,
+  // `rebuildForecastInstance`, the `ForecastInstancePlan` value type,
   // `runForecastAccumulator`) and a file-private logger for forecast
   // warnings.
   //

--- a/Domain/Models/TransactionPage.swift
+++ b/Domain/Models/TransactionPage.swift
@@ -27,6 +27,8 @@ struct TransactionPage: Sendable, Equatable {
   let priorBalance: InstrumentAmount?
   let totalCount: Int?
 
+  // MARK: - Running balances
+
   /// Computes the running balance after each transaction, converting each leg
   /// to the target instrument. Transactions must be ordered newest-first (as
   /// returned by the repository). `priorBalance` is the account balance
@@ -43,8 +45,8 @@ struct TransactionPage: Sendable, Equatable {
   ///   1. Walk every leg once to enumerate the unique source instruments
   ///      that need a rate.
   ///   2. Fetch one rate per instrument from `conversionService` in a single
-  ///      `TaskGroup` batch — the parent only suspends once for the whole
-  ///      batch, regardless of how many instruments are involved.
+  ///      `convertResultBatch` call — the parent only suspends once for the
+  ///      whole batch, regardless of how many instruments are involved.
   ///   3. Apply rates per leg synchronously. For all-target-instrument data
   ///      (the common scheduled / native-account case) phase 1 yields an
   ///      empty set, phase 2 is a no-op, and phase 3 has zero suspension
@@ -89,6 +91,8 @@ struct TransactionPage: Sendable, Equatable {
       prefetched: prefetched)
   }
 
+  // MARK: - Rate prefetch
+
   /// Outcome of a single per-instrument rate prefetch. Sendable so it can
   /// flow out of a `TaskGroup` child task.
   ///
@@ -119,66 +123,79 @@ struct TransactionPage: Sendable, Equatable {
     targetInstrument: Instrument,
     conversionService: InstrumentConversionService
   ) async -> PrefetchedRates {
-    var sources: Set<Instrument> = []
+    var sources: [Instrument] = []
+    var seen: Set<Instrument> = []
     for transaction in transactions {
-      for leg in transaction.legs where leg.instrument != targetInstrument {
-        sources.insert(leg.instrument)
+      for leg in transaction.legs
+      where leg.instrument != targetInstrument && seen.insert(leg.instrument).inserted {
+        sources.append(leg.instrument)
       }
     }
     if sources.isEmpty {
       return PrefetchedRates(rates: [:], knownZero: [], failures: [:])
     }
 
+    // One rate per UNIQUE source instrument: a 1-unit `convertResult`
+    // request per instrument, resolved in a single batched hop. `sources`
+    // preserves discovery order so each outcome maps back to its
+    // instrument by index. `convertResult` (not `convert`) so the
+    // `.knownZero` outcome (an `.unpriced` / `.spam` crypto token) stays an
+    // intentional zero rather than a real rate or a failure — issue #790: a
+    // spam ERC-20 with a copied ticker must contribute zero to the running
+    // balance, not poison it.
     let asOf = Date()
-    return await withTaskGroup(of: (Instrument, RatePrefetch).self) { group in
-      for instrument in sources {
-        group.addTask {
-          let outcome = await fetchOneRate(
-            for: instrument,
-            targetInstrument: targetInstrument,
-            asOf: asOf,
-            conversionService: conversionService)
-          return (instrument, outcome)
-        }
-      }
-      var rates: [Instrument: Decimal] = [:]
-      var knownZero: Set<Instrument> = []
-      var failures: [Instrument: String] = [:]
-      for await (instrument, outcome) in group {
-        switch outcome {
-        case .rate(let rate): rates[instrument] = rate
-        case .knownZero: knownZero.insert(instrument)
-        case .failure(let description): failures[instrument] = description
-        }
-      }
-      return PrefetchedRates(rates: rates, knownZero: knownZero, failures: failures)
+    let requests = sources.map { instrument in
+      BatchConversionRequest(
+        amount: InstrumentAmount(quantity: Decimal(1), instrument: instrument),
+        target: targetInstrument,
+        date: asOf)
     }
+    let outcomes: [BatchConversionOutcome]
+    do {
+      outcomes = try await conversionService.convertResultBatch(requests)
+    } catch {
+      // Cancellation is the only throw from `convertResultBatch`. The
+      // surrounding `withRunningBalances` is non-throwing and the running
+      // balance is best-effort, so degrade every source to a failure —
+      // each affected row blanks per Rule 11, same as if its rate fetch
+      // had failed.
+      var failures: [Instrument: String] = [:]
+      for instrument in sources { failures[instrument] = error.localizedDescription }
+      return PrefetchedRates(rates: [:], knownZero: [], failures: failures)
+    }
+
+    var rates: [Instrument: Decimal] = [:]
+    var knownZero: Set<Instrument> = []
+    var failures: [Instrument: String] = [:]
+    for (instrument, outcome) in zip(sources, outcomes) {
+      let prefetch = ratePrefetch(
+        from: outcome, instrument: instrument, targetInstrument: targetInstrument)
+      switch prefetch {
+      case .rate(let rate): rates[instrument] = rate
+      case .knownZero: knownZero.insert(instrument)
+      case .failure(let description): failures[instrument] = description
+      }
+    }
+    return PrefetchedRates(rates: rates, knownZero: knownZero, failures: failures)
   }
 
-  /// Fetch the conversion outcome for a single source instrument. Use
-  /// `convertResult` rather than `convert` so the `.knownZero` outcome
-  /// (an `.unpriced` / `.spam` crypto token) is preserved as an
-  /// intentional zero rather than being misapplied as a real rate or
-  /// thrown as a failure. Issue #790: a spam ERC-20 with a copied
-  /// ticker must contribute zero to the running balance, not poison it.
-  private static func fetchOneRate(
-    for instrument: Instrument,
-    targetInstrument: Instrument,
-    asOf: Date,
-    conversionService: InstrumentConversionService
-  ) async -> RatePrefetch {
-    do {
-      let result = try await conversionService.convertResult(
-        InstrumentAmount(quantity: Decimal(1), instrument: instrument),
-        to: targetInstrument,
-        on: asOf)
-      switch result {
-      case .value(let amount):
-        return .rate(amount.quantity)
-      case .knownZero:
-        return .knownZero
-      }
-    } catch {
+  /// Fold one batch outcome into a `RatePrefetch` for `instrument`. A
+  /// `.value` carries the 1-unit conversion (i.e. the rate); a `.knownZero`
+  /// is an intentional zero (issue #790); a `.failure` logs once — per
+  /// instrument, not per affected leg (Rule 11 of
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md`) — and blanks every row with a
+  /// leg in that instrument.
+  private static func ratePrefetch(
+    from outcome: BatchConversionOutcome,
+    instrument: Instrument,
+    targetInstrument: Instrument
+  ) -> RatePrefetch {
+    switch outcome {
+    case .value(let amount):
+      return .rate(amount.quantity)
+    case .knownZero:
+      return .knownZero
+    case .failure(let error):
       transactionLogger.warning(
         """
         Failed to fetch rate \(instrument.id, privacy: .public) → \
@@ -190,6 +207,8 @@ struct TransactionPage: Sendable, Equatable {
       return .failure(error.localizedDescription)
     }
   }
+
+  // MARK: - Running-balance accumulation
 
   private static func accumulateRunningBalances(
     transactions: [Transaction],
@@ -291,6 +310,8 @@ struct TransactionPage: Sendable, Equatable {
     }
     return .success(legs)
   }
+
+  // MARK: - Display-amount computation
 
   /// Picks the amount to display on a row: per-account sum when viewing an
   /// account, per-earmark sum when viewing an earmark, otherwise transfers

--- a/Features/Insights/InsightInputBuilder.swift
+++ b/Features/Insights/InsightInputBuilder.swift
@@ -86,6 +86,14 @@ struct InsightInputBuilder: Sendable {
   /// dropped, never guessed (`INSTRUMENT_CONVERSION_GUIDE.md` Rule 11); the
   /// original sign is preserved (a bill is a negative outflow — never
   /// `abs()`). Transactions with no income/expense leg are skipped.
+  ///
+  /// The conversions run in a single `convertResultBatch(...)` hop. Each
+  /// candidate's contributing leg becomes one request (index-aligned to
+  /// `candidates`); a `.failure`/`.knownZero` outcome drops the bill (Rule
+  /// 11) — an unpriced or spam token has no meaningful reporting-currency
+  /// value, so surfacing a "$0" future bill would mislead. Cancellation
+  /// surfaces as a throw from `convertResultBatch` and propagates to the
+  /// caller.
   private func scheduledBills(context: InsightContext) async throws -> [ScheduledBill] {
     let filter = TransactionFilter(scheduled: .scheduledOnly)
     let scheduled = try await backend.transactions.fetchAll(filter: filter)
@@ -93,29 +101,55 @@ struct InsightInputBuilder: Sendable {
     let now = context.now  // gate: is this bill in the future, relative to the injected now?
     let conversionDate = Date()  // convert a future obligation at the CURRENT wall-clock rate (Rule 6)
 
+    // Phase 1 — gather each future candidate's contributing leg and build one
+    // request per candidate, index-aligned so each outcome maps back.
+    let candidates =
+      scheduled
+      .filter { $0.date >= now }
+      .compactMap { transaction -> (transaction: Transaction, leg: TransactionLeg)? in
+        guard
+          let leg = transaction.legs.first(where: { $0.type == .income || $0.type == .expense })
+        else { return nil }
+        return (transaction, leg)
+      }
+    let requests = candidates.map { candidate in
+      BatchConversionRequest(
+        amount: candidate.leg.amount, target: reportingCurrency, date: conversionDate)
+    }
+
+    // Phase 2 — one batched conversion. Cancellation throws here.
+    let outcomes = try await backend.conversionService.convertResultBatch(requests)
+
+    // Phase 3 — build a bill per candidate from its outcome, dropping the
+    // ones whose conversion failed (Rule 11).
     var bills: [ScheduledBill] = []
-    for transaction in scheduled {
-      guard transaction.date >= now else { continue }
-      guard let leg = transaction.legs.first(where: { $0.type == .income || $0.type == .expense })
-      else { continue }
+    bills.reserveCapacity(candidates.count)
+    for (candidate, outcome) in zip(candidates, outcomes) {
       let amount: InstrumentAmount
-      do {
-        amount = try await backend.conversionService.convertAmount(
-          leg.amount, to: reportingCurrency, on: conversionDate)
-      } catch {
+      switch outcome {
+      case .value(let converted):
+        amount = converted
+      case .knownZero:
+        // Rule 11: an unpriced/spam token has no meaningful reporting-currency
+        // value — drop the bill rather than surface a misleading "$0".
+        logger.error(
+          "Dropping scheduled bill \(candidate.transaction.id, privacy: .public): conversion resolved to a known zero"
+        )
+        continue
+      case .failure(let error):
         // Rule 11: a leg whose conversion fails is dropped, never guessed.
         logger.error(
-          "Dropping scheduled bill \(transaction.id, privacy: .public): conversion failed: \(error)"
+          "Dropping scheduled bill \(candidate.transaction.id, privacy: .public): conversion failed: \(error)"
         )
         continue
       }
       bills.append(
         ScheduledBill(
-          id: transaction.id,
-          date: transaction.date,
-          payee: transaction.payee,
+          id: candidate.transaction.id,
+          date: candidate.transaction.date,
+          payee: candidate.transaction.payee,
           amount: amount,
-          accountId: leg.accountId))
+          accountId: candidate.leg.accountId))
     }
     return bills
   }


### PR DESCRIPTION
PR-C3 of the batch-conversion-API initiative (follow-on to #1163). Folds the two existing hand-rolled task-groups (forecast preConvertForecastInstances, TransactionPage.prefetchRates) and the serial insight-bill loop into convertResultBatch. Each site's behavior is preserved (forecast Date()+passthrough-on-error; identical prefetch rate map; drop-on-fail bills); dead code removed. code-review findings applied. 🤖 Generated with [Claude Code](https://claude.com/claude-code)