### PR TITLE
feat(scheduled): default new scheduled transactions to .once

### DIFF
--- a/Domain/Models/Transaction+Defaults.swift
+++ b/Domain/Models/Transaction+Defaults.swift
@@ -16,13 +16,15 @@ extension Transaction {
     )
   }
 
-  /// A blank monthly-recurring expense. Shows up in the Upcoming view
-  /// immediately; the user sets payee, amount, and recurrence in the inspector.
-  static func defaultMonthlyScheduled(accountId: UUID, instrument: Instrument) -> Transaction {
+  /// A blank scheduled expense that does not repeat (a single `.once`
+  /// occurrence). Shows up in the Upcoming view immediately; the user sets
+  /// payee, amount, and — if they want it to recur — the recurrence in the
+  /// inspector.
+  static func defaultScheduled(accountId: UUID, instrument: Instrument) -> Transaction {
     Transaction(
       date: Date(),
       payee: "",
-      recurPeriod: .month,
+      recurPeriod: .once,
       recurEvery: 1,
       legs: [
         TransactionLeg(accountId: accountId, instrument: instrument, quantity: 0, type: .expense)

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -149,7 +149,7 @@ struct AnalysisView: View {
       Transaction(
         date: Date(),
         payee: "",
-        recurPeriod: .month,
+        recurPeriod: .once,
         recurEvery: 1,
         legs: [TransactionLeg(accountId: id, instrument: instrument, quantity: 0, type: .expense)]
       )

--- a/Features/Transactions/TransactionStore+Mutations.swift
+++ b/Features/Transactions/TransactionStore+Mutations.swift
@@ -31,15 +31,15 @@ extension TransactionStore {
     return await create(.defaultExpense(accountId: acctId, instrument: instrument))
   }
 
-  /// Creates a blank monthly-recurring expense. See
-  /// `Transaction.defaultMonthlyScheduled(...)`.
+  /// Creates a blank scheduled expense that does not repeat. See
+  /// `Transaction.defaultScheduled(...)`.
   func createDefaultScheduled(
     accountId: UUID?,
     fallbackAccountId: UUID?,
     instrument: Instrument
   ) async -> Transaction? {
     guard let acctId = accountId ?? fallbackAccountId else { return nil }
-    return await create(.defaultMonthlyScheduled(accountId: acctId, instrument: instrument))
+    return await create(.defaultScheduled(accountId: acctId, instrument: instrument))
   }
 
   /// Creates a blank earmark-only income transaction. See

--- a/Features/Transactions/Views/TransactionListView+Create.swift
+++ b/Features/Transactions/Views/TransactionListView+Create.swift
@@ -54,11 +54,12 @@ extension TransactionListView {
     }
   }
 
-  /// Creates a new scheduled (recurring) transaction placeholder.
-  /// Mirrors `createNewTransaction()` but seeds the placeholder with a
-  /// monthly recurrence so the inspector opens in the recurring-transaction
-  /// editing mode. Used by the `.scheduledStatus` grouping's Add toolbar
-  /// button and `\.newTransactionAction` focused-scene-value.
+  /// Creates a new scheduled transaction placeholder. Mirrors
+  /// `createNewTransaction()` but seeds the placeholder with a single
+  /// (`.once`) scheduled occurrence so the inspector opens in scheduled
+  /// editing mode with Repeat off; the user turns Repeat on if they want it
+  /// to recur. Used by the `.scheduledStatus` grouping's Add toolbar button
+  /// and `\.newTransactionAction` focused-scene-value.
   func createNewScheduledTransaction() {
     let instrument = accounts.ordered.first?.instrument ?? .AUD
     let fallbackAccountId = accounts.ordered.first?.id
@@ -67,7 +68,7 @@ extension TransactionListView {
       Transaction(
         date: Date(),
         payee: "",
-        recurPeriod: .month,
+        recurPeriod: .once,
         recurEvery: 1,
         legs: [TransactionLeg(accountId: id, instrument: instrument, quantity: 0, type: .expense)]
       )

--- a/MoolahTests/Features/TransactionStoreCreateDefaultsTests.swift
+++ b/MoolahTests/Features/TransactionStoreCreateDefaultsTests.swift
@@ -101,7 +101,7 @@ struct TransactionStoreCreateDefaultsTests {
   // MARK: - createDefaultScheduled
 
   @Test
-  func testCreateDefaultScheduledSetsMonthlyRecurrence() async throws {
+  func testCreateDefaultScheduledDefaultsToNonRepeating() async throws {
     let (backend, _) = try TestBackend.create()
     let store = TransactionStore(
       repository: backend.transactions,
@@ -119,8 +119,8 @@ struct TransactionStoreCreateDefaultsTests {
 
     #expect(created != nil)
     #expect(created?.isScheduled == true)
-    #expect(created?.recurPeriod == .month)
-    #expect(created?.recurEvery == 1)
+    #expect(created?.isRecurring == false)
+    #expect(created?.recurPeriod == .once)
     #expect(created?.legs.first?.type == .expense)
     #expect(created?.legs.first?.quantity == 0)
     #expect(created?.accountIds.contains(accountId) == true)

--- a/MoolahTests/Features/TransactionStoreScheduledOneOffTests.swift
+++ b/MoolahTests/Features/TransactionStoreScheduledOneOffTests.swift
@@ -30,18 +30,22 @@ struct TransactionStoreScheduledOneOffTests {
     )
 
     // Simulates the user tapping "+" in the Upcoming view: a placeholder
-    // scheduled transaction is created with a default monthly period.
+    // scheduled transaction is created. The default does not repeat — it's a
+    // single scheduled occurrence (`.once`).
     let created = try #require(
       await store.createDefaultScheduled(
         accountId: accountId,
         fallbackAccountId: nil,
         instrument: Instrument.defaultTestInstrument))
     #expect(created.isScheduled == true)
-    #expect(created.isRecurring == true)
+    #expect(created.isRecurring == false)
 
-    // Simulates the user opening the inspector (draft from the saved record),
-    // flipping off "Repeat", and saving the update.
+    // Simulates the user opening the inspector, turning Repeat on (so the
+    // transaction becomes recurring) and then off again, saving the update.
+    // The round-trip must leave the transaction scheduled and one-off.
     var draft = TransactionDraft(from: created)
+    draft.isRepeating = true
+    #expect(draft.recurPeriod == .month)
     draft.isRepeating = false
     let updated = try #require(
       draft.toTransaction(id: created.id))


### PR DESCRIPTION
## What

New scheduled transactions now default to a single (`.once`) occurrence with **Repeat off**, instead of defaulting to monthly recurrence. The user enables Repeat in the inspector if they want it to recur.

## Why

A scheduled transaction is most often a one-off future payment; monthly was the wrong default and forced users to switch it off.

## Changes

- `Transaction.defaultScheduled` (renamed from `defaultMonthlyScheduled`) seeds `recurPeriod: .once`.
- Both "+" creation flows seed `.once`: `TransactionListView+Create.createNewScheduledTransaction()` and `AnalysisView.createNewScheduledTransaction()`.
- A `.once` transaction still has `isScheduled == true`, so it appears in the Upcoming view with the Repeat toggle off.

## Out of scope (intentionally unchanged)

The **Repeat** toggle (`TransactionDraft.isRepeating`) still selects `.month` when turned *on* — `.once` means "not repeating", so it can't be the toggled-on period.

## Tests

- `TransactionStoreCreateDefaultsTests` now asserts the default is non-repeating (`.once`).
- `TransactionStoreScheduledOneOffTests` updated to enable Repeat then disable it, preserving end-to-end "stays scheduled, doesn't leak to regular list" coverage.
- Affected suites pass; `just build-mac` and `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)