### PR TITLE
fix(pricing): UTC-seam + concurrency hygiene (ContiguousFetchPlanner, PriceCacheCap)

### DIFF
--- a/Shared/ContiguousFetchPlanner.swift
+++ b/Shared/ContiguousFetchPlanner.swift
@@ -21,19 +21,6 @@ enum ContiguousFetchPlanner {
     let forwardBuffer: Int
   }
 
-  /// Shared formatter for `addingDays` — `[.withFullDate]`, UTC. Hoisted to a
-  /// static so the hot per-window loop does not allocate an
-  /// `ISO8601DateFormatter` on every call. `ISO8601DateFormatter`'s
-  /// `date(from:)` / `string(from:)` are documented thread-safe and the
-  /// formatter is configured once and never mutated, so `nonisolated(unsafe)`
-  /// is sound here.
-  nonisolated(unsafe) private static let dateFormatter: ISO8601DateFormatter = {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    formatter.timeZone = TimeZone.utc
-    return formatter
-  }()
-
   /// Returns the next fetch window to issue, or `nil` when the requested date
   /// is already inside `[earliest, latest]` (read via prior-trading-day
   /// fallback, no fetch needed).
@@ -77,11 +64,14 @@ enum ContiguousFetchPlanner {
   /// month and year boundaries correctly. Never use raw `Int32 ± n` on a
   /// `DateKey` — the encoding is not contiguous across month ends.
   static func addingDays(_ days: Int, to key: Int32) -> Int32 {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    formatter.timeZone = TimeZone.utc
     let iso = DateKey.isoString(key)
     guard
-      let date = dateFormatter.date(from: iso),
+      let date = formatter.date(from: iso),
       let shifted = Calendar.utc.date(byAdding: .day, value: days, to: date),
-      let result = DateKey.from(isoString: dateFormatter.string(from: shifted))
+      let result = DateKey.from(isoString: formatter.string(from: shifted))
     else { return key }
     return result
   }

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -54,6 +54,14 @@ extension CryptoPriceService {
   /// for sharing, and awaits the result with cooperative-cancellation
   /// forwarding. The coalescing key is the token id — callers must ensure
   /// they only issue one window fetch at a time per token.
+  ///
+  /// **Cancellation asymmetry (intentional):** a coalesced *subscriber*
+  /// (second+ caller that awaits `inFlight.task.value`) can be cancelled by
+  /// its own task tree — that cancellation stops its wait and re-throws
+  /// `CancellationError` to the subscriber only. It does **not** propagate to
+  /// the owner task, which continues running so that other subscribers sharing
+  /// the same fetch are unaffected. Only the owner's own
+  /// `withTaskCancellationHandler` can cancel the underlying network request.
   func fetchWindowCoalesced(
     instrument: Instrument,
     mapping: CryptoProviderMapping,
@@ -62,6 +70,10 @@ extension CryptoPriceService {
     let tokenId = instrument.id
     if let inFlight = extensionTasks[tokenId] {
       do {
+        // Cancellation asymmetry: if *this* subscriber's task is cancelled,
+        // Swift surfaces CancellationError here and we re-throw it below,
+        // stopping only this subscriber's wait. The owner task keeps running
+        // so other coalesced callers are not affected — see function doc.
         try await inFlight.task.value
       } catch is CancellationError {
         throw CancellationError()

--- a/Shared/PriceCacheCap.swift
+++ b/Shared/PriceCacheCap.swift
@@ -50,13 +50,11 @@ func cappedToYesterday(
     return date
   }
   let components = local.dateComponents([.year, .month, .day], from: yesterdayLocal)
-  var utc = Calendar(identifier: .gregorian)
-  utc.timeZone = TimeZone(identifier: "UTC") ?? .current
   var noonComponents = components
   noonComponents.hour = 12
   noonComponents.minute = 0
   noonComponents.second = 0
-  guard let yesterdayLabelAtUTCNoon = utc.date(from: noonComponents) else {
+  guard let yesterdayLabelAtUTCNoon = Calendar.utc.date(from: noonComponents) else {
     return min(date, yesterdayLocal)
   }
   return min(date, yesterdayLabelAtUTCNoon)


### PR DESCRIPTION
## Why

Three pre-existing hygiene findings surfaced by the multi-agent review of #1174 (shared price-series engine), in files that PR didn't change — split out per the "fix all findings, separate PR if out of scope" convention. **Stacked on #1174** (the coalescing-doc fix lives in a file #1174 modifies).

## What

- **`PriceCacheCap.swift`** — route the UTC re-anchoring through the canonical `Calendar.utc` seam instead of an ad-hoc `Calendar(identifier: .gregorian)` with a wrong `?? .current` fallback (`guides/DATE_TIME_GUIDE.md` §5). UTC semantics unchanged.
- **`ContiguousFetchPlanner.swift`** — drop `nonisolated(unsafe)` on the shared static `ISO8601DateFormatter` (outside the `CONCURRENCY_GUIDE.md` §2 carve-outs; `ISO8601DateFormatter` isn't documented thread-safe). The formatter is allocated inline in its one call site (`addingDays`, off the hot path) — output byte-identical.
- **`CryptoPriceService+FetchRange.swift`** — document the intentional coalescing subscriber-cancellation asymmetry in `fetchWindowCoalesced` (a coalesced subscriber's cancellation stops its own wait but does not cancel the shared owner task). Comment only.

Behaviour-neutral. Suite green (planner, cap, coalescing, stock/crypto price suites). Reviewed (datetime + concurrency + focused re-review) — byte-identical formatter output confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
