### PR TITLE
fix(analysis): match legend colours to chart marks on category charts

### DIFF
--- a/Features/Analysis/Views/CategoriesOverTimeCard.swift
+++ b/Features/Analysis/Views/CategoriesOverTimeCard.swift
@@ -11,7 +11,11 @@ struct CategoriesOverTimeCard: View {
   @State private var selectedDate: Date?
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    // Derive the colour assignment once per render so the chart's colour
+    // scale and the legend swatches resolve identical colours from a single
+    // source.
+    let colors = CategoryColorAssignment(orderedCategoryIds: entries.map(\.categoryId))
+    return VStack(alignment: .leading, spacing: 12) {
       VStack(alignment: .leading, spacing: 8) {
         VStack(alignment: .leading, spacing: 4) {
           Text("Expenses by Category Over Time")
@@ -40,9 +44,9 @@ struct CategoriesOverTimeCard: View {
         emptyState
       } else {
         ExpandableChart(title: "Expenses Over Time") {
-          chart
+          chart(colors: colors)
         }
-        legend
+        legend(colors: colors)
       }
     }
     .padding()
@@ -64,23 +68,9 @@ struct CategoriesOverTimeCard: View {
       .frame(height: 300)
   }
 
-  private var chart: some View {
+  private func chart(colors: CategoryColorAssignment) -> some View {
     Chart {
-      ForEach(entries) { entry in
-        let name = categoryLabel(for: entry.categoryId)
-        ForEach(entry.points) { point in
-          AreaMark(
-            x: .value("Month", point.monthDate),
-            y: .value(
-              "Amount",
-              showActualValues
-                ? Double(truncating: point.actualAmount as NSDecimalNumber) : point.percentage),
-            stacking: .standard
-          )
-          .foregroundStyle(by: .value("Category", name))
-        }
-      }
-
+      areaMarks
       if let selectedDate {
         RuleMark(x: .value("Selected", selectedDate))
           .foregroundStyle(.gray.opacity(0.5))
@@ -89,7 +79,7 @@ struct CategoriesOverTimeCard: View {
     }
     .chartForegroundStyleScale(
       domain: entries.map { categoryLabel(for: $0.categoryId) },
-      range: entries.map { categoryColor(for: $0.categoryId) }
+      range: entries.map { colors.color(for: $0.categoryId) }
     )
     .chartXAxis {
       AxisMarks(values: .automatic(desiredCount: 8)) { _ in
@@ -124,6 +114,23 @@ struct CategoriesOverTimeCard: View {
     .accessibilityLabel(chartAccessibilityLabel)
   }
 
+  @ChartContentBuilder private var areaMarks: some ChartContent {
+    ForEach(entries) { entry in
+      let name = categoryLabel(for: entry.categoryId)
+      ForEach(entry.points) { point in
+        AreaMark(
+          x: .value("Month", point.monthDate),
+          y: .value(
+            "Amount",
+            showActualValues
+              ? Double(truncating: point.actualAmount as NSDecimalNumber) : point.percentage),
+          stacking: .standard
+        )
+        .foregroundStyle(by: .value("Category", name))
+      }
+    }
+  }
+
   private var chartAccessibilityLabel: String {
     let base =
       "Stacked area chart showing expense categories over time in \(showActualValues ? "actual amounts" : "percentages")"
@@ -131,12 +138,12 @@ struct CategoriesOverTimeCard: View {
     return base + ". Some months may be incomplete; prices still loading."
   }
 
-  private var legend: some View {
+  private func legend(colors: CategoryColorAssignment) -> some View {
     LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))], spacing: 8) {
       ForEach(entries) { entry in
         HStack(spacing: 4) {
           Circle()
-            .fill(categoryColor(for: entry.categoryId))
+            .fill(colors.color(for: entry.categoryId))
             .frame(width: 10, height: 10)
           Text(categoryLabel(for: entry.categoryId))
             .font(.caption)
@@ -158,17 +165,6 @@ struct CategoriesOverTimeCard: View {
   private func categoryLabel(for id: UUID?) -> String {
     guard let id, let category = categories.by(id: id) else { return "Uncategorized" }
     return categories.path(for: category)
-  }
-
-  private static let chartPalette: [Color] = [
-    .chartBlue, .chartGreen, .chartOrange, .chartPurple, .chartRed, .chartTeal,
-    .chartIndigo, .chartPink, .chartMint, .chartCyan, .chartBrown, .chartYellow,
-  ]
-
-  private func categoryColor(for id: UUID?) -> Color {
-    guard let id else { return .gray }
-    let index = abs(id.hashValue) % Self.chartPalette.count
-    return Self.chartPalette[index]
   }
 }
 

--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -9,7 +9,12 @@ struct ExpenseBreakdownCard: View {
   @State private var selectedCategoryId: UUID?
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    // Derive the breakdown and its colour assignment once per render so the
+    // pie chart's colour scale and the legend swatches resolve identical
+    // colours from a single source, and `buildExpenseBreakdown` runs once.
+    let breakdown = filteredBreakdown
+    let colors = CategoryColorAssignment(orderedCategoryIds: breakdown.map(\.categoryId))
+    return VStack(alignment: .leading, spacing: 12) {
       VStack(alignment: .leading, spacing: 4) {
         Text("Expenses by Category")
           .font(.title2)
@@ -20,13 +25,13 @@ struct ExpenseBreakdownCard: View {
         }
       }
 
-      if filteredBreakdown.isEmpty {
+      if breakdown.isEmpty {
         emptyState
       } else {
         ExpandableChart(title: "Expenses by Category") {
-          pieChart
+          pieChart(breakdown, colors: colors)
         }
-        legendGrid
+        legendGrid(breakdown, colors: colors)
         breadcrumbs
       }
     }
@@ -49,8 +54,10 @@ struct ExpenseBreakdownCard: View {
       .padding(.vertical, 40)
   }
 
-  private var pieChart: some View {
-    Chart(filteredBreakdown, id: \.categoryId) { item in
+  private func pieChart(
+    _ breakdown: [ExpenseBreakdownWithPercentage], colors: CategoryColorAssignment
+  ) -> some View {
+    Chart(breakdown, id: \.categoryId) { item in
       SectorMark(
         angle: .value("Amount", Double(truncating: item.totalExpenses.quantity as NSDecimalNumber)),
         innerRadius: .ratio(0.5),
@@ -58,7 +65,7 @@ struct ExpenseBreakdownCard: View {
       )
       .foregroundStyle(by: .value("Category", categoryLabel(for: item.categoryId)))
       .annotation(position: .overlay) {
-        if item.percentage > 5 {  // Only show label if >5%
+        if item.percentage > 5 {
           Text("\(Int(item.percentage))%")
             .font(.caption)
             .fontWeight(.semibold)
@@ -71,6 +78,13 @@ struct ExpenseBreakdownCard: View {
         }
       }
     }
+    // Bind the sector colours to the same assignment legendGrid uses so the
+    // two always agree; without an explicit scale Swift Charts paints sectors
+    // from its own default palette by data order, which the legend can't match.
+    .chartForegroundStyleScale(
+      domain: breakdown.map { categoryLabel(for: $0.categoryId) },
+      range: breakdown.map { colors.color(for: $0.categoryId) }
+    )
     // The legendGrid below already lists each category with its colour
     // swatch and total, so the chart's built-in legend is redundant.
     .chartLegend(.hidden)
@@ -78,15 +92,17 @@ struct ExpenseBreakdownCard: View {
     .accessibilityLabel("Expense breakdown pie chart")
   }
 
-  private var legendGrid: some View {
+  private func legendGrid(
+    _ breakdown: [ExpenseBreakdownWithPercentage], colors: CategoryColorAssignment
+  ) -> some View {
     LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))], spacing: 8) {
-      ForEach(filteredBreakdown, id: \.categoryId) { item in
+      ForEach(breakdown, id: \.categoryId) { item in
         Button {
           handleCategoryTap(item.categoryId)
         } label: {
           HStack {
             Circle()
-              .fill(categoryColor(for: item.categoryId))
+              .fill(colors.color(for: item.categoryId))
               .frame(width: 12, height: 12)
             Text(categoryLabel(for: item.categoryId))
               .font(.caption)
@@ -127,23 +143,12 @@ struct ExpenseBreakdownCard: View {
   }
 
   private func categoryLabel(for id: UUID?) -> String {
-    guard let id = id, let category = categories.by(id: id) else { return "Uncategorized" }
+    guard let id, let category = categories.by(id: id) else { return "Uncategorized" }
     return categories.path(for: category)
   }
 
-  /// Fixed palette of system-compatible colors for chart segments.
-  private static let chartPalette: [Color] = [
-    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink, .mint, .cyan, .brown, .yellow,
-  ]
-
-  private func categoryColor(for id: UUID?) -> Color {
-    guard let id = id else { return .gray }
-    let index = abs(id.hashValue) % Self.chartPalette.count
-    return Self.chartPalette[index]
-  }
-
   private func hasChildren(_ categoryId: UUID?) -> Bool {
-    guard let categoryId = categoryId else { return false }
+    guard let categoryId else { return false }
     return !categories.children(of: categoryId).isEmpty
   }
 

--- a/MoolahTests/Shared/CategoryColorAssignmentTests.swift
+++ b/MoolahTests/Shared/CategoryColorAssignmentTests.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import Testing
+
+@testable import Moolah
+
+@Suite("CategoryColorAssignment")
+struct CategoryColorAssignmentTests {
+  @Test("Uncategorized (nil id) is always gray")
+  func nilIsGray() {
+    let assignment = CategoryColorAssignment(orderedCategoryIds: [nil, UUID()])
+    #expect(assignment.color(for: nil) == .gray)
+  }
+
+  @Test("An id not present in the breakdown is gray")
+  func unknownIdIsGray() {
+    let assignment = CategoryColorAssignment(orderedCategoryIds: [UUID()])
+    #expect(assignment.color(for: UUID()) == .gray)
+  }
+
+  @Test("Distinct categories take the palette colors in encounter order")
+  func distinctCategoriesGetPaletteInOrder() {
+    let ids = (0..<CategoryColorAssignment.palette.count).map { _ in UUID() }
+    let assignment = CategoryColorAssignment(orderedCategoryIds: ids)
+    for (index, id) in ids.enumerated() {
+      #expect(assignment.color(for: id) == CategoryColorAssignment.palette[index])
+    }
+  }
+
+  @Test("A nil slot does not consume a palette color")
+  func uncategorizedDoesNotConsumePaletteSlot() {
+    let first = UUID()
+    let second = UUID()
+    let assignment = CategoryColorAssignment(orderedCategoryIds: [first, nil, second])
+    #expect(assignment.color(for: first) == CategoryColorAssignment.palette[0])
+    #expect(assignment.color(for: second) == CategoryColorAssignment.palette[1])
+  }
+
+  @Test("The palette wraps once it is exhausted")
+  func paletteWraps() {
+    let count = CategoryColorAssignment.palette.count
+    let ids = (0...count).map { _ in UUID() }  // count + 1 distinct ids
+    let assignment = CategoryColorAssignment(orderedCategoryIds: ids)
+    #expect(assignment.color(for: ids[count]) == CategoryColorAssignment.palette[0])
+  }
+
+  @Test("A category keeps the same color however often it appears")
+  func repeatedIdsAreStable() {
+    let first = UUID()
+    let second = UUID()
+    let assignment = CategoryColorAssignment(orderedCategoryIds: [first, second, first, second])
+    #expect(assignment.color(for: first) == CategoryColorAssignment.palette[0])
+    #expect(assignment.color(for: second) == CategoryColorAssignment.palette[1])
+  }
+}

--- a/Shared/CategoryColorAssignment.swift
+++ b/Shared/CategoryColorAssignment.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Assigns a chart-series colour to each category in a breakdown so that a
+/// chart's `chartForegroundStyleScale` and its accompanying legend resolve
+/// **identical** colours for every category.
+///
+/// Colours are handed out by the category's position in the ordered
+/// breakdown rather than by hashing its id. Position-based assignment gives
+/// two guarantees the previous `abs(id.hashValue) % palette.count` approach
+/// could not:
+///
+/// 1. **Stability** — a given breakdown always maps to the same colours, so
+///    the result no longer changes between launches (Swift seeds `hashValue`
+///    randomly per process).
+/// 2. **Separability** — distinct categories take distinct palette entries
+///    until the palette is exhausted, so neighbouring pie sectors / stacked
+///    bands don't collide on the same colour the way independent hashes do.
+///
+/// Build one instance from the ordered breakdown and use it for *both* the
+/// chart's colour scale and the legend swatches; that single source of truth
+/// is what keeps the two in agreement.
+struct CategoryColorAssignment {
+  /// Ordered chart-series palette. Resolves through `Color+ChartPalette` so a
+  /// future tuning pass stays in one file (see `UI_GUIDE` §5 exception).
+  static let palette: [Color] = [
+    .chartBlue, .chartGreen, .chartOrange, .chartPurple, .chartRed, .chartTeal,
+    .chartIndigo, .chartPink, .chartMint, .chartCyan, .chartBrown, .chartYellow,
+  ]
+
+  private let colorsById: [UUID: Color]
+
+  /// - Parameter orderedCategoryIds: the category ids in the order they appear
+  ///   in the breakdown. A `nil` entry represents the uncategorized bucket and
+  ///   is rendered grey without consuming a palette slot.
+  init(orderedCategoryIds: [UUID?]) {
+    var colors: [UUID: Color] = [:]
+    var nextIndex = 0
+    for case let id? in orderedCategoryIds where colors[id] == nil {
+      colors[id] = Self.palette[nextIndex % Self.palette.count]
+      nextIndex += 1
+    }
+    self.colorsById = colors
+  }
+
+  /// The colour for `id`. Uncategorized (`nil`) and any id outside the
+  /// breakdown resolve to `.gray`.
+  func color(for id: UUID?) -> Color {
+    guard let id, let color = colorsById[id] else { return .gray }
+    return color
+  }
+}


### PR DESCRIPTION
## Problem

On the Analysis page, the colours in the table of values (legend) did not match the colours used in the graphs — for **both** the *Expenses by Category* pie chart and the *Expenses by Category Over Time* stacked-area chart.

Root cause differed per chart but shared a fragile core (colour hashed into a small palette):

- **Pie chart** — the `Chart` had **no** `.chartForegroundStyleScale`, so Swift Charts painted sectors from its own *default* palette by data order, while the legend painted swatches from a separate hand-rolled `[.blue, .green, …]` palette keyed by `abs(id.hashValue) % count`. The two assignments were unrelated → hard mismatch. (It also used raw system colours, not the `.chart*` palette, unlike the over-time card.)
- **Over-time chart** — it *did* bind a scale, but both the scale and the legend keyed a 12-colour palette by the same hash. With more than a handful of categories, hash **collisions** are near-certain (birthday problem in 12 buckets), so distinct categories landed on the same colour and legend↔band correspondence became ambiguous. `hashValue` is also reseeded each process, so colours drifted between launches.

## Fix

New `CategoryColorAssignment` — a small, testable value type that assigns colours by a category's **position** in the ordered breakdown over the shared `.chart*` palette (the documented `UI_GUIDE` §5 chart-colour exception). Both cards build **one** assignment per render and feed it to the chart's colour scale **and** the legend swatches, so the two provably resolve identical colours. Position-based assignment also makes colours stable across launches and keeps distinct categories on distinct colours until the palette wraps (12 colours).

Also in this PR (tied to the change):
- Each card derives its breakdown + assignment once per render instead of rebuilding at every call site (the pie was running `buildExpenseBreakdown` 3× per render).
- Removed the now-redundant per-view palettes; extracted the over-time chart's marks into a `@ChartContentBuilder` helper; tidied two verbose `guard let x = x` forms in the touched file.

## Tests

- New `CategoryColorAssignmentTests` (6 cases): nil/unknown → gray, positional order, nil-slot does not consume a palette colour, wrap-at-12, per-id stability.
- `just build-mac`, `just test-mac CategoryColorAssignmentTests`, and `just format-check` all pass.

## Follow-ups (pre-existing, out of scope — flagged from review, not addressed here)

- `.chartTeal` / `.chartCyan` are near-identical (especially in dark mode); they sit at palette indices 5 and 9, so 6+ categories show two look-alike colours. This lives in the shared `Color+ChartPalette.swift` and affects every chart in the app.
- >12 categories wrap to a repeated colour (could aggregate the tail as "Other").
- Accessibility debt in `ExpenseBreakdownCard`'s legend (leaf-category rows are non-interactive `Button`s, "Double tap" verb is iOS-only, generic pie `accessibilityLabel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)