### PR TITLE
feat(analysis): curate category palette + grey the small-value tail; fix pie legend a11y

### DIFF
--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -89,7 +89,7 @@ struct ExpenseBreakdownCard: View {
     // swatch and total, so the chart's built-in legend is redundant.
     .chartLegend(.hidden)
     .frame(height: 250)
-    .accessibilityLabel("Expense breakdown pie chart")
+    .accessibilityLabel(pieChartAccessibilityLabel(breakdown))
   }
 
   private func legendGrid(
@@ -97,29 +97,51 @@ struct ExpenseBreakdownCard: View {
   ) -> some View {
     LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))], spacing: 8) {
       ForEach(breakdown, id: \.categoryId) { item in
-        Button {
-          handleCategoryTap(item.categoryId)
-        } label: {
-          HStack {
-            Circle()
-              .fill(colors.color(for: item.categoryId))
-              .frame(width: 12, height: 12)
-            Text(categoryLabel(for: item.categoryId))
-              .font(.caption)
-              .foregroundStyle(.primary)
-            Spacer()
-            Text(item.totalExpenses.formatted)
-              .font(.caption)
-              .monospacedDigit()
-              .foregroundStyle(.secondary)
-          }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(
-          "\(categoryLabel(for: item.categoryId)): \(item.totalExpenses.formatted)"
-        )
-        .accessibilityHint(hasChildren(item.categoryId) ? "Double tap to drill down" : "")
+        legendRow(item, colors: colors)
       }
+    }
+  }
+
+  /// A legend row is only interactive when the category has children to drill
+  /// into; leaf categories render as plain content so VoiceOver doesn't
+  /// announce a button that does nothing.
+  @ViewBuilder
+  private func legendRow(
+    _ item: ExpenseBreakdownWithPercentage, colors: CategoryColorAssignment
+  ) -> some View {
+    let label = categoryLabel(for: item.categoryId)
+    let accessibilityLabel = "\(label): \(item.totalExpenses.formatted)"
+    if hasChildren(item.categoryId) {
+      Button {
+        handleCategoryTap(item.categoryId)
+      } label: {
+        legendRowContent(item, label: label, colors: colors)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(accessibilityLabel)
+      .accessibilityHint("Shows subcategories")
+    } else {
+      legendRowContent(item, label: label, colors: colors)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+  }
+
+  private func legendRowContent(
+    _ item: ExpenseBreakdownWithPercentage, label: String, colors: CategoryColorAssignment
+  ) -> some View {
+    HStack {
+      Circle()
+        .fill(colors.color(for: item.categoryId))
+        .frame(width: 12, height: 12)
+      Text(label)
+        .font(.caption)
+        .foregroundStyle(.primary)
+      Spacer()
+      Text(item.totalExpenses.formatted)
+        .font(.caption)
+        .monospacedDigit()
+        .foregroundStyle(.secondary)
     }
   }
 
@@ -140,6 +162,15 @@ struct ExpenseBreakdownCard: View {
   private var filteredBreakdown: [ExpenseBreakdownWithPercentage] {
     AnalysisStore.buildExpenseBreakdown(
       from: breakdown, categories: categories, selectedCategoryId: selectedCategoryId)
+  }
+
+  private func pieChartAccessibilityLabel(_ breakdown: [ExpenseBreakdownWithPercentage]) -> String {
+    let base =
+      breakdown.count == 1
+      ? "Expense breakdown pie chart with 1 category"
+      : "Expense breakdown pie chart with \(breakdown.count) categories"
+    guard hasUnavailableData else { return base }
+    return base + ". Some totals may be incomplete; prices still loading."
   }
 
   private func categoryLabel(for id: UUID?) -> String {
@@ -225,4 +256,26 @@ struct ExpenseBreakdownWithPercentage: Identifiable {
   )
   .frame(width: 400)
   .padding()
+}
+
+#Preview("Many categories (palette + grey tail)") {
+  let names = [
+    "Housing", "Groceries", "Transport", "Dining", "Utilities", "Health",
+    "Shopping", "Entertainment", "Insurance", "Subscriptions", "Travel",
+    "Education", "Gifts", "Pets",
+  ]
+  let categories = names.map { Category(id: UUID(), name: $0) }
+  let breakdown = categories.enumerated().map { index, category in
+    ExpenseBreakdown(
+      categoryId: category.id,
+      month: "202604",
+      totalExpenses: InstrumentAmount(quantity: Decimal(1500 - index * 100), instrument: .AUD)
+    )
+  }
+
+  ScrollView {
+    ExpenseBreakdownCard(breakdown: breakdown, categories: Categories(from: categories))
+      .frame(width: 400)
+      .padding()
+  }
 }

--- a/MoolahTests/Shared/CategoryColorAssignmentTests.swift
+++ b/MoolahTests/Shared/CategoryColorAssignmentTests.swift
@@ -35,12 +35,15 @@ struct CategoryColorAssignmentTests {
     #expect(assignment.color(for: second) == CategoryColorAssignment.palette[1])
   }
 
-  @Test("The palette wraps once it is exhausted")
-  func paletteWraps() {
+  @Test("Categories beyond the palette fall back to gray")
+  func overflowCategoriesAreGray() {
     let count = CategoryColorAssignment.palette.count
-    let ids = (0...count).map { _ in UUID() }  // count + 1 distinct ids
+    let ids = (0..<(count + 3)).map { _ in UUID() }  // three past the palette
     let assignment = CategoryColorAssignment(orderedCategoryIds: ids)
-    #expect(assignment.color(for: ids[count]) == CategoryColorAssignment.palette[0])
+    #expect(assignment.color(for: ids[count - 1]) == CategoryColorAssignment.palette[count - 1])
+    for overflowIndex in count..<ids.count {
+      #expect(assignment.color(for: ids[overflowIndex]) == .gray)
+    }
   }
 
   @Test("A category keeps the same color however often it appears")

--- a/Shared/CategoryColorAssignment.swift
+++ b/Shared/CategoryColorAssignment.swift
@@ -5,45 +5,55 @@ import SwiftUI
 /// **identical** colours for every category.
 ///
 /// Colours are handed out by the category's position in the ordered
-/// breakdown rather than by hashing its id. Position-based assignment gives
-/// two guarantees the previous `abs(id.hashValue) % palette.count` approach
-/// could not:
+/// breakdown — which both charts sort largest-first — rather than by hashing
+/// its id. This gives three properties the previous
+/// `abs(id.hashValue) % palette.count` approach could not:
 ///
 /// 1. **Stability** — a given breakdown always maps to the same colours, so
 ///    the result no longer changes between launches (Swift seeds `hashValue`
 ///    randomly per process).
-/// 2. **Separability** — distinct categories take distinct palette entries
-///    until the palette is exhausted, so neighbouring pie sectors / stacked
-///    bands don't collide on the same colour the way independent hashes do.
+/// 2. **Separability** — distinct categories take distinct palette entries, so
+///    neighbouring pie sectors / stacked bands don't collide on the same
+///    colour the way independent hashes did.
+/// 3. **Honest overflow** — the palette holds as many genuinely distinct,
+///    dark-mode-tuned hues as remain reliably distinguishable (≈11; see
+///    ColorBrewer / D3 categorical scales). Categories past it — always the
+///    smallest, barely-visible slices because the breakdown is sorted
+///    descending — resolve to `.gray` rather than to a muddy generated colour
+///    or a wrapped duplicate. They still appear individually in the legend.
 ///
 /// Build one instance from the ordered breakdown and use it for *both* the
 /// chart's colour scale and the legend swatches; that single source of truth
 /// is what keeps the two in agreement.
 struct CategoryColorAssignment {
-  /// Ordered chart-series palette. Resolves through `Color+ChartPalette` so a
-  /// future tuning pass stays in one file (see `UI_GUIDE` §5 exception).
+  /// Curated chart-series palette, ordered so the largest categories (assigned
+  /// first) stay maximally separated in hue. Resolves through
+  /// `Color+ChartPalette` so a future tuning pass stays in one file (see
+  /// `UI_GUIDE` §5 exception). Deliberately omits `.chartCyan`, which is
+  /// near-indistinguishable from `.chartTeal`.
   static let palette: [Color] = [
-    .chartBlue, .chartGreen, .chartOrange, .chartPurple, .chartRed, .chartTeal,
-    .chartIndigo, .chartPink, .chartMint, .chartCyan, .chartBrown, .chartYellow,
+    .chartBlue, .chartOrange, .chartGreen, .chartRed, .chartPurple, .chartYellow,
+    .chartTeal, .chartPink, .chartIndigo, .chartBrown, .chartMint,
   ]
 
   private let colorsById: [UUID: Color]
 
   /// - Parameter orderedCategoryIds: the category ids in the order they appear
-  ///   in the breakdown. A `nil` entry represents the uncategorized bucket and
-  ///   is rendered grey without consuming a palette slot.
+  ///   in the breakdown (largest first). A `nil` entry represents the
+  ///   uncategorized bucket and resolves to `.gray` without consuming a
+  ///   palette slot.
   init(orderedCategoryIds: [UUID?]) {
     var colors: [UUID: Color] = [:]
     var nextIndex = 0
     for case let id? in orderedCategoryIds where colors[id] == nil {
-      colors[id] = Self.palette[nextIndex % Self.palette.count]
+      colors[id] = nextIndex < Self.palette.count ? Self.palette[nextIndex] : .gray
       nextIndex += 1
     }
     self.colorsById = colors
   }
 
-  /// The colour for `id`. Uncategorized (`nil`) and any id outside the
-  /// breakdown resolve to `.gray`.
+  /// The colour for `id`. Uncategorized (`nil`), categories past the palette,
+  /// and any id outside the breakdown all resolve to `.gray`.
   func color(for id: UUID?) -> Color {
     guard let id, let color = colorsById[id] else { return .gray }
     return color


### PR DESCRIPTION
## What & why

Follow-up to #1176. Two changes the user asked for after that landed:

### 1. Better colours, no 12-cap
- The category palette is now a **curated set of ~11 genuinely distinct, dark-mode-tuned colours**. Dropped `.chartCyan` (its dark-mode value differs from `.chartTeal` by 1/255 — visually identical) and reordered so the largest categories get maximally separated hues.
- Categories **beyond the palette resolve to grey** instead of wrapping onto a duplicate colour. Because both charts sort largest-first, grey only ever lands on the small, barely-visible tail slices. **They still appear individually in the legend with their amount** — this is *not* the rejected "Other" grouping.
- Rationale: published categorical palettes (ColorBrewer, D3) top out around a dozen reliably-distinguishable hues. Past that, generated colours are muddy near-duplicates you can't map legend→slice anyway. Greying the small tail is the honest treatment — and the slices are too small to read regardless.

### 2. Pie legend accessibility (the deferred items from #1176)
- A legend row is wrapped in a `Button` only when the category **has children to drill into**; leaf rows render as plain content, so VoiceOver no longer announces a button that does nothing.
- Drill-down hint is outcome-focused (`"Shows subcategories"`) rather than a platform-specific gesture verb — VoiceOver announces the gesture itself.
- The pie chart's `accessibilityLabel` is now descriptive (category count + incomplete-data note) instead of the generic "Expense breakdown pie chart".

## Tests
- `CategoryColorAssignmentTests` updated: replaced the wrap-at-12 case with an **overflow-is-grey** boundary test (last palette entry coloured, all overflow entries grey).
- `just build-mac`, `just test-mac CategoryColorAssignmentTests` (6/6), and `just format-check` all pass.
- `code-review` and `ui-review` agents run — only Minor findings, addressed (doc accuracy) or noted.

## Notes / easy follow-ups
- Palette membership and order are a single array in `CategoryColorAssignment` — trivial to tweak after eyeballing live.
- A pre-existing redundant `.accessibilityLabel` on `incompleteDataCaption` exists in both analysis cards (flagged by review); left as a separate cleanup to keep this PR scoped.
- The SwiftUI `#Preview` pipeline currently can't render in the dev environment due to an unrelated pre-existing `FoundationModelsNarrator` deprecation (the macOS build itself is clean); a "Many categories" preview is included to demonstrate the palette + grey tail once that's unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
