### PR TITLE
fix(insights): singular grammar in count-based detector titles

### DIFF
--- a/Domain/Insights/Detectors/DataQualityInsights.swift
+++ b/Domain/Insights/Detectors/DataQualityInsights.swift
@@ -17,7 +17,8 @@ enum DataQualityInsights {
       Insight(
         id: "\(InsightKind.uncategorizedBacklog.rawValue):\(monthKey(context))",
         kind: .uncategorizedBacklog,
-        title: "\(count) transactions need a category",
+        title: count == 1
+          ? "1 transaction needs a category" : "\(count) transactions need a category",
         date: context.now,
         framing: .neutral,
         actionability: .review,
@@ -39,7 +40,8 @@ enum DataQualityInsights {
       Insight(
         id: "\(InsightKind.unreconciledTransfers.rawValue):\(monthKey(context))",
         kind: .unreconciledTransfers,
-        title: "\(count) transfers to review and merge",
+        title: count == 1
+          ? "1 transfer to review and merge" : "\(count) transfers to review and merge",
         date: context.now,
         framing: .neutral,
         actionability: .act,

--- a/Domain/Insights/Detectors/LiquidityInsights.swift
+++ b/Domain/Insights/Detectors/LiquidityInsights.swift
@@ -111,9 +111,14 @@ enum LiquidityInsights {
 
   private static func monthsText(_ months: Double) -> String {
     if months >= 24 {
+      // Always ≥ 2.0 years in this branch, so "years" is never singular.
       return "\((months / 12).formatted(.number.precision(.fractionLength(1)))) years"
     }
-    return "\(months.formatted(.number.precision(.fractionLength(0)))) months"
+    // Derive the displayed number and the noun from the same rounded value so
+    // they never disagree at a half-month boundary (e.g. "1 month", not "1 months").
+    let whole = months.rounded()
+    return
+      "\(whole.formatted(.number.precision(.fractionLength(0)))) \(whole == 1 ? "month" : "months")"
   }
 
   private static func monthKey(_ context: InsightContext) -> String {

--- a/MoolahTests/Domain/Insights/AdditionalInsightTests.swift
+++ b/MoolahTests/Domain/Insights/AdditionalInsightTests.swift
@@ -16,7 +16,15 @@ struct AdditionalInsightTests {
     let insights = DataQualityInsights.uncategorizedBacklog(input)
     let nudge = try #require(insights.first)
     #expect(nudge.kind == .uncategorizedBacklog)
-    #expect(nudge.title.contains("30"))
+    #expect(nudge.title == "30 transactions need a category")
+  }
+
+  @Test
+  func uncategorizedBacklogSingularReadsGrammatically() throws {
+    let input = InsightInput(context: context, uncategorizedTransactionCount: 1)
+    let nudge = try #require(
+      DataQualityInsights.uncategorizedBacklog(input, minimumCount: 1).first)
+    #expect(nudge.title == "1 transaction needs a category")
   }
 
   @Test
@@ -33,6 +41,17 @@ struct AdditionalInsightTests {
     let insight = try #require(DataQualityInsights.unreconciledTransfers(input).first)
     #expect(insight.kind == .unreconciledTransfers)
     #expect(insight.actionability == .act)
+    #expect(insight.title == "5 transfers to review and merge")
+  }
+
+  @Test
+  func unreconciledTransfersSingularReadsGrammatically() throws {
+    let input = InsightInput(
+      context: context, pendingTransferCount: 1,
+      oldestPendingTransferDate: InsightTestSupport.daysAgo(20))
+    let insight = try #require(
+      DataQualityInsights.unreconciledTransfers(input, minimumCount: 1).first)
+    #expect(insight.title == "1 transfer to review and merge")
   }
 
   // MARK: - Account groups

--- a/MoolahTests/Domain/Insights/LiquidityInsightTests.swift
+++ b/MoolahTests/Domain/Insights/LiquidityInsightTests.swift
@@ -40,6 +40,21 @@ struct LiquidityInsightTests {
   }
 
   @Test
+  func runwaySingularMonthReadsGrammatically() throws {
+    let balances = [
+      DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(2000))
+    ]
+    let monthly = ["202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 1000, expense: 3000)
+    }
+    // $2,000 liquid ÷ $2,000/mo burn = 1.0 month → singular noun, not "1 months".
+    let runway = try #require(
+      LiquidityInsights.runway(dailyBalances: balances, monthly: monthly, context: context).first)
+    #expect(runway.title == "Only 1 month of runway left")
+    #expect(runway.facts.contains { $0.label == "Runway" && $0.value == "1 month" })
+  }
+
+  @Test
   func runwayAttachesBalanceForecastChart() throws {
     let balances = [
       InsightTestSupport.balance(offsetDays: 10, total: 12000, forecast: false),


### PR DESCRIPTION
## What & why

Follow-up to the [insight fallback descriptions](https://github.com/moolah-rocks/moolah-native/pull/1177) work. A few **detector titles** built grammatically-broken strings when a count rounded to one:

- `uncategorizedBacklog` → "1 transactions need a category"
- `unreconciledTransfers` → "1 transfers to review and merge"
- `runwayEstimate` → "Only 1 months of runway left" (and the "Runway" fact → "1 months")

## Fix

- `DataQualityInsights`: pluralise the noun on the singular path, plus the verb for the backlog title ("1 transaction needs a category"). Counts > 1 are byte-identical to before.
- `LiquidityInsights.monthsText`: derive the displayed number and the noun from the **same** rounded value, so they can't disagree at a half-month boundary ("1 month", not "1 months"). The years branch is always ≥ 2.0, so it stays plural.

The two backlog titles are guarded by `minimumCount` (≥10 / ≥3) so the singular case isn't reachable with shipped defaults, but the count is a parameter and the runway title genuinely reaches "1 month" — and grammatical robustness is the point.

## Testing

- Strengthened the existing `DataQualityInsights` tests to assert exact plural titles, and added singular-count tests for both (`minimumCount: 1`).
- Added a runway singular-month test ($2,000 ÷ $2,000/mo = 1.0 month) asserting "Only 1 month of runway left" and the "1 month" fact.
- Full `just test` passes on iOS Simulator and macOS (4397 tests); `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
