### PR TITLE
fix(analysis): apply remaining review findings on category charts

### DIFF
--- a/Features/Analysis/Views/CategoriesOverTimeCard.swift
+++ b/Features/Analysis/Views/CategoriesOverTimeCard.swift
@@ -58,7 +58,6 @@ struct CategoriesOverTimeCard: View {
     Text("Some prices are still loading; totals may be incomplete")
       .font(.caption)
       .foregroundStyle(.secondary)
-      .accessibilityLabel("Some prices are still loading; totals may be incomplete")
   }
 
   private var emptyState: some View {
@@ -181,7 +180,7 @@ struct CategoriesOverTimeCard: View {
       points: (0..<6).map { month in
         CategoryOverTimePoint(
           month: "20260\(month + 1)",
-          monthDate: Calendar.current.date(
+          monthDate: Calendar.utc.date(
             byAdding: .month, value: -5 + month, to: Date()) ?? Date(),
           actualAmount: Decimal(Int.random(in: 100...500)),
           percentage: Double.random(in: 10...50)
@@ -214,7 +213,7 @@ struct CategoriesOverTimeCard: View {
       points: (0..<6).map { month in
         CategoryOverTimePoint(
           month: "20260\(month + 1)",
-          monthDate: Calendar.current.date(
+          monthDate: Calendar.utc.date(
             byAdding: .month, value: -5 + month, to: Date()) ?? Date(),
           actualAmount: Decimal(Int.random(in: 100...500)),
           percentage: Double.random(in: 10...50)

--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -44,7 +44,6 @@ struct ExpenseBreakdownCard: View {
     Text("Some prices are still loading; totals may be incomplete")
       .font(.caption)
       .foregroundStyle(.secondary)
-      .accessibilityLabel("Some prices are still loading; totals may be incomplete")
   }
 
   private var emptyState: some View {
@@ -165,12 +164,20 @@ struct ExpenseBreakdownCard: View {
   }
 
   private func pieChartAccessibilityLabel(_ breakdown: [ExpenseBreakdownWithPercentage]) -> String {
-    let base =
-      breakdown.count == 1
-      ? "Expense breakdown pie chart with 1 category"
-      : "Expense breakdown pie chart with \(breakdown.count) categories"
-    guard hasUnavailableData else { return base }
-    return base + ". Some totals may be incomplete; prices still loading."
+    let countPhrase = breakdown.count == 1 ? "1 category" : "\(breakdown.count) categories"
+    var summary = "Expense breakdown pie chart with \(countPhrase)"
+    // The breakdown is sorted largest-first, so the leading entries are the
+    // dominant slices a sighted user would read off first.
+    let largest = breakdown.prefix(2).map {
+      "\(categoryLabel(for: $0.categoryId)) \($0.totalExpenses.formatted)"
+    }
+    if !largest.isEmpty {
+      summary += ". Largest: \(largest.joined(separator: ", "))"
+    }
+    if hasUnavailableData {
+      summary += ". Some totals may be incomplete; prices still loading."
+    }
+    return summary
   }
 
   private func categoryLabel(for id: UUID?) -> String {


### PR DESCRIPTION
## What & why

Follow-up to #1178 (now merged) — applies the remaining review findings on the Analysis category charts. No deferrals.

- **Pie chart `accessibilityLabel` now summarises the dominant slices.** Was just "…with N categories"; now appends the largest one or two categories with amounts (the breakdown is sorted largest-first), so a VoiceOver user gets the at-a-glance picture a sighted user reads off the pie instead of tabbing every legend row. Keeps the incomplete-data caveat when relevant.
- **Removed the redundant `.accessibilityLabel` on `incompleteDataCaption`** in both `ExpenseBreakdownCard` and `CategoriesOverTimeCard`. A `Text` already exposes its string as its VoiceOver label; the duplicate was a no-op that had to be kept in sync.
- **`CategoriesOverTimeCard` previews now anchor month dates via `Calendar.utc`** instead of `Calendar.current`, so the sample chart's x-axis is zone-invariant (the timezoneless-date seam — a month carrier built in local time drifts a month in UTC-negative zones).

## Tests
- `just build-mac`, `just test-mac CategoryColorAssignmentTests` (6/6), and `just format-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
